### PR TITLE
Spelling

### DIFF
--- a/neo4j/v1/security.py
+++ b/neo4j/v1/security.py
@@ -112,7 +112,7 @@ def custom_auth(principal, credentials, realm, scheme, **parameters):
     :param credentials: authenticates the principal
     :param realm: specifies the authentication provider
     :param scheme: specifies the type of authentication
-    :param parameters: parameters passed along to the authenticatin provider
+    :param parameters: parameters passed along to the authentication provider
     :return: auth token for use with :meth:`GraphDatabase.driver`
     """
     return AuthToken(scheme, principal, credentials, realm, **parameters)

--- a/test/unit/test_security.py
+++ b/test/unit/test_security.py
@@ -40,17 +40,17 @@ class AuthTokenTestCase(TestCase):
         assert not hasattr(auth, "parameters")
 
     def test_should_generate_base_auth_with_realm_correctly(self):
-        auth = basic_auth("molly", "meoooow", "cat_caffe")
+        auth = basic_auth("molly", "meoooow", "cat_cafe")
         assert auth.scheme == "basic"
         assert auth.principal == "molly"
         assert auth.credentials == "meoooow"
-        assert auth.realm == "cat_caffe"
+        assert auth.realm == "cat_cafe"
         assert not hasattr(auth, "parameters")
 
     def test_should_generate_custom_auth_correctly(self):
-        auth = custom_auth("molly", "meoooow", "cat_caffe", "cat", age="1", color="white")
+        auth = custom_auth("molly", "meoooow", "cat_cafe", "cat", age="1", color="white")
         assert auth.scheme == "cat"
         assert auth.principal == "molly"
         assert auth.credentials == "meoooow"
-        assert auth.realm == "cat_caffe"
+        assert auth.realm == "cat_cafe"
         assert auth.parameters == {"age": "1", "color": "white"}


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`