### PR TITLE
Idiomaticised examples

### DIFF
--- a/test/examples/autocommit_transaction_example.py
+++ b/test/examples/autocommit_transaction_example.py
@@ -18,10 +18,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# tag::autocommit-transaction-import[]
-from neo4j.v1 import Session;
 from test.examples.base_application import BaseApplication
+
+# tag::autocommit-transaction-import[]
 # end::autocommit-transaction-import[]
+
 
 class AutocommitTransactionExample(BaseApplication):
     def __init__(self, uri, user, password):
@@ -29,6 +30,6 @@ class AutocommitTransactionExample(BaseApplication):
 
     # tag::autocommit-transaction[]
     def add_person(self, name):
-        session = self._driver.session()
-        session.run( "CREATE (a:Person {name: $name})", {"name": name} )
+        with self._driver.session() as session:
+            session.run("CREATE (a:Person {name: $name})", name=name)
     # end::autocommit-transaction[]

--- a/test/examples/base_application.py
+++ b/test/examples/base_application.py
@@ -23,7 +23,7 @@ from neo4j.v1 import GraphDatabase
 
 class BaseApplication(object):
     def __init__(self, uri, user, password):
-        self._driver = GraphDatabase.driver(uri, auth=( user, password ), max_retry_time=0)
+        self._driver = GraphDatabase.driver(uri, auth=(user, password), max_retry_time=0)
 
     def close(self):
         self._driver.close()

--- a/test/examples/basic_auth_example.py
+++ b/test/examples/basic_auth_example.py
@@ -33,5 +33,5 @@ class BasicAuthExample:
         self._driver.close()
 
     def can_connect(self):
-        record_list = list(self._driver.session().run("RETURN 1"))
-        return int(record_list[0][0]) == 1
+        result = self._driver.session().run("RETURN 1")
+        return result.single()[0] == 1

--- a/test/examples/config_connection_timeout_example.py
+++ b/test/examples/config_connection_timeout_example.py
@@ -22,12 +22,12 @@
 from neo4j.v1 import GraphDatabase
 # end::config-connection-timeout-import[]
 
+
 class ConfigConnectionTimeoutExample:
     # tag::config-connection-timeout[]
     def __init__(self, uri, user, password):
-        self._driver = GraphDatabase.driver( uri, auth=( user, password ),
-                Config.build().withConnectionTimeout( 15, SECONDS ).toConfig() )
+        self._driver = GraphDatabase.driver(uri, auth=(user, password), connection_timeout=15)
     # end::config-connection-timeout[]
 
     def close(self):
-        self._driver.close();
+        self._driver.close()

--- a/test/examples/config_max_retry_time_example.py
+++ b/test/examples/config_max_retry_time_example.py
@@ -30,4 +30,4 @@ class ConfigMaxRetryTimeExample:
     # end::config-max-retry-time[]
 
     def close(self):
-        self._driver.close();
+        self._driver.close()

--- a/test/examples/config_trust_example.py
+++ b/test/examples/config_trust_example.py
@@ -30,4 +30,4 @@ class ConfigTrustExample:
     # end::config-trust[]
 
     def close(self):
-        self._driver.close();
+        self._driver.close()

--- a/test/examples/custom_auth_example.py
+++ b/test/examples/custom_auth_example.py
@@ -33,5 +33,6 @@ class CustomAuthExample:
         self._driver.close()
 
     def can_connect(self):
-        record_list = list(self._driver.session().run("RETURN 1"))
-        return int(record_list[0][0]) == 1
+        with self._driver.session() as session:
+            result = session.run("RETURN 1")
+            return result.single()[0] == 1

--- a/test/examples/driver_lifecycle_example.py
+++ b/test/examples/driver_lifecycle_example.py
@@ -22,11 +22,12 @@
 from neo4j.v1 import GraphDatabase
 # end::driver-lifecycle-import[]
 
+
 # tag::driver-lifecycle[]
 class DriverLifecycleExample:
     def __init__(self, uri, user, password):
         self._driver = GraphDatabase.driver(uri, auth=(user, password))
 
     def close(self):
-        self._driver.close();
+        self._driver.close()
 # end::driver-lifecycle[]

--- a/test/examples/hello_world_example.py
+++ b/test/examples/hello_world_example.py
@@ -20,25 +20,29 @@
 
 # tag::hello-world-import[]
 from neo4j.v1 import GraphDatabase
-from test.examples.base_application import BaseApplication
 # end::hello-world-import[]
 
-# tag::hello-world[]
-class HelloWorldExample(BaseApplication):
-    def __init__(self, uri, user, password):
-        super(HelloWorldExample, self).__init__(uri, user, password)
 
-    def _create_and_return_greeting(self, tx, message):
-        record_list = list(tx.run("CREATE (a:Greeting) " +
-                                  "SET a.message = $message " +
-                                  "RETURN a.message + ', from node ' + id(a)",
-                                  {"message": message}))
-        return str(record_list[0][0])
-        
+# tag::hello-world[]
+class HelloWorldExample(object):
+
+    def __init__(self, uri, user, password):
+        self._driver = GraphDatabase.driver(uri, auth=(user, password))
+
+    def close(self):
+        self._driver.close()
+
     def print_greeting(self, message):
         with self._driver.session() as session:
-            greeting = session.write_transaction(lambda tx: self._create_and_return_greeting(tx, message))
+            greeting = session.write_transaction(self._create_and_return_greeting, message)
             print(greeting)
+
+    @staticmethod
+    def _create_and_return_greeting(tx, message):
+        result = tx.run("CREATE (a:Greeting) "
+                        "SET a.message = $message "
+                        "RETURN a.message + ', from node ' + id(a)", message=message)
+        return result.single()[0]
 # end::hello-world[]
 
 # tag::hello-world-output[]

