### PR TITLE
Added TCK for python

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -62,6 +62,7 @@ echo "Running tests with $(python --version)"
 pip install --upgrade -r ${DRIVER_HOME}/test_requirements.txt
 echo ""
 TEST_RUNNER="coverage run -m ${UNITTEST} discover -vfs ${TEST}"
+BEHAVE_RUNNER="behave test/tck"
 if [ ${RUNNING} -eq 1 ]
 then
     ${TEST_RUNNER}
@@ -73,6 +74,11 @@ else
     then
         coverage report --show-missing
     fi
+    python -c 'from test.tck.configure_feature_files import *; set_up()'
+    echo "Feature files downloaded"
+    neokit/neorun ${NEORUN_OPTIONS} "${BEHAVE_RUNNER}" ${VERSIONS}
+    python -c 'from test.tck.configure_feature_files import *; clean_up()'
+    echo "Feature files removed"
 fi
 
 # Exit correctly

--- a/test/tck/configure_feature_files.py
+++ b/test/tck/configure_feature_files.py
@@ -1,0 +1,30 @@
+import os
+import tarfile
+import urllib2
+
+
+def clean_up():
+    dir_path = (os.path.dirname(os.path.realpath(__file__)))#'test/tck/'
+    files = os.listdir(dir_path)
+    for f in files:
+        if not os.path.isdir(f) and ".feature" in f:
+            os.remove(os.path.join(dir_path, f))
+
+
+def set_up():
+    dir_path = (os.path.dirname(os.path.realpath(__file__)))
+    feature_url = "https://s3-eu-west-1.amazonaws.com/remoting.neotechnology.com/driver-compliance/tck.tar.gz"
+    file_name = feature_url.split('/')[-1]
+    tar = open(file_name, 'w')
+    response = urllib2.urlopen(feature_url)
+    block_sz = 1024
+    while True:
+        buffer = response.read(block_sz)
+        if not buffer:
+            break
+        tar.write(buffer)
+    tar.close()
+    tar = tarfile.open(file_name)
+    tar.extractall(dir_path)
+    tar.close()
+    os.remove(file_name)

--- a/test/tck/configure_feature_files.py
+++ b/test/tck/configure_feature_files.py
@@ -1,7 +1,5 @@
 import os
 import tarfile
-import urllib2
-
 
 def clean_up():
     dir_path = (os.path.dirname(os.path.realpath(__file__)))
@@ -13,18 +11,28 @@ def clean_up():
 
 def set_up():
     dir_path = (os.path.dirname(os.path.realpath(__file__)))
-    feature_url = "https://s3-eu-west-1.amazonaws.com/remoting.neotechnology.com/driver-compliance/tck.tar.gz"
-    file_name = feature_url.split('/')[-1]
-    tar = open(file_name, 'w')
-    response = urllib2.urlopen(feature_url)
-    block_sz = 1024
-    while True:
-        buffer = response.read(block_sz)
-        if not buffer:
-            break
-        tar.write(buffer)
-    tar.close()
+    url = "https://s3-eu-west-1.amazonaws.com/remoting.neotechnology.com/driver-compliance/tck.tar.gz"
+    file_name = url.split('/')[-1]
+    _download_tar(url,file_name)
+
     tar = tarfile.open(file_name)
     tar.extractall(dir_path)
     tar.close()
     os.remove(file_name)
+
+
+def _download_tar(url, file_name):
+    try:
+        import urllib2
+        tar = open(file_name, 'w')
+        response = urllib2.urlopen(url)
+        block_sz = 1024
+        while True:
+            buffer = response.read(block_sz)
+            if not buffer:
+                break
+            tar.write(buffer)
+        tar.close()
+    except ImportError:
+        from urllib import request
+        request.urlretrieve(url, file_name)

--- a/test/tck/environment.py
+++ b/test/tck/environment.py
@@ -1,0 +1,23 @@
+import logging
+
+from test.tck import tck_util
+from behave.log_capture import capture
+
+
+def before_all(context):
+    # -- SET LOG LEVEL: behave --logging-level=ERROR ...
+    # on behave command-line or in "behave.ini".
+    context.config.setup_logging()
+
+
+@capture
+def after_scenario(context, scenario):
+    for step in scenario.steps:
+        if step.status == 'failed':
+            logging.error("Scenario :'%s' at step: '%s' failed! ", scenario.name, step.name)
+            logging.debug("Expected result: %s", tck_util.as_cypger_text(context.expected))
+            logging.debug("Actual result: %s", tck_util.as_cypger_text(context.results))
+        if step.status == 'skipped':
+            logging.warn("Scenario :'%s' at step: '%s' was skipped! ", scenario.name, step.name)
+        if step.status == 'passed':
+            logging.debug("Scenario :'%s' at step: '%s' was passed! ", scenario.name, step.name)

