### PR TITLE
Exceptions cleanup

### DIFF
--- a/neo4j/__init__.py
+++ b/neo4j/__init__.py
@@ -37,7 +37,7 @@ from urllib.parse import urlparse, parse_qs
 from neo4j.addressing import Address
 from neo4j.api import *
 from neo4j.conf import Config, PoolConfig
-from neo4j.exceptions import ConnectionExpired, ServiceUnavailable
+from neo4j.exceptions import ServiceUnavailable
 from neo4j.meta import experimental, get_user_agent, version as __version__
 
 

--- a/neo4j/errors.py
+++ b/neo4j/errors.py
@@ -198,6 +198,7 @@ class DatabaseError(BoltFailure):
 
 class TransientError(BoltFailure):
     """
+    A temporary error has occurred. The application should retry the operation.
     """
 
     transient = True

--- a/neo4j/exceptions.py
+++ b/neo4j/exceptions.py
@@ -30,7 +30,7 @@ class ProtocolError(Exception):
 
 
 class ServiceUnavailable(Exception):
-    """ Raised when no database service is available.
+    """ Raised when no database service is available. When the driver is no longer able to establish communication with the server, even after retries.
     """
 
 
@@ -39,12 +39,6 @@ class IncompleteCommitError(Exception):
     response. For non-idempotent write transactions, this leaves the data
     in an unknown state with regard to whether the transaction completed
     successfully or not.
-    """
-
-
-class ConnectionExpired(Exception):
-    """ Raised when a connection is no longer available for the
-    purpose it was originally acquired.
     """
 
 
@@ -161,6 +155,25 @@ class AuthError(ClientError, SecurityError):
     """ Raised when authentication failure occurs.
     """
 
