### PR TITLE
Add routing_driver -method to GraphDatabase -class

### DIFF
--- a/neo4j/__init__.py
+++ b/neo4j/__init__.py
@@ -76,8 +76,29 @@ class GraphDatabase(object):
         """ Create a :class:`.Driver` object. Calling this method provides
         identical functionality to constructing a :class:`.Driver` or
         :class:`.Driver` subclass instance directly.
+        :param uri: the URL to a Neo4j instance
+        :param config: user defined configuration
+        :return: a new driver to the database instance specified by the URL
         """
         return Driver(uri, **config)
+
+    @classmethod
+    def routing_driver(cls, routing_uris, **config):
+        """ Create a :class`.RoutingDriver` object from the first available address.
+        :param routing_uris: List or comma separated list of URIs for Neo4j instances. All given URIs should
+        have 'neo4j' scheme
+        :param config: user defined configuration
+        :return: a new driver instance
+        """
+        if isinstance(routing_uris, list):
+            uris = routing_uris
+        else:
+            uris = routing_uris.split(",")
+        for uri in uris:
+            try:
+                return RoutingDriver(uri, **config)
+            except ServiceUnavailable:
+                warn(f"Unable to create routing driver for URI: {uri}")
 
 
 class Driver(object):

--- a/test/stub/test_routingdriver.py
+++ b/test/stub/test_routingdriver.py
@@ -323,3 +323,17 @@ class RoutingDriverTestCase(StubTestCase):
                     # reader 127.0.0.1:9004 should've been forgotten because of an error
                     assert table.readers == {('127.0.0.1', 9005)}
                     assert table.writers == {('127.0.0.1', 9006)}
+
+    def test_bolt_plus_routing_multiple_uris_as_comma_separated_list_constructs_routing_driver(self):
+        with StubCluster({9002: "router.script"}):
+            uris = "neo4j://127.0.0.1:9001,neo4j://127.0.0.1:9002,neo4j://127.0.0.1:9003"
+            with self.assertWarnsRegex(UserWarning, "Unable to create routing driver for URI:"):
+                with GraphDatabase.routing_driver(uris, auth=self.auth_token, encrypted=False) as driver:
+                    assert isinstance(driver, RoutingDriver)
+
+    def test_bolt_plus_routing_multiple_uris_as_list_constructs_routing_driver(self):
+        with StubCluster({9002: "router.script"}):
+            uris = ["neo4j://127.0.0.1:9001", "neo4j://127.0.0.1:9002", "neo4j://127.0.0.1:9003"]
+            with self.assertWarnsRegex(UserWarning, "Unable to create routing driver for URI:"):
+                with GraphDatabase.routing_driver(uris, auth=self.auth_token, encrypted=False) as driver:
+                    assert isinstance(driver, RoutingDriver)


### PR DESCRIPTION
This adds routing_driver -method to GraphDatabase -class which allows passing core -members as comma separated URI -string or as a list. Approach is similar than neo4j-java-driver implementation.