### PR TITLE
(docs) use with-as for driver initialization

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,17 +13,17 @@ Quick Example
 
     from neo4j import GraphDatabase
 
-    uri = "bolt://localhost:7687"
-    driver = GraphDatabase.driver(uri, auth=("neo4j", "password"))
-
     def print_friends_of(tx, name):
         for record in tx.run("MATCH (a:Person)-[:KNOWS]->(f) "
                              "WHERE a.name = {name} "
                              "RETURN f.name", name=name):
         print(record["f.name"])
 
-    with driver.session() as session:
-        session.read_transaction(print_friends_of, "Alice")
+    uri = "bolt://localhost:7687"
+    
+    with GraphDatabase.driver(uri, auth=("neo4j", "password")) as driver:
+        with driver.session() as session:
+            session.read_transaction(print_friends_of, "Alice")
 
 
 .. note::


### PR DESCRIPTION
In particular, the current example does not `close()` the connection causing two (non-critical) warnings appear at termination of the Python script: https://github.com/neo4j/neo4j-python-driver/issues/290

Using `with` exactly prevents forgotten `close()` calls.