--- a/test/examples/read_write_transaction_example.py
+++ b/test/examples/read_write_transaction_example.py
@@ -18,10 +18,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# tag::read-write-transaction-import[]
-from neo4j.v1 import GraphDatabase
 from test.examples.base_application import BaseApplication
+
+# tag::read-write-transaction-import[]
 # end::read-write-transaction-import[]
+
 
 class ReadWriteTransactionExample(BaseApplication):
     def __init__(self, uri, user, password):
@@ -30,14 +31,16 @@ class ReadWriteTransactionExample(BaseApplication):
     # tag::read-write-transaction[]
     def add_person(self, name):
         with self._driver.session() as session:
-            session.write_transaction(lambda tx: self.create_person_node(tx, name))
-            return session.read_transaction(lambda tx: self.match_person_node(tx, name))
+            session.write_transaction(self.create_person_node, name)
+            return session.read_transaction(self.match_person_node, name)
 
-    def create_person_node(self, tx, name):
-        tx.run("CREATE (a:Person {name: $name})", {"name": name })
+    @staticmethod
+    def create_person_node(tx, name):
+        tx.run("CREATE (a:Person {name: $name})", name=name)
         return None
 
-    def match_person_node(self, tx, name):
-        record_list = list(tx.run("MATCH (a:Person {name: $name}) RETURN count(a)", {"name": name }))
-        return int(record_list[0][0])
+    @staticmethod
+    def match_person_node(tx, name):
+        result = tx.run("MATCH (a:Person {name: $name}) RETURN count(a)", name=name)
+        return result.single()[0]
     # end::read-write-transaction[]

--- a/test/examples/result_consume_example.py
+++ b/test/examples/result_consume_example.py
@@ -18,10 +18,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# tag::result-consume-import[]
-from neo4j.v1 import GraphDatabase
 from test.examples.base_application import BaseApplication
+
+# tag::result-consume-import[]
 # end::result-consume-import[]
+
 
 class ResultConsumeExample(BaseApplication):
     def __init__(self, uri, user, password):
@@ -32,12 +33,8 @@ class ResultConsumeExample(BaseApplication):
         with self._driver.session() as session:
             return session.read_transaction(self.match_person_nodes)
 
-    def match_person_nodes(self, tx):
-        names = []
-        results = tx.run("MATCH (a:Person) RETURN a.name ORDER BY a.name")
-
-        for result in results:
-            names.append(result["a.name"])
-
-        return names
+    @staticmethod
+    def match_person_nodes(tx):
+        result = tx.run("MATCH (a:Person) RETURN a.name ORDER BY a.name")
+        return [record["a.name"] for record in result]
     # end::result-consume[]

--- a/test/examples/service_unavailable_example.py
+++ b/test/examples/service_unavailable_example.py
@@ -18,21 +18,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# tag::service-unavailable-import[]
-from neo4j.v1 import GraphDatabase, ServiceUnavailable
 from test.examples.base_application import BaseApplication
+
+# tag::service-unavailable-import[]
+from neo4j.v1 import ServiceUnavailable
 # end::service-unavailable-import[]
+
 
 class ServiceUnavailableExample(BaseApplication):
     def __init__(self, uri, user, password):
         super(ServiceUnavailableExample, self).__init__(uri, user, password)
 
     # tag::service-unavailable[]
-    def addItem(self):
-        session = self._driver.session()
-        try:
-            session.write_transaction(lambda tx: tx.run("CREATE (a:Item)"))
-            return True
-        except ServiceUnavailable:
-            return False
+    def add_item(self):
+        with self._driver.session() as session:
+            try:
+                session.write_transaction(lambda tx: tx.run("CREATE (a:Item)"))
+                return True
+            except ServiceUnavailable:
+                return False
     # end::service-unavailable[]

--- a/test/examples/session_example.py
+++ b/test/examples/session_example.py
@@ -18,9 +18,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# tag::session-import[]
 from test.examples.base_application import BaseApplication
+
+# tag::session-import[]
 # end::session-import[]
+
 
 class SessionExample(BaseApplication):
     def __init__(self, uri, user, password):
@@ -28,6 +30,6 @@ class SessionExample(BaseApplication):
 
     # tag::session[]
     def add_person(self, name):
-        session = self._driver.session()
-        session.run("CREATE (a:Person {name: $name})", {"name": name})
+        with self._driver.session() as session:
+            session.run("CREATE (a:Person {name: $name})", name=name)
     # end::session[]

--- a/test/examples/transaction_function_example.py
+++ b/test/examples/transaction_function_example.py
@@ -18,10 +18,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# tag::transaction-function-import[]
-from neo4j.v1 import GraphDatabase
 from test.examples.base_application import BaseApplication
+
+# tag::transaction-function-import[]
 # end::transaction-function-import[]
+
 
 class TransactionFunctionExample(BaseApplication):
     def __init__(self, uri, user, password):
@@ -30,10 +31,9 @@ class TransactionFunctionExample(BaseApplication):
     # tag::transaction-function[]
     def add_person(self, name):
         with self._driver.session() as session:
-            session.write_transaction(lambda tx: self.create_person_node(tx, name))
+            session.write_transaction(self.create_person_node, name)
             
-    def create_person_node(self, tx, name):
-        tx.run("CREATE (a:Person {name: $name})", {"name": name})
-        return 1
+    @staticmethod
+    def create_person_node(tx, name):
+        tx.run("CREATE (a:Person {name: $name})", name=name)
     # end::transaction-function[]
-


### PR DESCRIPTION
This PR:
- Removes redundant code
- Uses kwargs for parameters
- Collapses lambdas and passes trailing args
- Uses `with` blocks for sessions
- Uses `single` in result consumption