### PR TITLE
Do not purge inUse connections

### DIFF
--- a/neo4j/bolt/connection.py
+++ b/neo4j/bolt/connection.py
@@ -508,7 +508,7 @@ class ConnectionPool(object):
                         conn.close()
                     except IOError:
                         pass
-            if len(connections) == 0:
+            if not connections:
                 self.remove(address)
 
     def remove(self, address):

--- a/neo4j/v1/routing.py
+++ b/neo4j/v1/routing.py
@@ -81,9 +81,6 @@ class OrderedSet(MutableSet):
         e.clear()
         e.update(OrderedDict.fromkeys(elements))
 
-    def elements(self):
-        return list(self._elements)
-
 
 class RoutingTable(object):
 
@@ -144,7 +141,7 @@ class RoutingTable(object):
         self.ttl = new_routing_table.ttl
 
     def servers(self):
-        return set(self.routers.elements() + self.writers.elements() + self.readers.elements())
+        return set(self.routers) | set(self.writers) | set(self.readers)
 
 
 class RoutingSession(BoltSession):

--- a/test/stub/scripts/router_with_multiple_servers.script
+++ b/test/stub/scripts/router_with_multiple_servers.script
@@ -1,0 +1,8 @@
+!: AUTO INIT
+!: AUTO RESET
+
+C: RUN "CALL dbms.cluster.routing.getServers" {}
+   PULL_ALL
+S: SUCCESS {"fields": ["ttl", "servers"]}
+   RECORD [300, [{"role":"ROUTE","addresses":["127.0.0.1:9001","127.0.0.1:9002"]},{"role":"READ","addresses":["127.0.0.1:9001","127.0.0.1:9003"]},{"role":"WRITE","addresses":["127.0.0.1:9004"]}]]
+   SUCCESS {}

--- a/test/stub/test_routingdriver.py
+++ b/test/stub/test_routingdriver.py
@@ -289,12 +289,18 @@ class RoutingDriverTestCase(StubTestCase):
                     pool = driver._pool
                     table = pool.routing_table
 
-                    # address should not have connections in the pool, it has failed
-                    assert ('127.0.0.1', 9004) not in pool.connections
+                    # address should have connections in the pool but be inactive, it has failed
+                    assert ('127.0.0.1', 9004) in pool.connections
+                    conns = pool.connections[('127.0.0.1', 9004)]
+                    conn = conns[0]
+                    assert conn._closed == True
+                    assert conn.in_use == True
                     assert table.routers == {('127.0.0.1', 9001), ('127.0.0.1', 9002), ('127.0.0.1', 9003)}
                     # reader 127.0.0.1:9004 should've been forgotten because of an error
                     assert table.readers == {('127.0.0.1', 9005)}
                     assert table.writers == {('127.0.0.1', 9006)}
+
+                assert conn.in_use == False
 
     def test_forgets_address_on_database_unavailable_error(self):
         with StubCluster({9001: "router.script", 9004: "database_unavailable.script"}):

--- a/test/unit/test_routing.py
+++ b/test/unit/test_routing.py
@@ -169,6 +169,20 @@ class RoutingTableParseRoutingInfoTestCase(TestCase):
             _ = RoutingTable.parse_routing_info([VALID_ROUTING_RECORD, VALID_ROUTING_RECORD])
 
 
+class RoutingTableServersTestCase(TestCase):
+    def test_should_return_all_distinct_servers_in_routing_table(self):
+        routing_table = {
+            "ttl": 300,
+            "servers": [
+                {"role": "ROUTE", "addresses": ["127.0.0.1:9001", "127.0.0.1:9002", "127.0.0.1:9003"]},
+                {"role": "READ", "addresses": ["127.0.0.1:9001", "127.0.0.1:9005"]},
+                {"role": "WRITE", "addresses": ["127.0.0.1:9002"]},
+            ],
+        }
+        table = RoutingTable.parse_routing_info([routing_table])
+        assert table.servers() == {('127.0.0.1', 9001), ('127.0.0.1', 9002), ('127.0.0.1', 9003), ('127.0.0.1', 9005)}
+
+
 class RoutingTableFreshnessTestCase(TestCase):
     def test_should_be_fresh_after_update(self):
         table = RoutingTable.parse_routing_info([VALID_ROUTING_RECORD])


### PR DESCRIPTION
Do not purge inUse connections when connection error happens or new routing table is available

Instead we deactive the server (a.k.a. closing all idle connections) in connection pool.

When an connection failure happens, the connection server will be removed from the routing table and all idle connections with this server will be closed in the connection pool.

When a new routing table is available, all idle connections towards the servers that are not in the new routing table will be removed. If the server has no inUse connections, then this server will also be totally removed from the connection pool.

Note: 
* There is no extra protection to against `acquire` to create a new connection with an inactive server except that the server should not be in the routing table and therefore should not be used to `acquire` new connections.
* When error happens on a connection, we will deactivate the server but we will probably not remove all server's connections from connection pool as the failed connection is highly still inUse by the broken session.