### PR TITLE
Hide auth details in log message

### DIFF
--- a/neo4j/bolt/connection.py
+++ b/neo4j/bolt/connection.py
@@ -214,7 +214,7 @@ class Connection(object):
         elif signature == ACK_FAILURE:
             log_info("C: ACK_FAILURE %r", fields)
         elif signature == INIT:
-            log_info("C: INIT %r", fields)
+            log_info("C: INIT (%r, {...})", fields[0])
         else:
             raise ValueError("Unknown message signature")
         self.packer.pack_struct(signature, fields)


### PR DESCRIPTION
This PR hides the auth details from the INIT log message. For greater security.