+
+class SessionExpired(Exception):
+    """ A SessionExpired indicates that the session can no longer satisfy the criteria under which it was acquired,
+    e.g. a server no longer accepts write requests.
+
+    A new session needs to be acquired from the driver and all actions taken on the expired session must be replayed.
+    """
+
+    def __init__(self, session, *args, **kwargs):
+        super(SessionExpired, self).__init__(session, *args, **kwargs)
+
+
+class TransactionError(Exception):
+    """ Raised when an error occurs while using a transaction.
+    """
+
+    def __init__(self, transaction, *args, **kwargs):
+        super(TransactionError, self).__init__(*args, **kwargs)
+        self.transaction = transaction
 
 client_errors = {
 

--- a/neo4j/io/_bolt3.py
+++ b/neo4j/io/_bolt3.py
@@ -22,7 +22,12 @@
 from select import select
 from struct import pack as struct_pack
 
-from neo4j.exceptions import ProtocolError, CypherError, AuthError, ServiceUnavailable
+from neo4j.exceptions import (
+    ProtocolError,
+    CypherError,
+    AuthError,
+    ServiceUnavailable,
+)
 from neo4j.packstream import UnpackableBuffer, Unpacker
 
 

--- a/neo4j/work/__init__.py
+++ b/neo4j/work/__init__.py
@@ -20,7 +20,7 @@
 
 
 from neo4j.conf import Config
-from neo4j.exceptions import ConnectionExpired, ServiceUnavailable
+from neo4j.exceptions import ServiceUnavailable
 
 
 class WorkspaceConfig(Config):
@@ -78,7 +78,7 @@ class Workspace:
                 try:
                     self._connection.send_all()
                     self._connection.fetch_all()
-                except (WorkspaceError, ConnectionExpired, ServiceUnavailable):
+                except (WorkspaceError, ServiceUnavailable):
                     pass
             if self._connection:
                 self._connection.in_use = False

--- a/neo4j/work/simple.py
+++ b/neo4j/work/simple.py
@@ -29,11 +29,12 @@ from neo4j import READ_ACCESS, WRITE_ACCESS
 from neo4j.conf import DeprecatedAlias
 from neo4j.data import DataHydrator, DataDehydrator
 from neo4j.exceptions import (
-    ConnectionExpired,
     CypherError,
     IncompleteCommitError,
     ServiceUnavailable,
     TransientError,
+    SessionExpired,
+    TransactionError,
 )
 from neo4j.work import Workspace, WorkspaceConfig
 from neo4j.work.summary import BoltStatementResultSummary
@@ -122,7 +123,7 @@ class Session(Workspace):
             try:
                 self._connection.send_all()
                 self._connection.fetch_all()
-            except (ConnectionExpired, CypherError, TransactionError,
+            except (CypherError, TransactionError,
                     ServiceUnavailable, SessionExpired):
                 pass
             finally:
@@ -216,7 +217,7 @@ class Session(Workspace):
             try:
                 self._connection.send_all()
                 self._connection.fetch_message()
-            except ConnectionExpired as error:
+            except ServiceUnavailable as error:
                 raise SessionExpired(*error.args)
 
         return result
@@ -227,7 +228,7 @@ class Session(Workspace):
         if self._connection:
             try:
                 self._connection.send_all()
-            except ConnectionExpired as error:
+            except ServiceUnavailable as error:
                 raise SessionExpired(*error.args)
 
     def fetch(self):
@@ -238,7 +239,7 @@ class Session(Workspace):
         if self._connection:
             try:
                 detail_count, _ = self._connection.fetch_message()
-            except ConnectionExpired as error:
+            except ServiceUnavailable as error:
                 raise SessionExpired(*error.args)
             else:
                 return detail_count
@@ -253,7 +254,7 @@ class Session(Workspace):
             try:
                 self._connection.send_all()
                 detail_count, _ = self._connection.fetch_all()
-            except ConnectionExpired as error:
+            except ServiceUnavailable as error:
                 raise SessionExpired(*error.args)
             else:
                 return detail_count
@@ -390,7 +391,7 @@ class Session(Workspace):
                         tx.success = True
                 finally:
                     tx.close()
-            except (ServiceUnavailable, SessionExpired, ConnectionExpired) as error:
+            except (ServiceUnavailable, SessionExpired) as error:
                 errors.append(error)
             except TransientError as error:
                 if is_retriable_transient_error(error):
@@ -727,22 +728,7 @@ class BoltStatementResult:
         return [record.data(*items) for record in self.records()]
 
 
-class SessionExpired(Exception):
-    """ Raised when no a session is no longer able to fulfil
-    the purpose described by its original parameters.
-    """
 
-    def __init__(self, session, *args, **kwargs):
-        super(SessionExpired, self).__init__(session, *args, **kwargs)
-
-
-class TransactionError(Exception):
-    """ Raised when an error occurs while using a transaction.
-    """
-
-    def __init__(self, transaction, *args, **kwargs):
-        super(TransactionError, self).__init__(*args, **kwargs)
-        self.transaction = transaction
 
 
 def unit_of_work(metadata=None, timeout=None):

--- a/tests/stub/test_directdriver.py
+++ b/tests/stub/test_directdriver.py
@@ -19,8 +19,10 @@
 # limitations under the License.
 
 
-from neo4j.exceptions import ServiceUnavailable
-
+from neo4j.exceptions import (
+    ServiceUnavailable,
+    SessionExpired,
+)
 from neo4j import GraphDatabase, BoltDriver
 
 from tests.stub.conftest import StubTestCase, StubCluster
@@ -29,28 +31,32 @@ from tests.stub.conftest import StubTestCase, StubCluster
 class BoltDriverTestCase(StubTestCase):
 
     def test_bolt_uri_constructs_bolt_driver(self):
+        #  python -m pytest tests/stub/test_directdriver.py -s -k test_bolt_uri_constructs_bolt_driver
         with StubCluster("v3/empty.script"):
             uri = "bolt://127.0.0.1:9001"
             with GraphDatabase.driver(uri, auth=self.auth_token) as driver:
                 assert isinstance(driver, BoltDriver)
 
     def test_direct_disconnect_on_run(self):
+        #  python -m pytest tests/stub/test_directdriver.py -s -k test_direct_disconnect_on_run
         with StubCluster("v3/disconnect_on_run.script"):
             uri = "bolt://127.0.0.1:9001"
             with GraphDatabase.driver(uri, auth=self.auth_token) as driver:
-                with self.assertRaises(ServiceUnavailable):
+                with self.assertRaises(SessionExpired):
                     with driver.session() as session:
                         session.run("RETURN $x", {"x": 1}).consume()
 
     def test_direct_disconnect_on_pull_all(self):
+        #  python -m pytest tests/stub/test_directdriver.py -s -k test_direct_disconnect_on_pull_all
         with StubCluster("v3/disconnect_on_pull_all.script"):
             uri = "bolt://127.0.0.1:9001"
             with GraphDatabase.driver(uri, auth=self.auth_token) as driver:
-                with self.assertRaises(ServiceUnavailable):
+                with self.assertRaises(SessionExpired):
                     with driver.session() as session:
                         session.run("RETURN $x", {"x": 1}).consume()
 
     def test_direct_session_close_after_server_close(self):
+        #  python -m pytest tests/stub/test_directdriver.py -s -k test_direct_session_close_after_server_close
         with StubCluster("v3/disconnect_after_init.script"):
             uri = "bolt://127.0.0.1:9001"
             with GraphDatabase.driver(uri, auth=self.auth_token, max_retry_time=0,


### PR DESCRIPTION
Removed ConnectionExpired
    
Moved, SessionExpired, TransactionError from neo4j/work/simple.py to neo4j/exceptons.py
    
Change test_directdriver to use the SessionExpired:
    
A SessionExpired indicates that the session can no longer satisfy the criteria under which it was acquired, e.g. a server no longer accepts write requests.
A new session needs to be acquired from the driver and all actions taken on the expired session must be replayed.