--- a/test/tck/environment.py
+++ b/test/tck/environment.py
@@ -15,8 +15,8 @@ def after_scenario(context, scenario):
     for step in scenario.steps:
         if step.status == 'failed':
             logging.error("Scenario :'%s' at step: '%s' failed! ", scenario.name, step.name)
-            logging.debug("Expected result: %s", tck_util.as_cypger_text(context.expected))
-            logging.debug("Actual result: %s", tck_util.as_cypger_text(context.results))
+            logging.debug("Expected result: %s", tck_util.as_cypher_text(context.expected))
+            logging.debug("Actual result: %s", tck_util.as_cypher_text(context.results))
         if step.status == 'skipped':
             logging.warn("Scenario :'%s' at step: '%s' was skipped! ", scenario.name, step.name)
         if step.status == 'passed':

--- a/test/tck/steps/bolt_type_steps.py
+++ b/test/tck/steps/bolt_type_steps.py
@@ -1,0 +1,241 @@
+from behave import *
+
+from test.tck import tck_util
+
+from neo4j.v1.typesystem import Node, Relationship, Path
+
+use_step_matcher("re")
+
+
+@given("A running database")
+def step_impl(context):
+    return None
+    # check if running
+
+
+@given("a value (?P<Input>.+) of type (?P<BoltType>.+)")
+def step_impl(context, Input, BoltType):
+    context.expected = tck_util.get_bolt_value(BoltType, Input)
+
+
+@given("a value  of type (?P<BoltType>.+)")
+def step_impl(context, BoltType):
+    context.expected = tck_util.get_bolt_value(BoltType, u' ')
+
+
+@given("a list value (?P<Input>.+) of type (?P<BoltType>.+)")
+def step_impl(context, Input, BoltType):
+    context.expected = tck_util.get_list_from_feature_file(Input, BoltType)
+
+
+@given("an empty list L")
+def step_impl(context):
+    context.L = []
+
+
+@given("an empty map M")
+def step_impl(context):
+    context.M = {}
+
+
+@given("an empty node N")
+def step_impl(context):
+    context.N = Node()
+
+
+@given("a node N with properties and labels")
+def step_impl(context):
+    context.N = Node({"Person"}, {"name": "Alice", "age": 33})
+
+
+@given("a String of size (?P<size>\d+)")
+def step_impl(context, size):
+    context.expected = tck_util.get_random_string(int(size))
+
+
+@given("a List of size (?P<size>\d+) and type (?P<Type>.+)")
+def step_impl(context, size, Type):
+    context.expected = tck_util.get_list_of_random_type(int(size), Type)
+
+
+@given("a Map of size (?P<size>\d+) and type (?P<Type>.+)")
+def step_impl(context, size, Type):
+    context.expected = tck_util.get_dict_of_random_type(int(size), Type)
+
+
+@step("adding a table of lists to the list L")
+def step_impl(context):
+    for row in context.table:
+        context.L.append(tck_util.get_list_from_feature_file(row[1], row[0]))
+
+
+@step("adding a table of values to the list L")
+def step_impl(context):
+    for row in context.table:
+        context.L.append(tck_util.get_bolt_value(row[0], row[1]))
+
+
+@step("adding a table of values to the map M")
+def step_impl(context):
+    for row in context.table:
+        context.M['a' + str(len(context.M))] = tck_util.get_bolt_value(row[0], row[1])
+
+
+@step("adding map M to list L")
+def step_impl(context):
+    context.L.append(context.M)
+
+
+@when("adding a table of lists to the map M")
+def step_impl(context):
+    for row in context.table:
+        context.M['a' + str(len(context.M))] = tck_util.get_list_from_feature_file(row[1], row[0])
+
+
+@step("adding a copy of map M to map M")
+def step_impl(context):
+    context.M['a' + str(len(context.M))] = context.M.copy()
+
+
+@when("the driver asks the server to echo this value back")
+def step_impl(context):
+    context.results = {}
+    context.results["as_string"] = tck_util.send_string("RETURN " + tck_util.as_cypger_text(context.expected))
+    context.results["as_parameters"] = tck_util.send_parameters("RETURN {input}", {'input': context.expected})
+
+
+@when("the driver asks the server to echo this list back")
+def step_impl(context):
+    context.expected = context.L
+    context.results = {}
+    context.results["as_string"] = tck_util.send_string("RETURN " + tck_util.as_cypger_text(context.expected))
+    context.results["as_parameters"] = tck_util.send_parameters("RETURN {input}", {'input': context.expected})
+
+
+@when("the driver asks the server to echo this map back")
+def step_impl(context):
+    context.expected = context.M
+    context.results = {}
+    context.results["as_string"] = tck_util.send_string("RETURN " + tck_util.as_cypger_text(context.expected))
+    context.results["as_parameters"] = tck_util.send_parameters("RETURN {input}", {'input': context.expected})
+
+
+@when("the driver asks the server to echo this node back")
+def step_impl(context):
+    context.expected = context.N
+    context.results = {}
+    context.results["as_parameters"] = tck_util.send_parameters("RETURN {input}", {'input': context.expected})
+
+
+@then("the result returned from the server should be a single record with a single value")
+def step_impl(context):
+    assert len(context.results) > 0
+    for result in context.results.values():
+        assert len(result) == 1
+        assert len(result[0]) == 1
+
+
+@step("the value given in the result should be the same as what was sent")
+def step_impl(context):
+    assert len(context.results) > 0
+    for result in context.results.values():
+        result_value = result[0].values()[0]
+        assert result_value == context.expected
+
+
+@step("the node value given in the result should be the same as what was sent")
+def step_impl(context):
+    assert len(context.results) > 0
+    for result in context.results.values():
+        result_value = result[0].values()[0]
+        assert result_value == context.expected
+        assert result_value.labels == context.expected.labels
+        assert result_value.keys() == context.expected.keys()
+        assert result_value.values() == context.expected.values()
+        assert result_value.items() == context.expected.items()
+        assert len(result_value) == len(context.expected)
+        assert iter(result_value) == iter(context.expected)
+
+
+##CURRENTLY NOT SUPPORTED IN PYTHON DRIVERS
+
+@given("a relationship R")
+def step_impl(context):
+    alice = Node({"Person"}, {"name": "Alice", "age": 33})
+    bob = Node({"Person"}, {"name": "Bob", "age": 44})
+    context.R = Relationship(alice, bob, "KNOWS", {"since": 1999})
+
+
+@when("the driver asks the server to echo this relationship R back")
+def step_impl(context):
+    context.expected = context.R
+    context.results = {}
+    context.results["as_parameters"] = tck_util.send_parameters("RETURN {input}", {'input': context.expected})
+
+
+@step("the relationship value given in the result should be the same as what was sent")
+def step_impl(context):
+    assert len(context.results) > 0
+    for result in context.results.values():
+        result_value = result[0].values()[0]
+        assert result_value == context.expected
+        assert result_value.start == context.expected.start
+        assert result_value.type == context.expected.type
+        assert result_value.end == context.expected.end
+        assert result_value.items() == context.expected.items()
+        assert result_value.keys() == context.expected.keys()
+        assert result_value.values() == context.expected.values()
+
+
+@given("a zero length path P")
+def step_impl(context):
+    context.P = Path(Node({"Person"}, {"name": "Alice", "age": 33}))
+
+
+@given("a arbitrary long path P")
+def step_impl(context):
+    alice = Node({"Person"}, {"name": "Alice", "age": 33})
+    bob = Node({"Person"}, {"name": "Bob", "age": 44})
+    carol = Node({"Person"}, {"name": "Carol", "age": 55})
+    alice_knows_bob = Relationship(alice, bob, "KNOWS", {"since": 1999})
+    carol_dislikes_bob = Relationship(carol, bob, "DISLIKES")
+    context.P = Path(alice, alice_knows_bob, bob, carol_dislikes_bob, carol)
+
+
+@when("the driver asks the server to echo this path back")
+def step_impl(context):
+    context.expected = context.P
+    context.results = {}
+    context.results["as_parameters"] = tck_util.send_parameters("RETURN {input}", {'input': context.expected})
+
+
+@step("the path value given in the result should be the same as what was sent")
+def step_impl(context):
+    assert len(context.results) > 0
+    for result in context.results.values():
+        result_value = result[0].values()[0]
+        assert result_value == context.expected
+        assert result_value.start == context.expected.start
+        assert result_value.end == context.expected.end
+        assert result_value.nodes == context.expected.nodes
+        assert result_value.relationships == context.expected.relationships
+        assert list(result_value) == list(context.expected)
+
+
+@given("a Node with great amount of properties and labels")
+def step_impl(context):
+    context.N = Node(tck_util.get_list_of_random_type(1000, "String"),
+                     tck_util.get_dict_of_random_type(1000, "String"))
+
+
+@given("a path P of size (?P<size>\d+)")
+def step_impl(context, size):
+    nodes_and_rels = [Node({tck_util.get_random_string(5)}, tck_util.get_dict_of_random_type(3, "String"))]
+    for i in range(1, int(12)):
+        n = nodes_and_rels.append(Node({tck_util.get_random_string(5)}, tck_util.get_dict_of_random_type(3, "String")))
+        r = Relationship(nodes_and_rels[-1], n, tck_util.get_random_string(4),
+                         tck_util.get_dict_of_random_type(3, "String"))
+        nodes_and_rels.append(r)
+        nodes_and_rels.append(n)
+
+    context.P = Path(nodes_and_rels[0], nodes_and_rels[1:])

