### PR TITLE
add neo4j.v1.types to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ packages = [
     "neo4j.compat",
     "neo4j.packstream",
     "neo4j.v1",
+    "neo4j.v1.types",
 ]
 package_data = {
     "neo4j.bolt": ["*.pyx"],


### PR DESCRIPTION
I think there are ways of discovering submodules programatically when setup.py is run but this fixes installing the driver with pip for now. Without it the types module does not get installed and it fails at runtime
