### PR TITLE
Allow retry timeout to be 0

### DIFF
--- a/test/examples/base_application.py
+++ b/test/examples/base_application.py
@@ -20,9 +20,10 @@
 
 from neo4j.v1 import GraphDatabase
 
+
 class BaseApplication(object):
     def __init__(self, uri, user, password):
-        self._driver = GraphDatabase.driver( uri, auth=( user, password ) )
+        self._driver = GraphDatabase.driver(uri, auth=( user, password ), max_retry_time=0)
 
     def close(self):
         self._driver.close()

--- a/test/examples/config_max_retry_time_example.py
+++ b/test/examples/config_max_retry_time_example.py
@@ -22,11 +22,11 @@
 from neo4j.v1 import GraphDatabase
 # end::config-max-retry-time-import[]
 
+
 class ConfigMaxRetryTimeExample:
     # tag::config-max-retry-time[]
     def __init__(self, uri, user, password):
-        self._driver = GraphDatabase.driver(uri, auth=(user, password),
-                Config.build().withMaxTransactionRetryTime( 15, SECONDS ).toConfig() )
+        self._driver = GraphDatabase.driver(uri, auth=(user, password), max_retry_time=15)
     # end::config-max-retry-time[]
 
     def close(self):

--- a/test/examples/config_trust_example.py
+++ b/test/examples/config_trust_example.py
@@ -19,14 +19,14 @@
 # limitations under the License.
 
 # tag::config-trust-import[]
-from neo4j.v1 import GraphDatabase
+from neo4j.v1 import GraphDatabase, TRUST_ALL_CERTIFICATES
 # end::config-trust-import[]
+
 
 class ConfigTrustExample:
     # tag::config-trust[]
     def __init__(self, uri, user, password):
-        self._driver = GraphDatabase.driver(uri, auth=(user, password),
-                Config.build().withTrustStrategy( Config.TrustStrategy.trustSystemCertificates() ).toConfig() )
+        self._driver = GraphDatabase.driver(uri, auth=(user, password), trust=TRUST_ALL_CERTIFICATES)
     # end::config-trust[]
 
     def close(self):

--- a/test/examples/config_unencrypted_example.py
+++ b/test/examples/config_unencrypted_example.py
@@ -22,6 +22,7 @@
 from neo4j.v1 import GraphDatabase
 # end::config-unencrypted-import[]
 
+
 class ConfigUnencryptedExample:
     # tag::config-unencrypted[]
     def __init__(self, uri, user, password):
@@ -29,4 +30,4 @@ class ConfigUnencryptedExample:
     # end::config-unencrypted[]
 
     def close(self):
-        self._driver.close();
+        self._driver.close()

--- a/test/examples/test_examples.py
+++ b/test/examples/test_examples.py
@@ -149,7 +149,6 @@ class ExamplesTest(IntegrationTestCase):
 
         self.assertEqual(self.person_count("Alice"), 1)
 
-        
     def read(self, statement):
         from neo4j.v1 import GraphDatabase
         with GraphDatabase.driver(self.bolt_uri, auth=self.auth_token) as driver:

--- a/test/stub/test_directdriver.py
+++ b/test/stub/test_directdriver.py
@@ -52,7 +52,7 @@ class DirectDriverTestCase(StubTestCase):
     def test_direct_session_close_after_server_close(self):
         with StubCluster({9001: "disconnect_after_init.script"}):
             uri = "bolt://127.0.0.1:9001"
-            with GraphDatabase.driver(uri, auth=self.auth_token, encrypted=False) as driver:
+            with GraphDatabase.driver(uri, auth=self.auth_token, encrypted=False, max_retry_time=0) as driver:
                 with driver.session() as session:
                     with self.assertRaises(ServiceUnavailable):
                         session.write_transaction(lambda tx: tx.run("CREATE (a:Item)"))


### PR DESCRIPTION
Fixed some wrong example code for configurations
Speed up some tests by seting retry timeout to 0