### PR TITLE
Read large values stress test - nested reference buffer bug #201 #165

### DIFF
--- a/neo4j/bolt/io.py
+++ b/neo4j/bolt/io.py
@@ -191,7 +191,7 @@ class ChunkedInputBuffer(object):
             p += 2
             if chunk_size == 0:
                 self._limit = p
-                self._frame = MessageFrame(memoryview(self._view[origin:self._limit]), panes)
+                self._frame = MessageFrame(memoryview(self._data[origin:self._limit]), panes)
                 return True
             q = p + chunk_size
             panes.append((p - origin, q - origin))

--- a/test/performance/stress.py
+++ b/test/performance/stress.py
@@ -23,6 +23,18 @@ class Runner(Thread):
         self.create_nodes()
         self.create_index()
         self.match_nodes()
+        self.read_large()
+
+    def read_large(self):
+        for i in range(1, 7):
+            t0 = time()
+            with self.driver.session() as session:
+                try:
+                    session.run("RETURN '{}'".format("x" * (i * 2 ** 20))).consume()
+                except CypherError:
+                    pass
+            t1 = time()
+            stderr.write("Read %d MB in %fs\n" % (i, t1 - t0))
 
     def drop_index(self):
         with self.driver.session() as session:


### PR DESCRIPTION
This test should fail because a reference to the previous _view is kept in [ChunkedInputBuffer.frame_message](https://github.com/neo4j/neo4j-python-driver/blob/1.5/neo4j/bolt/io.py#L194)
Fix to follow.