### PR TITLE
No STDOUT messages

### DIFF
--- a/neo4j/__init__.py
+++ b/neo4j/__init__.py
@@ -651,8 +651,6 @@ class Session(object):
         if not callable(unit_of_work):
             raise TypeError("Unit of work is not callable")
 
-        metadata = getattr(unit_of_work, "metadata", None)
-        print(metadata)    # TODO
         retry_delay = retry_delay_generator(INITIAL_RETRY_DELAY,
                                             RETRY_DELAY_MULTIPLIER,
                                             RETRY_DELAY_JITTER_FACTOR)

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -4,5 +4,6 @@ mock
 pytest
 pytest-benchmark
 pytest-cov
+six
 teamcity-messages
 tox


### PR DESCRIPTION
Could [these lines](https://github.com/neo4j/neo4j-python-driver/blob/1.7/neo4j/__init__.py#L654) be cut from `neo4j/__init__.py`? 

```
metadata = getattr(unit_of_work, "metadata", None)
print(metadata) # TODO
```
The metadata print fills my console 👎 and isn't controllable with `logging`. 