### PR TITLE
Fix problem with failed retriable transactions in cluster

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -1006,7 +1006,7 @@ def _handshake(s, resolved_address):
         # response, the server has closed the connection
         log.debug("[#%04X]  S: <CLOSE>", local_port)
         s.close()
-        raise BoltHandshakeError("Connection to {address} closed without handshake response".format(address=resolved_address), address=resolved_address, request_data=handshake, response_data=None)
+        raise ServiceUnavailable("Connection to {address} closed without handshake response".format(address=resolved_address))
     if data_size != 4:
         # Some garbled data has been received
         log.debug("[#%04X]  S: @*#!", local_port)


### PR DESCRIPTION
During rolling upgrades of clusters the handshake can be interrupted and
a read during handshake can fail, this should be retried. Change the
exception raised for this condition.