### PR TITLE
Routing driver forgets addresses on some errors

### DIFF
--- a/neo4j/v1/api.py
+++ b/neo4j/v1/api.py
@@ -277,7 +277,7 @@ class Session(object):
             if sync:
                 try:
                     self._connection.sync()
-                except ServiceUnavailable:
+                except (SessionError, ServiceUnavailable):
                     pass
             if self._connection:
                 self._connection.in_use = False

--- a/test/stub/scripts/database_unavailable.script
+++ b/test/stub/scripts/database_unavailable.script
@@ -1,0 +1,12 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+!: AUTO ACK_FAILURE
+!: AUTO RUN "ROLLBACK" {}
+!: AUTO RUN "BEGIN" {}
+!: AUTO RUN "COMMIT" {}
+
+C: RUN "RETURN 1" {}
+C: PULL_ALL
+S: FAILURE {"code": "Neo.TransientError.General.DatabaseUnavailable", "message": "Database is busy doing store copy"}
+S: IGNORED

--- a/test/stub/scripts/forbidden_on_read_only_database.script
+++ b/test/stub/scripts/forbidden_on_read_only_database.script
@@ -1,0 +1,12 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+!: AUTO ACK_FAILURE
+!: AUTO RUN "ROLLBACK" {}
+!: AUTO RUN "BEGIN" {}
+!: AUTO RUN "COMMIT" {}
+
+C: RUN "CREATE (n {name:'Bob'})" {}
+C: PULL_ALL
+S: FAILURE {"code": "Neo.ClientError.General.ForbiddenOnReadOnlyDatabase", "message": "Unable to write"}
+S: IGNORED

--- a/test/stub/scripts/not_a_leader.script
+++ b/test/stub/scripts/not_a_leader.script
@@ -1,0 +1,12 @@
+!: AUTO INIT
+!: AUTO RESET
+!: AUTO PULL_ALL
+!: AUTO ACK_FAILURE
+!: AUTO RUN "ROLLBACK" {}
+!: AUTO RUN "BEGIN" {}
+!: AUTO RUN "COMMIT" {}
+
+C: RUN "CREATE (n {name:'Bob'})" {}
+C: PULL_ALL
+S: FAILURE {"code": "Neo.ClientError.Cluster.NotALeader", "message": "Leader switched has happened"}
+S: IGNORED

--- a/test/stub/scripts/rude_reader.script
+++ b/test/stub/scripts/rude_reader.script
@@ -1,0 +1,7 @@
+!: AUTO INIT
+!: AUTO RESET
+
+C: RUN "RETURN 1" {}
+   PULL_ALL
+S: <EXIT>
+

--- a/test/stub/test_routing.py
+++ b/test/stub/test_routing.py
@@ -50,8 +50,8 @@ INVALID_ROUTING_RECORD = {
 UNREACHABLE_ADDRESS = ("127.0.0.1", 8080)
 
 
-def connector(address):
-    return connect(address, auth=basic_auth("neotest", "neotest"))
+def connector(address, error_handler):
+    return connect(address, error_handler=error_handler, auth=basic_auth("neotest", "neotest"))
 
 
 def RoutingPool(*routers):

--- a/test/unit/test_routing.py
+++ b/test/unit/test_routing.py
@@ -52,8 +52,8 @@ INVALID_ROUTING_RECORD = {
 }
 
 
-def connector(address):
-    return connect(address, auth=basic_auth("neotest", "neotest"))
+def connector(address, error_handler):
+    return connect(address, error_handler=error_handler, auth=basic_auth("neotest", "neotest"))
 
 
 class RoundRobinSetTestCase(TestCase):


### PR DESCRIPTION
This PR makes routing driver forget addresses and purge their connections on network and database errors. It also makes driver forget write server addresses when they fail as writers, connections remain in the pool because such machines can remain readers/routers.