### PR TITLE
Catch socket error 61 on Windows

### DIFF
--- a/neo4j/v1/connection.py
+++ b/neo4j/v1/connection.py
@@ -383,7 +383,7 @@ def connect(host, port=None, ssl_context=None, **config):
     try:
         s = create_connection((host, port))
     except SocketError as error:
-        if error.errno == 111 or error.errno == 61:
+        if error.errno in [111, 61, 10061]:
             raise ProtocolError("Unable to connect to %s on port %d - is the server running?" % (host, port))
         else:
             raise


### PR DESCRIPTION
The error number for connection refused on Windows is 10061, instead of 61, so this just adds it to the list of error numbers to be caught for raising a ProtocolError.
