### PR TITLE
[1.7] test requirements.py bug fix

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,4 @@
+more-itertools<=5.0.0 ; python_version=="2.7"
 boltkit==1.2.0
 coverage
 mock


### PR DESCRIPTION
The version 6.0 of more-itertools seems to have introduced the bug:

def _collate(*iterables, key=lambda a: a, reverse=False):
		       ^ SyntaxError: invalid syntax

`from tox import cmdline`, have the dependency of more-itertools.

Issue:

https://github.com/pytest-dev/pytest/issues/4770
https://github.com/pytest-dev/pytest/issues/4772

The other solution is to use a never version of pip.

pip install --upgrade pip