### PR TITLE
Make tests green when running against 4.1 db

### DIFF
--- a/tests/integration/test_autocommit.py
+++ b/tests/integration/test_autocommit.py
@@ -196,9 +196,17 @@ def test_autocommit_transactions_should_support_timeout(neo4j_driver):
         with neo4j_driver.session() as s2:
             tx1 = s1.begin_transaction()
             tx1.run("MATCH (a:Node) SET a.property = 1").consume()
-            with pytest.raises(TransientError):
+            try:
                 result = s2.run(Query("MATCH (a:Node) SET a.property = 2", timeout=0.25))
                 result.consume()
+            # On 4.0 and older
+            except TransientError:
+                pass
+            # On 4.1 and forward
+            except ClientError:
+                pass
+            else:
+                raise
 
 
 def test_regex_in_parameter(session):

--- a/tests/integration/test_explicit_tx.py
+++ b/tests/integration/test_explicit_tx.py
@@ -160,8 +160,16 @@ def test_transaction_timeout(driver):
             tx1 = s1.begin_transaction()
             tx1.run("MATCH (a:Node) SET a.property = 1").consume()
             tx2 = s2.begin_transaction(timeout=0.25)
-            with pytest.raises(TransientError):
+            try:
                 tx2.run("MATCH (a:Node) SET a.property = 2").consume()
+            # On 4.0 and older
+            except TransientError:
+                pass
+            # On 4.1 and forward
+            except ClientError:
+                pass
+            else:
+                raise
 
 
 # TODO: Re-enable and test when TC is available again

--- a/tests/integration/test_summary.py
+++ b/tests/integration/test_summary.py
@@ -20,6 +20,11 @@
 
 import pytest
 
+def get_operator_type(op):
+    # Fabric will suffix with db name, remove this to handle fabric on/off
+    op = op.split("@")
+    return op[0]
+
 
 def test_can_obtain_summary_after_consuming_result(session):
     # python -m pytest tests/integration/test_summary.py -s -v -k test_can_obtain_summary_after_consuming_result
@@ -43,7 +48,7 @@ def test_can_obtain_plan_info(session):
     result = session.run("EXPLAIN CREATE (n) RETURN n")
     summary = result.consume()
     plan = summary.plan
-    assert plan.operator_type == "ProduceResults"
+    assert get_operator_type(plan.operator_type) == "ProduceResults"
     assert plan.identifiers == ["n"]
     assert len(plan.children) == 1
 
@@ -54,7 +59,7 @@ def test_can_obtain_profile_info(session):
     profile = summary.profile
     assert profile.db_hits == 0
     assert profile.rows == 1
-    assert profile.operator_type == "ProduceResults"
+    assert get_operator_type(profile.operator_type) == "ProduceResults"
     assert profile.identifiers == ["n"]
     assert len(profile.children) == 1
 


### PR DESCRIPTION
4.1 uses the correctly classified error when client aborts transaction due to timeout, need to handle that in timeout tests.

4.1 suffixes plan operators with db name, handle this and unsuffixed cases in tests.