--- a/test/tck/tck_util.py
+++ b/test/tck/tck_util.py
@@ -1,0 +1,120 @@
+import string
+import random
+
+import sys
+
+from neo4j.v1 import GraphDatabase
+
+driver = GraphDatabase.driver("bolt://localhost")
+
+
+def send_string(text):
+    session = driver.session()
+    result = session.run(text)
+    session.close()
+    return result
+
+
+def send_parameters(statement, parameters):
+    session = driver.session()
+    result = session.run(statement, parameters)
+    session.close()
+    return result
+
+
+def get_bolt_value(type, value):
+    if type == 'Integer':
+        return int(value)
+    if type == 'Float':
+        return float(value)
+    if type == 'String':
+        return value
+    if type == 'Null':
+        return None
+    if type == 'Boolean':
+        return bool(value)
+    raise ValueError('No such type : %s', type)
+
+
+def as_cypger_text(expected):
+    if expected is None:
+        return "Null"
+    if isinstance(expected, unicode):
+        return '"' + expected + '"'
+    if isinstance(expected, float):
+        return repr(expected).replace('+', '')
+    if isinstance(expected, list):
+        l = u'['
+        for i, val in enumerate(expected):
+            l += as_cypger_text(val)
+            if i < len(expected)-1:
+                l+= u','
+        l += u']'
+        return l
+    if isinstance(expected, dict):
+        d = u'{'
+        for i, (key, val) in enumerate(expected.items()):
+            d += unicode(key) + ':'
+            d += as_cypger_text(val)
+            if i < len(expected.items())-1:
+                d+= u','
+        d += u'}'
+        return d
+    else:
+        return unicode(expected)
+
+
+def get_list_from_feature_file(string_list, bolt_type):
+    inputs = string_list.strip('[]')
+    inputs = inputs.split(',')
+    list_to_return = []
+    for value in inputs:
+        list_to_return.append(get_bolt_value(bolt_type, value))
+    return list_to_return
+
+
+def get_random_string(size):
+    return u''.join(
+            random.SystemRandom().choice(list(string.ascii_uppercase + string.digits + string.ascii_lowercase)) for _ in
+            range(size))
+
+
+def get_random_bool():
+    return bool(random.randint(0, 1))
+
+
+def _get_random_func(type):
+    def get_none():
+        return None
+
+    if type == 'Integer':
+        fu = random.randint
+        args = [-sys.maxint - 1, sys.maxint]
+    elif type == 'Float':
+        fu = random.random
+        args = []
+    elif type == 'String':
+        fu = get_random_string
+        args = [3]
+    elif type == 'Null':
+        fu = get_none
+        args = []
+    elif type == 'Boolean':
+        fu = get_random_bool
+        args = []
+    else:
+        raise ValueError('No such type : %s', type)
+    return (fu, args)
+
+
+def get_list_of_random_type(size, type):
+    fu, args = _get_random_func(type)
+    return [fu(*args) for _ in range(size)]
+
+
+def get_dict_of_random_type(size, type):
+    fu, args = _get_random_func(type)
+    map = {}
+    for i in range(size):
+        map['a' + str(i)] = fu(*args)
+    return map

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
+behave
 coverage
 teamcity-messages


### PR DESCRIPTION
TCK tests are set to run with runtests.sh

Python-drivers currently do not accept sending Path/Node/Relationship while Java-drivers do. So those tests are currently failing.
