### PR TITLE
[1.7.0] Custom resolver option

### DIFF
--- a/docs/source/driver.rst
+++ b/docs/source/driver.rst
@@ -160,7 +160,7 @@ For example::
             from socket import gaierror
             raise gaierror("Unexpected socket address %r" % socket_address)
 
-     driver = GraphDatabase.driver("bolt://foo:9999", auth=("neo4j", "password"), resolver=my_resolver)
+     driver = GraphDatabase.driver("bolt+routing://foo:9999", auth=("neo4j", "password"), resolver=my_resolver)
 
 
 

--- a/docs/source/driver.rst
+++ b/docs/source/driver.rst
@@ -147,8 +147,9 @@ This setting does not terminate running queries.
 ``resolver``
 ------------
 
-A custom resolver function to use for DNS resolution.
+A custom resolver function to resolve host and port values ahead of DNS resolution.
 This function is called with a 2-tuple of (host, port) and should return an iterable of tuples as would be returned from ``getaddrinfo``.
+If no custom resolver function is supplied, the internal resolver moves straight to regular DNS resolution.
 
 For example::
 

--- a/docs/source/driver.rst
+++ b/docs/source/driver.rst
@@ -144,6 +144,24 @@ The maximum time to allow for retries to be attempted when using transaction fun
 After this time, no more retries will be attempted.
 This setting does not terminate running queries.
 
+``resolver``
+------------
+
+A custom resolver function to use for DNS resolution.
+This function is called with a 2-tuple of (host, port) and should return an iterable of tuples as would be returned from ``getaddrinfo``.
+
+For example::
+
+    def my_resolver(socket_address):
+         if socket_address == ("foo", 9999):
+            yield "::1", 7687
+            yield "127.0.0.1", 7687
+         else:
+            from socket import gaierror
+            raise gaierror("Unexpected socket address %r" % socket_address)
+
+     driver = GraphDatabase.driver("bolt://foo:9999", auth=("neo4j", "password"), resolver=my_resolver)
+
 
 
 Object Lifetime

--- a/neo4j/addressing.py
+++ b/neo4j/addressing.py
@@ -21,13 +21,8 @@
 from collections import namedtuple
 from socket import getaddrinfo, gaierror, SOCK_STREAM, IPPROTO_TCP
 
-from neo4j.compat import urlparse
+from neo4j.compat import urlparse, parse_qs
 from neo4j.exceptions import AddressError
-
-try:
-    from urllib.parse import parse_qs
-except ImportError:
-    from urlparse import parse_qs
 
 
 VALID_IPv4_SEGMENTS = [str(i).encode("latin1") for i in range(0x100)]

--- a/neo4j/bolt/connection.py
+++ b/neo4j/bolt/connection.py
@@ -685,12 +685,15 @@ def connect(address, ssl_context=None, error_handler=None, **config):
     a protocol version can be agreed.
     """
 
+    last_error = None
     # Establish a connection to the host and port specified
     # Catches refused connections see:
     # https://docs.python.org/2/library/errno.html
     log_debug("~~ [RESOLVE] %s", address)
-    last_error = None
-    for resolved_address in resolve(address):
+    resolver = config.get("resolver")
+    if not callable(resolver):
+        resolver = resolve
+    for resolved_address in resolver(address):
         log_debug("~~ [RESOLVED] %s -> %s", address, resolved_address)
         try:
             s = _connect(resolved_address, **config)

--- a/neo4j/compat/__init__.py
+++ b/neo4j/compat/__init__.py
@@ -122,6 +122,6 @@ else:
 
 # The location of urlparse varies between Python 2 and 3
 try:
-    from urllib.parse import urlparse
+    from urllib.parse import urlparse, parse_qs
 except ImportError:
-    from urlparse import urlparse
+    from urlparse import urlparse, parse_qs


### PR DESCRIPTION
This PR adds an option to pass a custom resolver function into the driver configuration. This allows an override of the regular `getaddrinfo` call used for DNS resolution, introducing the possibility for multiple addresses to be provided for bootstrapping the routing process.