### PR TITLE
Updated ServerInfo class with new methods

### DIFF
--- a/neo4j/api.py
+++ b/neo4j/api.py
@@ -191,7 +191,9 @@ class ServerInfo:
     @property
     def protocol_version(self):
         """ Bolt protocol version with which the remote server
-        communicates.
+        communicates. This is returned as a :class:`.Version`
+        object, which itself extends a simple 2-tuple of
+        (major, minor) integers.
         """
         return self._protocol_version
 

--- a/neo4j/api.py
+++ b/neo4j/api.py
@@ -26,6 +26,8 @@ from.exceptions import (
     DriverError,
     ConfigurationError,
 )
+from .meta import deprecated
+
 
 """ Base classes and helpers.
 """
@@ -172,23 +174,44 @@ class Bookmark:
 
 
 class ServerInfo:
+    """ Represents a package of information relating to a Neo4j server.
+    """
 
     def __init__(self, address, protocol_version):
-        self.address = address
-        self.protocol_version = protocol_version
-        self.metadata = {}
+        self._address = address
+        self._protocol_version = protocol_version
+        self._metadata = {}
+
+    @property
+    def address(self):
+        """ Network address of the remote server.
+        """
+        return self._address
+
+    @property
+    def protocol_version(self):
+        """ Bolt protocol version with which the remote server
+        communicates.
+        """
+        return self._protocol_version
 
     @property
     def agent(self):
-        """The server agent string the server responded with.
-
-        :return: Server agent string
-        :rtype: str
+        """ Server agent string by which the remote server identifies
+        itself.
         """
-        # Example "Neo4j/4.0.5"
-        # Example "Neo4j/4"
-        return self.metadata.get("server")
+        return self._metadata.get("server")
 
+    @property
+    def connection_id(self):
+        """ Unique identifier for the remote server connection.
+        """
+        return self._metadata.get("connection_id")
+
+    # TODO in 5.0: remove this method
+    @deprecated("The version_info method is deprecated, please use "
+                "ServerInfo.agent, ServerInfo.protocol_version, or "
+                "call the dbms.components procedure instead")
     def version_info(self):
         """Return the server version if available.
 
@@ -220,14 +243,12 @@ class ServerInfo:
                 pass
         return tuple(value)
 
-    def _update_metadata(self, metadata):
-        """Internal, update the metadata and perform check that the prefix is whitelisted by calling self.version()
-
-        :param metadata: metadata from the server
-        :type metadata: dict
+    def update(self, metadata):
+        """ Update server information with extra metadata. This is
+        typically drawn from the metadata received after successful
+        connection initialisation.
         """
-        self.metadata.update(metadata)
-        _ = self.version_info()
+        self._metadata.update(metadata)
 
 
 class Version(tuple):

--- a/neo4j/exceptions.py
+++ b/neo4j/exceptions.py
@@ -304,3 +304,8 @@ class AuthConfigurationError(ConfigurationError):
 class CertificateConfigurationError(ConfigurationError):
     """ Raised when there is an error with the authentication configuration.
     """
+
+
+class UnsupportedServerProduct(Exception):
+    """ Raised when an unsupported server product is detected.
+    """

--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "Bolt",
     "BoltPool",
     "Neo4jPool",
+    "check_supported_server_product",
 ]
 
 
@@ -79,6 +80,7 @@ from neo4j.exceptions import (
     ReadServiceUnavailable,
     WriteServiceUnavailable,
     ConfigurationError,
+    UnsupportedServerProduct,
 )
 from neo4j.routing import RoutingTable
 from neo4j.conf import (
@@ -1050,3 +1052,14 @@ def connect(address, *, timeout, custom_resolver, ssl_context, keep_alive):
         raise ServiceUnavailable("Failed to resolve addresses for %s" % address)
     else:
         raise last_error
+
+
+def check_supported_server_product(agent):
+    """ Checks that a server product is supported by the driver by
+    looking at the server agent string.
+
+    :param agent: server agent string to check for validity
+    :raises UnsupportedServerProduct: if the product is not supported
+    """
+    if not agent.startswith("Neo4j/"):
+        raise UnsupportedServerProduct(agent)

--- a/neo4j/io/_bolt3.py
+++ b/neo4j/io/_bolt3.py
@@ -42,6 +42,7 @@ from neo4j.exceptions import (
     ForbiddenOnReadOnlyDatabase,
     SessionExpired,
     ConfigurationError,
+    UnsupportedServerProduct,
 )
 from neo4j._exceptions import (
     BoltIncompleteCommitError,
@@ -54,6 +55,7 @@ from neo4j.packstream import (
 from neo4j.io import (
     Bolt,
     BoltPool,
+    check_supported_server_product,
 )
 from neo4j.api import ServerInfo
 from neo4j.addressing import Address
@@ -153,9 +155,10 @@ class Bolt3(Bolt):
             logged_headers["credentials"] = "*******"
         log.debug("[#%04X]  C: HELLO %r", self.local_port, logged_headers)
         self._append(b"\x01", (headers,),
-                     response=InitResponse(self, on_success=self.server_info._update_metadata))
+                     response=InitResponse(self, on_success=self.server_info.update))
         self.send_all()
         self.fetch_all()
+        check_supported_server_product(self.server_info.agent)
 
     def run(self, query, parameters=None, mode=None, bookmarks=None, metadata=None, timeout=None, db=None, **handlers):
         if db is not None:

--- a/neo4j/io/_bolt4.py
+++ b/neo4j/io/_bolt4.py
@@ -54,6 +54,7 @@ from neo4j.packstream import (
 from neo4j.io import (
     Bolt,
     BoltPool,
+    check_supported_server_product,
 )
 from neo4j.api import ServerInfo
 from neo4j.addressing import Address
@@ -153,9 +154,10 @@ class Bolt4x0(Bolt):
             logged_headers["credentials"] = "*******"
         log.debug("[#%04X]  C: HELLO %r", self.local_port, logged_headers)
         self._append(b"\x01", (headers,),
-                     response=InitResponse(self, on_success=self.server_info._update_metadata))
+                     response=InitResponse(self, on_success=self.server_info.update))
         self.send_all()
         self.fetch_all()
+        check_supported_server_product(self.server_info.agent)
 
     def run(self, query, parameters=None, mode=None, bookmarks=None, metadata=None, timeout=None, db=None, **handlers):
         if not parameters:


### PR DESCRIPTION
This PR updates the `ServerInfo` class to add new accessors for `address`, `protocol_version` and `connection_id`. It also deprecates the old `version_info` method (for removal in 5.0) and improves the implementation of the "supported server product" check.