### PR TITLE
Fix error "'NoneType' object has no attribute 'close'"

### DIFF
--- a/neo4j/bolt/connection.py
+++ b/neo4j/bolt/connection.py
@@ -387,7 +387,10 @@ class Connection(object):
         """
         if not self.closed():
             log_debug("~~ [CLOSE]")
-            self.socket.close()
+            try:
+                self.socket.close()
+            except AttributeError:
+                pass
             self._closed = True
 
     def closed(self):


### PR DESCRIPTION
When a `neo4j.bolt.connection.Connection` object tries to close in the `__del__` method, the Python socket can't be closed and fails with `'NoneType' object has no attribute 'close'`. This PR is a simple workaround and should be harmless since the exception is ignored anyways.

The full exception encountered while using the latest neomodel:
```
Exception AttributeError: AttributeError("'NoneType' object has no attribute 'close'",) in <bound method DirectDriver.__del__ of <neo4j.v1.direct.DirectDriver object at 0x7fc899a9a110>> ignored
Exception AttributeError: "'NoneType' object has no attribute 'close'" in <bound method Connection.__del__ of <neo4j.bolt.connection.Connection object at 0x7fc899a9a390>> ignored
```