### PR TITLE
[4.0] Fixed summary metadata consumption

### DIFF
--- a/tests/integration/test_summary.py
+++ b/tests/integration/test_summary.py
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 
 def test_can_obtain_summary_after_consuming_result(session):
     result = session.run("CREATE (n) RETURN n")
@@ -89,5 +90,13 @@ def test_can_obtain_notification_info(session):
 
 def test_contains_time_information(session):
     summary = session.run("UNWIND range(1,1000) AS n RETURN n AS number").consume()
-    assert isinstance(summary.t_first, int)
-    assert isinstance(summary.t_last, int)
+
+    assert isinstance(summary.result_available_after, int)
+    assert isinstance(summary.result_consumed_after, int)
+
+    with pytest.raises(AttributeError) as ex:
+        summary.t_first
+
+    with pytest.raises(AttributeError) as ex:
+        summary.t_last
+


### PR DESCRIPTION
Bolt Version 3 introduced the t_first and t_last keys,
instead of the result_available_after and result_consumed_after keys.

The result is now in line with the other drivers.