### PR TITLE
[1.7] Fixed summary metadata consumption

### DIFF
--- a/neo4j/__init__.py
+++ b/neo4j/__init__.py
@@ -47,6 +47,10 @@ __all__ = [
     "kerberos_auth",
 ]
 
+BOLT_VERSION_1 = 1
+BOLT_VERSION_2 = 2
+BOLT_VERSION_3 = 3
+
 try:
     from neobolt.exceptions import (
         ConnectionExpired,
@@ -1077,10 +1081,10 @@ class BoltStatementResultSummary(object):
     #: A :class:`.ProfiledPlan` instance
     profile = None
 
-    #: The time it took for the server to have the result available.
+    #: The time it took for the server to have the result available. (milliseconds)
     result_available_after = None
 
-    #: The time it took for the server to consume the result.
+    #: The time it took for the server to consume the result. (milliseconds)
     result_consumed_after = None
 
     #: Notifications provide extra information for a user executing a statement.
@@ -1097,10 +1101,12 @@ class BoltStatementResultSummary(object):
         self.parameters = metadata.get("parameters")
         self.statement_type = metadata.get("type")
         self.counters = SummaryCounters(metadata.get("stats", {}))
-        self.result_available_after = metadata.get("result_available_after")
-        self.result_consumed_after = metadata.get("result_consumed_after")
-        self.t_first = metadata.get("t_first")
-        self.t_last = metadata.get("t_last")
+        if self.protocol_version < BOLT_VERSION_3:
+            self.result_available_after = metadata.get("result_available_after")
+            self.result_consumed_after = metadata.get("result_consumed_after")
+        else:
+            self.result_available_after = metadata.get("t_first")
+            self.result_consumed_after = metadata.get("t_last")
         if "plan" in metadata:
             self.plan = _make_plan(metadata["plan"])
         if "profile" in metadata:

--- a/test/integration/test_session.py
+++ b/test/integration/test_session.py
@@ -277,12 +277,15 @@ class SummaryTestCase(DirectIntegrationTestCase):
             raise SkipTest("Execution times are not supported before server 3.1")
         with self.driver.session() as session:
             summary = session.run("UNWIND range(1,1000) AS n RETURN n AS number").consume()
-            if self.protocol_version() >= 3:
-                self.assertIsInstance(summary.t_first, int)
-                self.assertIsInstance(summary.t_last, int)
-            else:
-                self.assertIsInstance(summary.result_available_after, int)
-                self.assertIsInstance(summary.result_consumed_after, int)
+
+            self.assertIsInstance(summary.result_available_after, int)
+            self.assertIsInstance(summary.result_consumed_after, int)
+
+            with self.assertRaises(AttributeError) as ex:
+                summary.t_first
+
+            with self.assertRaises(AttributeError) as ex:
+                summary.t_last
 
 
 class ResetTestCase(DirectIntegrationTestCase):


### PR DESCRIPTION
Bolt Version 3 introduced the t_first and t_last keys,
instead of the result_available_after and result_consumed_after keys.

The result is now in line with the other drivers.