### PR TITLE
[4.0] Fixed meta data consumption in summary

### DIFF
--- a/neo4j/work/summary.py
+++ b/neo4j/work/summary.py
@@ -21,6 +21,11 @@
 
 from collections import namedtuple
 
+BOLT_VERSION_1 = 1
+BOLT_VERSION_2 = 2
+BOLT_VERSION_3 = 3
+BOLT_VERSION_4 = 4
+
 
 class BoltStatementResultSummary:
     """ A summary of execution returned with a :class:`.StatementResult` object.
@@ -50,10 +55,10 @@ class BoltStatementResultSummary:
     #: A :class:`.ProfiledPlan` instance
     profile = None
 
-    #: The time it took for the server to have the result available.
+    #: The time it took for the server to have the result available. (milliseconds)
     result_available_after = None
 
-    #: The time it took for the server to consume the result.
+    #: The time it took for the server to consume the result. (milliseconds)
     result_consumed_after = None
 
     #: Notifications provide extra information for a user executing a statement.
@@ -70,10 +75,12 @@ class BoltStatementResultSummary:
         self.parameters = metadata.get("parameters")
         self.statement_type = metadata.get("type")
         self.counters = SummaryCounters(metadata.get("stats", {}))
-        self.result_available_after = metadata.get("result_available_after")
-        self.result_consumed_after = metadata.get("result_consumed_after")
-        self.t_first = metadata.get("t_first")
-        self.t_last = metadata.get("t_last")
+        if self.protocol_version[0] < BOLT_VERSION_3:
+            self.result_available_after = metadata.get("result_available_after")
+            self.result_consumed_after = metadata.get("result_consumed_after")
+        else:
+            self.result_available_after = metadata.get("t_first")
+            self.result_consumed_after = metadata.get("t_last")
         if "plan" in metadata:
             self.plan = _make_plan(metadata["plan"])
         if "profile" in metadata:

--- a/tests/integration/test_summary.py
+++ b/tests/integration/test_summary.py
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 
 def test_can_obtain_summary_after_consuming_result(session):
     result = session.run("CREATE (n) RETURN n")
@@ -89,5 +90,22 @@ def test_can_obtain_notification_info(session):
 
 def test_contains_time_information(session):
     summary = session.run("UNWIND range(1,1000) AS n RETURN n AS number").consume()
-    assert isinstance(summary.t_first, int)
-    assert isinstance(summary.t_last, int)
+
+    assert isinstance(summary.result_available_after, int)
+    assert isinstance(summary.result_consumed_after, int)
+
+    with pytest.raises(AttributeError) as ex:
+        assert isinstance(summary.t_first, int)
+
+    with pytest.raises(AttributeError) as ex:
+        assert isinstance(summary.t_last, int)
+
+
+def test_protocol_version_information(session):
+    summary = session.run("UNWIND range(1,100) AS n RETURN n AS number").consume()
+
+    assert isinstance(summary.protocol_version, tuple)
+    assert isinstance(summary.protocol_version[0], int)
+    assert isinstance(summary.protocol_version[1], int)
+
+


### PR DESCRIPTION
Bolt Version 3 introduced the t_first and t_last keys over the wire,
instead of the result_available_after and result_consumed_after keys.

The result is now in line with the other drivers.