### PR TITLE
Do not connect to cluster/server upon driver creation

### DIFF
--- a/neo4j/__init__.py
+++ b/neo4j/__init__.py
@@ -450,3 +450,8 @@ class Neo4jDriver(Routing, Driver):
             if val is not None:
                 return routing_info
         raise ServiceUnavailable("Could not connect to any routing servers.")
+
+    def update_routing_table(self, database=None):
+        if database is None:
+            database = self._pool.workspace_config.database
+        self._pool.update_routing_table(database=database)

--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -532,8 +532,6 @@ class BoltPool(IOPool):
             return Bolt.open(addr, auth=auth, timeout=timeout, routing_context=routing_context, **pool_config)
 
         pool = cls(opener, pool_config, workspace_config, routing_context, address)
-        seeds = [pool.acquire() for _ in range(pool_config.init_size)]
-        pool.release(*seeds)
         return pool
 
     def __init__(self, opener, pool_config, workspace_config, routing_context, address):
@@ -576,14 +574,7 @@ class Neo4jPool(IOPool):
             return Bolt.open(addr, auth=auth, timeout=timeout, routing_context=routing_context, **pool_config)
 
         pool = cls(opener, pool_config, workspace_config, routing_context, address)
-
-        try:
-            pool.update_routing_table(database=workspace_config.database)
-        except Exception:
-            pool.close()
-            raise
-        else:
-            return pool
+        return pool
 
     def __init__(self, opener, pool_config, workspace_config, routing_context, address):
         """

--- a/testkitbackend/backend.py
+++ b/testkitbackend/backend.py
@@ -17,6 +17,7 @@
 from json import loads, dumps
 from inspect import getmembers, isfunction
 import testkitbackend.requests as requests
+from neo4j.exceptions import Neo4jError, DriverError
 
 
 class Backend:
@@ -27,6 +28,7 @@ class Backend:
         self.sessions = {}
         self.results = {}
         self.transactions = {}
+        self.errors = {}
         self.key = 0
         # Collect all request handlers
         self._requestHandlers = dict(
@@ -66,7 +68,12 @@ class Backend:
         if not handler:
             raise Exception("No request handler for " + name)
         data = request["data"]
-        handler(self, data)
+        try:
+            handler(self, data)
+        except Neo4jError or DriverError as e:
+            key = self.next_key()
+            self.errors[key] = e
+            self.send_response("DriverError", {"id": key})
 
     def send_response(self, name, data):
         """ Sends a response to backend.

--- a/testkitbackend/backend.py
+++ b/testkitbackend/backend.py
@@ -17,7 +17,7 @@
 from json import loads, dumps
 from inspect import getmembers, isfunction
 import testkitbackend.requests as requests
-from neo4j.exceptions import Neo4jError, DriverError
+from neo4j.exceptions import Neo4jError, DriverError, ServiceUnavailable
 
 
 class Backend:
@@ -70,10 +70,12 @@ class Backend:
         data = request["data"]
         try:
             handler(self, data)
-        except Neo4jError or DriverError as e:
+        except Neo4jError or DriverError or ServiceUnavailable as e:
             key = self.next_key()
             self.errors[key] = e
             self.send_response("DriverError", {"id": key})
+        except Exception as e:
+            self.send_response("BackendError", {"msg": str(e)})
 
     def send_response(self, name, data):
         """ Sends a response to backend.

--- a/testkitbackend/requests.py
+++ b/testkitbackend/requests.py
@@ -98,6 +98,13 @@ def SessionBeginTransaction(backend, data):
     backend.send_response("Transaction", {"id": key})
 
 
+def SessionLastBookmarks(backend, data):
+    key = data["sessionId"]
+    session = backend.sessions[key].session
+    bookmark = session.last_bookmark()
+    backend.send_response("Bookmarks", {"bookmarks": [bookmark]})
+
+
 def ResultNext(backend, data):
     result = backend.results[data["resultId"]]
     try:

--- a/testkitbackend/requests.py
+++ b/testkitbackend/requests.py
@@ -58,6 +58,7 @@ def NewSession(backend, data):
             "default_access_mode": access_mode,
             "bookmarks": data["bookmarks"],
             "database": data["database"],
+            "fetch_size": data.get("fetchSize", None)
     }
     # TODO: fetchSize, database
     session = driver.session(**config)
@@ -103,6 +104,7 @@ def ResultNext(backend, data):
         record = next(iter(result))
     except StopIteration:
         backend.send_response("NullRecord", {})
+        return
     backend.send_response("Record", totestkit.record(record))
 
 

--- a/testkitbackend/requests.py
+++ b/testkitbackend/requests.py
@@ -126,7 +126,7 @@ def transactionFunc(backend, data, is_read):
                 cont = False
             elif session_tracker.state == '-':
                 if session_tracker.error_id:
-                    raise backend.Errors[session_tracker.error_id]
+                    raise backend.errors[session_tracker.error_id]
                 else:
                     raise Exception("Client said no")
 

--- a/testkitbackend/requests.py
+++ b/testkitbackend/requests.py
@@ -91,7 +91,7 @@ def SessionBeginTransaction(backend, data):
     metadata = data.get('txMeta', None)
     timeout = data.get('timeout', None)
     if timeout:
-        timeout = int(timeout)
+        timeout = float(timeout) / 1000
     tx = session.begin_transaction(metadata=metadata, timeout=timeout)
     key = backend.next_key()
     backend.transactions[key] = tx

--- a/testkitbackend/requests.py
+++ b/testkitbackend/requests.py
@@ -154,7 +154,10 @@ def SessionLastBookmarks(backend, data):
     key = data["sessionId"]
     session = backend.sessions[key].session
     bookmark = session.last_bookmark()
-    backend.send_response("Bookmarks", {"bookmarks": [bookmark]})
+    bookmarks = []
+    if bookmark:
+        bookmarks.append(bookmark)
+    backend.send_response("Bookmarks", {"bookmarks": bookmarks})
 
 
 def ResultNext(backend, data):

--- a/tests/integration/examples/test_database_selection_example.py
+++ b/tests/integration/examples/test_database_selection_example.py
@@ -63,20 +63,10 @@ class DatabaseSelectionExample:
         # end::database-selection[]
 
 
-def test_database_selection_example(neo4j_uri, auth):
-    try:
-        s = StringIO()
-        with redirect_stdout(s):
-            example = DatabaseSelectionExample(neo4j_uri, auth[0], auth[1])
-            example.run_example_code()
-            example.close()
-        assert s.getvalue().startswith("Hello, Example-Database")
-    except ServiceUnavailable as error:
-        if isinstance(error.__cause__, BoltHandshakeError):
-            pytest.skip(error.args[0])
-        if error.args[0] == "Server does not support routing":
-            # This is because a single instance Neo4j 3.5 does not have dbms.routing.cluster.getRoutingTable() call
-            pytest.skip(error.args[0])
-    except ConfigurationError as error:
-            pytest.skip(error.args[0])
-
+def test_database_selection_example(neo4j_uri, auth, requires_bolt_4x):
+    s = StringIO()
+    with redirect_stdout(s):
+        example = DatabaseSelectionExample(neo4j_uri, auth[0], auth[1])
+        example.run_example_code()
+        example.close()
+    assert s.getvalue().startswith("Hello, Example-Database")

--- a/tests/integration/test_bolt_driver.py
+++ b/tests/integration/test_bolt_driver.py
@@ -89,7 +89,8 @@ def test_fail_nicely_when_using_http_port(service):
     address = service.addresses[0]
     uri = "bolt://{}:{}".format(address[0], NEO4J_PORTS["http"])
     with pytest.raises(ServiceUnavailable):
-        _ = GraphDatabase.driver(uri, auth=service.auth)
+        driver = GraphDatabase.driver(uri, auth=service.auth)
+        driver.verify_connectivity()
 
 
 def test_custom_resolver(service):

--- a/tests/integration/test_neo4j_driver.py
+++ b/tests/integration/test_neo4j_driver.py
@@ -60,42 +60,9 @@ def test_neo4j_uri(neo4j_uri, auth, target):
             pytest.skip(error.args[0])
 
 
-def test_supports_multi_db(neo4j_uri, auth, target):
+def test_supports_multi_db(neo4j_driver, requires_bolt_4x):
     # python -m pytest tests/integration/test_neo4j_driver.py -s -v -k test_supports_multi_db
-    try:
-        driver = GraphDatabase.driver(neo4j_uri, auth=auth)
-        assert isinstance(driver, Neo4jDriver)
-    except ServiceUnavailable as error:
-        if error.args[0] == "Server does not support routing":
-            # This is because a single instance Neo4j 3.5 does not have dbms.routing.cluster.getRoutingTable() call
-            pytest.skip(error.args[0])
-        elif isinstance(error.__cause__, BoltHandshakeError):
-            pytest.skip(error.args[0])
-
-    with driver.session() as session:
-        result = session.run("RETURN 1")
-        _ = result.single().value()   # Consumes the result
-        summary = result.consume()
-        server_info = summary.server
-
-    assert isinstance(summary, ResultSummary)
-    assert isinstance(server_info, ServerInfo)
-    assert server_info.version_info() is not None
-    assert isinstance(server_info.protocol_version, Version)
-
-    result = driver.supports_multi_db()
-    driver.close()
-
-    if server_info.protocol_version == Bolt3.PROTOCOL_VERSION:
-        assert result is False
-        assert summary.database is None
-        assert summary.query_type == "r"
-    else:
-        assert result is True
-        assert server_info.version_info() >= Version(4, 0)
-        assert server_info.protocol_version >= Version(4, 0)
-        assert summary.database == "neo4j"  # This is the default database name if not set explicitly on the Neo4j Server
-        assert summary.query_type == "r"
+    assert neo4j_driver.supports_multi_db()
 
 
 def test_test_multi_db_specify_database(neo4j_uri, auth, target):
@@ -117,225 +84,190 @@ def test_test_multi_db_specify_database(neo4j_uri, auth, target):
         assert error.args[0] == "Unable to get a routing table for database 'test_database' because this database does not exist"
 
 
-def test_neo4j_multi_database_support_create(neo4j_uri, auth, target):
+def test_neo4j_multi_database_support_create(neo4j_uri, auth, target, requires_bolt_4x):
     # python -m pytest tests/integration/test_neo4j_driver.py -s -v -k test_neo4j_multi_database_support_create
-    try:
-        with GraphDatabase.driver(neo4j_uri, auth=auth) as driver:
-            with driver.session(database="system") as session:
-                session.run("DROP DATABASE test IF EXISTS").consume()
-                result = session.run("SHOW DATABASES")
-                databases = set()
-                for record in result:
-                    databases.add(record.get("name"))
-                assert "system" in databases
-                assert "neo4j" in databases
+    with GraphDatabase.driver(neo4j_uri, auth=auth) as driver:
+        with driver.session(database="system") as session:
+            session.run("DROP DATABASE test IF EXISTS").consume()
+            result = session.run("SHOW DATABASES")
+            databases = set()
+            for record in result:
+                databases.add(record.get("name"))
+            assert "system" in databases
+            assert "neo4j" in databases
 
-                session.run("CREATE DATABASE test").consume()
-                result = session.run("SHOW DATABASES")
-                for record in result:
-                    databases.add(record.get("name"))
-                assert "system" in databases
-                assert "neo4j" in databases
-                assert "test" in databases
-            with driver.session(database="system") as session:
-                session.run("DROP DATABASE test IF EXISTS").consume()
-    except ServiceUnavailable as error:
-        if error.args[0] == "Server does not support routing":
-            # This is because a single instance Neo4j 3.5 does not have dbms.routing.cluster.getRoutingTable() call
-            pytest.skip(error.args[0])
-        elif isinstance(error.__cause__, BoltHandshakeError):
-            pytest.skip(error.args[0])
+            session.run("CREATE DATABASE test").consume()
+            result = session.run("SHOW DATABASES")
+            for record in result:
+                databases.add(record.get("name"))
+            assert "system" in databases
+            assert "neo4j" in databases
+            assert "test" in databases
+        with driver.session(database="system") as session:
+            session.run("DROP DATABASE test IF EXISTS").consume()
 
 
-def test_neo4j_multi_database_support_different(neo4j_uri, auth, target):
+def test_neo4j_multi_database_support_different(neo4j_uri, auth, target, requires_bolt_4x):
     # python -m pytest tests/integration/test_neo4j_driver.py -s -v -k test_neo4j_multi_database_support_different
-    try:
-        with GraphDatabase.driver(neo4j_uri, auth=auth) as driver:
-            with driver.session() as session:
-                # Test that default database is empty
-                session.run("MATCH (n) DETACH DELETE n").consume()
-                result = session.run("MATCH (p:Person) RETURN p")
-                names = set()
-                for ix in result:
-                    names.add(ix["p"].get("name"))
-                assert names == set()  # THIS FAILS?
-            with driver.session(database="system") as session:
-                session.run("DROP DATABASE testa IF EXISTS").consume()
-                session.run("DROP DATABASE testb IF EXISTS").consume()
-            with driver.session(database="system") as session:
-                result = session.run("SHOW DATABASES")
-                databases = set()
-                for record in result:
-                    databases.add(record.get("name"))
-                assert databases == {"system", "neo4j"}
-                result = session.run("CREATE DATABASE testa")
-                result.consume()
-                result = session.run("CREATE DATABASE testb")
-                result.consume()
-            with driver.session(database="testa") as session:
-                result = session.run('CREATE (p:Person {name: "ALICE"})')
-                result.consume()
-            with driver.session(database="testb") as session:
-                result = session.run('CREATE (p:Person {name: "BOB"})')
-                result.consume()
-            with driver.session() as session:
-                # Test that default database is still empty
-                result = session.run("MATCH (p:Person) RETURN p")
-                names = set()
-                for ix in result:
-                    names.add(ix["p"].get("name"))
-                assert names == set()  # THIS FAILS?
-            with driver.session(database="testa") as session:
-                result = session.run("MATCH (p:Person) RETURN p")
-                names = set()
-                for ix in result:
-                    names.add(ix["p"].get("name"))
-                assert names == {"ALICE", }
-            with driver.session(database="testb") as session:
-                result = session.run("MATCH (p:Person) RETURN p")
-                names = set()
-                for ix in result:
-                    names.add(ix["p"].get("name"))
-                assert names == {"BOB", }
-            with driver.session(database="system") as session:
-                session.run("DROP DATABASE testa IF EXISTS").consume()
-            with driver.session(database="system") as session:
-                session.run("DROP DATABASE testb IF EXISTS").consume()
-            with driver.session() as session:
-                session.run("MATCH (n) DETACH DELETE n").consume()
-    except ServiceUnavailable as error:
-        if error.args[0] == "Server does not support routing":
-            # This is because a single instance Neo4j 3.5 does not have dbms.routing.cluster.getRoutingTable() call
-            pytest.skip(error.args[0])
-        elif isinstance(error.__cause__, BoltHandshakeError):
-            pytest.skip(error.args[0])
+    with GraphDatabase.driver(neo4j_uri, auth=auth) as driver:
+        with driver.session() as session:
+            # Test that default database is empty
+            session.run("MATCH (n) DETACH DELETE n").consume()
+            result = session.run("MATCH (p:Person) RETURN p")
+            names = set()
+            for ix in result:
+                names.add(ix["p"].get("name"))
+            assert names == set()  # THIS FAILS?
+        with driver.session(database="system") as session:
+            session.run("DROP DATABASE testa IF EXISTS").consume()
+            session.run("DROP DATABASE testb IF EXISTS").consume()
+        with driver.session(database="system") as session:
+            result = session.run("SHOW DATABASES")
+            databases = set()
+            for record in result:
+                databases.add(record.get("name"))
+            assert databases == {"system", "neo4j"}
+            result = session.run("CREATE DATABASE testa")
+            result.consume()
+            result = session.run("CREATE DATABASE testb")
+            result.consume()
+        with driver.session(database="testa") as session:
+            result = session.run('CREATE (p:Person {name: "ALICE"})')
+            result.consume()
+        with driver.session(database="testb") as session:
+            result = session.run('CREATE (p:Person {name: "BOB"})')
+            result.consume()
+        with driver.session() as session:
+            # Test that default database is still empty
+            result = session.run("MATCH (p:Person) RETURN p")
+            names = set()
+            for ix in result:
+                names.add(ix["p"].get("name"))
+            assert names == set()  # THIS FAILS?
+        with driver.session(database="testa") as session:
+            result = session.run("MATCH (p:Person) RETURN p")
+            names = set()
+            for ix in result:
+                names.add(ix["p"].get("name"))
+            assert names == {"ALICE", }
+        with driver.session(database="testb") as session:
+            result = session.run("MATCH (p:Person) RETURN p")
+            names = set()
+            for ix in result:
+                names.add(ix["p"].get("name"))
+            assert names == {"BOB", }
+        with driver.session(database="system") as session:
+            session.run("DROP DATABASE testa IF EXISTS").consume()
+        with driver.session(database="system") as session:
+            session.run("DROP DATABASE testb IF EXISTS").consume()
+        with driver.session() as session:
+            session.run("MATCH (n) DETACH DELETE n").consume()
 
 
-def test_neo4j_multi_database_test_routing_table_creates_new_if_deleted(neo4j_uri, auth, target):
+def test_neo4j_multi_database_test_routing_table_creates_new_if_deleted(neo4j_uri, auth, target, requires_bolt_4x):
     # python -m pytest tests/integration/test_neo4j_driver.py -s -v -k test_neo4j_multi_database_test_routing_table_creates_new_if_deleted
-    try:
-        with GraphDatabase.driver(neo4j_uri, auth=auth) as driver:
-            with driver.session(database="system") as session:
-                result = session.run("DROP DATABASE test IF EXISTS")
-                result.consume()
-                result = session.run("SHOW DATABASES")
-                databases = set()
-                for record in result:
-                    databases.add(record.get("name"))
-                assert databases == {"system", "neo4j"}
+    with GraphDatabase.driver(neo4j_uri, auth=auth) as driver:
+        with driver.session(database="system") as session:
+            result = session.run("DROP DATABASE test IF EXISTS")
+            result.consume()
+            result = session.run("SHOW DATABASES")
+            databases = set()
+            for record in result:
+                databases.add(record.get("name"))
+            assert databases == {"system", "neo4j"}
 
-                result = session.run("CREATE DATABASE test")
-                result.consume()
-                result = session.run("SHOW DATABASES")
-                for record in result:
-                    databases.add(record.get("name"))
-                assert databases == {"system", "neo4j", "test"}
-            with driver.session(database="test") as session:
-                result = session.run("RETURN 1 AS x")
-                result.consume()
-            del driver._pool.routing_tables["test"]
-            with driver.session(database="test") as session:
-                result = session.run("RETURN 1 AS x")
-                result.consume()
-            with driver.session(database="system") as session:
-                result = session.run("DROP DATABASE test IF EXISTS")
-                result.consume()
-    except ServiceUnavailable as error:
-        if error.args[0] == "Server does not support routing":
-            # This is because a single instance Neo4j 3.5 does not have dbms.routing.cluster.getRoutingTable() call
-            pytest.skip(error.args[0])
-        elif isinstance(error.__cause__, BoltHandshakeError):
-            pytest.skip(error.args[0])
+            result = session.run("CREATE DATABASE test")
+            result.consume()
+            result = session.run("SHOW DATABASES")
+            for record in result:
+                databases.add(record.get("name"))
+            assert databases == {"system", "neo4j", "test"}
+        with driver.session(database="test") as session:
+            result = session.run("RETURN 1 AS x")
+            result.consume()
+        del driver._pool.routing_tables["test"]
+        with driver.session(database="test") as session:
+            result = session.run("RETURN 1 AS x")
+            result.consume()
+        with driver.session(database="system") as session:
+            result = session.run("DROP DATABASE test IF EXISTS")
+            result.consume()
 
 
-def test_neo4j_multi_database_test_routing_table_updates_if_stale(neo4j_uri, auth, target):
+def test_neo4j_multi_database_test_routing_table_updates_if_stale(neo4j_uri, auth, target, requires_bolt_4x):
     # python -m pytest tests/integration/test_neo4j_driver.py -s -v -k test_neo4j_multi_database_test_routing_table_updates_if_stale
-    try:
-        with GraphDatabase.driver(neo4j_uri, auth=auth) as driver:
-            with driver.session(database="system") as session:
-                result = session.run("DROP DATABASE test IF EXISTS")
-                result.consume()
-                result = session.run("SHOW DATABASES")
-                databases = set()
-                for record in result:
-                    databases.add(record.get("name"))
-                assert databases == {"system", "neo4j"}
+    with GraphDatabase.driver(neo4j_uri, auth=auth) as driver:
+        with driver.session(database="system") as session:
+            result = session.run("DROP DATABASE test IF EXISTS")
+            result.consume()
+            result = session.run("SHOW DATABASES")
+            databases = set()
+            for record in result:
+                databases.add(record.get("name"))
+            assert databases == {"system", "neo4j"}
 
-                result = session.run("CREATE DATABASE test")
-                result.consume()
-                result = session.run("SHOW DATABASES")
-                for record in result:
-                    databases.add(record.get("name"))
-                assert databases == {"system", "neo4j", "test"}
-            with driver.session(database="test") as session:
-                result = session.run("RETURN 1 AS x")
-                result.consume()
-            driver._pool.routing_tables["test"].ttl = 0
-            old_value = driver._pool.routing_tables["test"].last_updated_time
-            with driver.session(database="test") as session:
-                result = session.run("RETURN 1 AS x")
-                result.consume()
-            with driver.session(database="system") as session:
-                result = session.run("DROP DATABASE test IF EXISTS")
-                result.consume()
-            assert driver._pool.routing_tables["test"].last_updated_time > old_value
-    except ServiceUnavailable as error:
-        if error.args[0] == "Server does not support routing":
-            # This is because a single instance Neo4j 3.5 does not have dbms.routing.cluster.getRoutingTable() call
-            pytest.skip(error.args[0])
-        elif isinstance(error.__cause__, BoltHandshakeError):
-            pytest.skip(error.args[0])
+            result = session.run("CREATE DATABASE test")
+            result.consume()
+            result = session.run("SHOW DATABASES")
+            for record in result:
+                databases.add(record.get("name"))
+            assert databases == {"system", "neo4j", "test"}
+        with driver.session(database="test") as session:
+            result = session.run("RETURN 1 AS x")
+            result.consume()
+        driver._pool.routing_tables["test"].ttl = 0
+        old_value = driver._pool.routing_tables["test"].last_updated_time
+        with driver.session(database="test") as session:
+            result = session.run("RETURN 1 AS x")
+            result.consume()
+        with driver.session(database="system") as session:
+            result = session.run("DROP DATABASE test IF EXISTS")
+            result.consume()
+        assert driver._pool.routing_tables["test"].last_updated_time > old_value
 
 
-def test_neo4j_multi_database_test_routing_table_removes_aged(neo4j_uri, auth, target):
+def test_neo4j_multi_database_test_routing_table_removes_aged(neo4j_uri, auth, target, requires_bolt_4x):
     # python -m pytest tests/integration/test_neo4j_driver.py -s -v -k test_neo4j_multi_database_test_routing_table_removes_aged
-    try:
-        with GraphDatabase.driver(neo4j_uri, auth=auth) as driver:
-            with driver.session(database="system") as session:
-                result = session.run("DROP DATABASE testa IF EXISTS")
-                result.consume()
-                result = session.run("DROP DATABASE testb IF EXISTS")
-                result.consume()
-                result = session.run("SHOW DATABASES")
-                databases = set()
-                for record in result:
-                    databases.add(record.get("name"))
-                assert databases == {"system", "neo4j"}
+    with GraphDatabase.driver(neo4j_uri, auth=auth) as driver:
+        with driver.session(database="system") as session:
+            result = session.run("DROP DATABASE testa IF EXISTS")
+            result.consume()
+            result = session.run("DROP DATABASE testb IF EXISTS")
+            result.consume()
+            result = session.run("SHOW DATABASES")
+            databases = set()
+            for record in result:
+                databases.add(record.get("name"))
+            assert databases == {"system", "neo4j"}
 
-                result = session.run("CREATE DATABASE testa")
-                result.consume()
-                result = session.run("CREATE DATABASE testb")
-                result.consume()
-                result = session.run("SHOW DATABASES")
-                for record in result:
-                    databases.add(record.get("name"))
-                assert databases == {"system", "neo4j", "testa", "testb"}
-            with driver.session(database="testa") as session:
-                result = session.run("RETURN 1 AS x")
-                result.consume()
-            with driver.session(database="testb") as session:
-                result = session.run("RETURN 1 AS x")
-                result.consume()
-            driver._pool.routing_tables["testa"].ttl = 0
-            driver._pool.routing_tables["testb"].ttl = -1 * RoutingConfig.routing_table_purge_delay
-            old_value = driver._pool.routing_tables["testa"].last_updated_time
-            with driver.session(database="testa") as session:
-                # This will refresh the routing table for "testa" and the refresh will trigger a cleanup of aged routing tables
-                result = session.run("RETURN 1 AS x")
-                result.consume()
-            with driver.session(database="system") as session:
-                result = session.run("DROP DATABASE testa IF EXISTS")
-                result.consume()
-                result = session.run("DROP DATABASE testb IF EXISTS")
-                result.consume()
-            assert driver._pool.routing_tables["testa"].last_updated_time > old_value
-            assert "testb" not in driver._pool.routing_tables
-    except ServiceUnavailable as error:
-        if error.args[0] == "Server does not support routing":
-            # This is because a single instance Neo4j 3.5 does not have dbms.routing.cluster.getRoutingTable() call
-            pytest.skip(error.args[0])
-        elif isinstance(error.__cause__, BoltHandshakeError):
-            pytest.skip(error.args[0])
+            result = session.run("CREATE DATABASE testa")
+            result.consume()
+            result = session.run("CREATE DATABASE testb")
+            result.consume()
+            result = session.run("SHOW DATABASES")
+            for record in result:
+                databases.add(record.get("name"))
+            assert databases == {"system", "neo4j", "testa", "testb"}
+        with driver.session(database="testa") as session:
+            result = session.run("RETURN 1 AS x")
+            result.consume()
+        with driver.session(database="testb") as session:
+            result = session.run("RETURN 1 AS x")
+            result.consume()
+        driver._pool.routing_tables["testa"].ttl = 0
+        driver._pool.routing_tables["testb"].ttl = -1 * RoutingConfig.routing_table_purge_delay
+        old_value = driver._pool.routing_tables["testa"].last_updated_time
+        with driver.session(database="testa") as session:
+            # This will refresh the routing table for "testa" and the refresh will trigger a cleanup of aged routing tables
+            result = session.run("RETURN 1 AS x")
+            result.consume()
+        with driver.session(database="system") as session:
+            result = session.run("DROP DATABASE testa IF EXISTS")
+            result.consume()
+            result = session.run("DROP DATABASE testb IF EXISTS")
+            result.consume()
+        assert driver._pool.routing_tables["testa"].last_updated_time > old_value
+        assert "testb" not in driver._pool.routing_tables
 
 
 def test_neo4j_driver_fetch_size_config_autocommit_normal_case(neo4j_uri, auth):

--- a/tests/integration/test_summary.py
+++ b/tests/integration/test_summary.py
@@ -136,148 +136,141 @@ def test_summary_counters_case_1(session):
     assert counters.contains_system_updates is False
 
 
-def test_summary_counters_case_2(neo4j_uri, auth, target):
+def test_summary_counters_case_2(neo4j_uri, auth, target, requires_bolt_4x):
     # python -m pytest tests/integration/test_summary.py -s -v -k test_summary_counters_case_2
-    try:
-        with GraphDatabase.driver(neo4j_uri, auth=auth) as driver:
+    with GraphDatabase.driver(neo4j_uri, auth=auth) as driver:
 
-            with driver.session(database="system") as session:
-                session.run("DROP DATABASE test IF EXISTS").consume()
+        with driver.session(database="system") as session:
+            session.run("DROP DATABASE test IF EXISTS").consume()
 
-                # SHOW DATABASES
+            # SHOW DATABASES
 
-                result = session.run("SHOW DATABASES")
-                databases = set()
-                for record in result:
-                    databases.add(record.get("name"))
-                assert "system" in databases
-                assert "neo4j" in databases
+            result = session.run("SHOW DATABASES")
+            databases = set()
+            for record in result:
+                databases.add(record.get("name"))
+            assert "system" in databases
+            assert "neo4j" in databases
 
-                summary = result.consume()
+            summary = result.consume()
 
-                assert summary.query == "SHOW DATABASES"
-                assert summary.parameters == {}
+            assert summary.query == "SHOW DATABASES"
+            assert summary.parameters == {}
 
-                assert isinstance(summary.query_type, str)
+            assert isinstance(summary.query_type, str)
 
-                counters = summary.counters
+            counters = summary.counters
 
-                assert isinstance(counters, SummaryCounters)
-                assert counters.nodes_created == 0
-                assert counters.nodes_deleted == 0
-                assert counters.relationships_created == 0
-                assert counters.relationships_deleted == 0
-                assert counters.properties_set == 0
-                assert counters.labels_added == 0
-                assert counters.labels_removed == 0
-                assert counters.indexes_added == 0
-                assert counters.indexes_removed == 0
-                assert counters.constraints_added == 0
-                assert counters.constraints_removed == 0
-                assert counters.contains_updates is False
+            assert isinstance(counters, SummaryCounters)
+            assert counters.nodes_created == 0
+            assert counters.nodes_deleted == 0
+            assert counters.relationships_created == 0
+            assert counters.relationships_deleted == 0
+            assert counters.properties_set == 0
+            assert counters.labels_added == 0
+            assert counters.labels_removed == 0
+            assert counters.indexes_added == 0
+            assert counters.indexes_removed == 0
+            assert counters.constraints_added == 0
+            assert counters.constraints_removed == 0
+            assert counters.contains_updates is False
 
-                assert counters.system_updates == 0
-                assert counters.contains_system_updates is False
+            assert counters.system_updates == 0
+            assert counters.contains_system_updates is False
 
-                # CREATE DATABASE test
+            # CREATE DATABASE test
 
-                summary = session.run("CREATE DATABASE test").consume()
+            summary = session.run("CREATE DATABASE test").consume()
 
-                assert summary.query == "CREATE DATABASE test"
-                assert summary.parameters == {}
+            assert summary.query == "CREATE DATABASE test"
+            assert summary.parameters == {}
 
-                assert isinstance(summary.query_type, str)
+            assert isinstance(summary.query_type, str)
 
-                counters = summary.counters
+            counters = summary.counters
 
-                assert isinstance(counters, SummaryCounters)
-                assert counters.nodes_created == 0
-                assert counters.nodes_deleted == 0
-                assert counters.relationships_created == 0
-                assert counters.relationships_deleted == 0
-                assert counters.properties_set == 0
-                assert counters.labels_added == 0
-                assert counters.labels_removed == 0
-                assert counters.indexes_added == 0
-                assert counters.indexes_removed == 0
-                assert counters.constraints_added == 0
-                assert counters.constraints_removed == 0
-                assert counters.contains_updates is False
+            assert isinstance(counters, SummaryCounters)
+            assert counters.nodes_created == 0
+            assert counters.nodes_deleted == 0
+            assert counters.relationships_created == 0
+            assert counters.relationships_deleted == 0
+            assert counters.properties_set == 0
+            assert counters.labels_added == 0
+            assert counters.labels_removed == 0
+            assert counters.indexes_added == 0
+            assert counters.indexes_removed == 0
+            assert counters.constraints_added == 0
+            assert counters.constraints_removed == 0
+            assert counters.contains_updates is False
 
-                assert counters.system_updates == 1
-                assert counters.contains_system_updates is True
+            assert counters.system_updates == 1
+            assert counters.contains_system_updates is True
 
-            with driver.session(database="test") as session:
-                summary = session.run("CREATE (n)").consume()
-                assert summary.counters.contains_updates is True
-                assert summary.counters.contains_system_updates is False
-                assert summary.counters.nodes_created == 1
+        with driver.session(database="test") as session:
+            summary = session.run("CREATE (n)").consume()
+            assert summary.counters.contains_updates is True
+            assert summary.counters.contains_system_updates is False
+            assert summary.counters.nodes_created == 1
 
-            with driver.session(database="test") as session:
-                summary = session.run("MATCH (n) DELETE (n)").consume()
-                assert summary.counters.contains_updates is True
-                assert summary.counters.contains_system_updates is False
-                assert summary.counters.nodes_deleted == 1
+        with driver.session(database="test") as session:
+            summary = session.run("MATCH (n) DELETE (n)").consume()
+            assert summary.counters.contains_updates is True
+            assert summary.counters.contains_system_updates is False
+            assert summary.counters.nodes_deleted == 1
 
-            with driver.session(database="test") as session:
-                summary = session.run("CREATE ()-[:KNOWS]->()").consume()
-                assert summary.counters.contains_updates is True
-                assert summary.counters.contains_system_updates is False
-                assert summary.counters.relationships_created == 1
+        with driver.session(database="test") as session:
+            summary = session.run("CREATE ()-[:KNOWS]->()").consume()
+            assert summary.counters.contains_updates is True
+            assert summary.counters.contains_system_updates is False
+            assert summary.counters.relationships_created == 1
 
-            with driver.session(database="test") as session:
-                summary = session.run("MATCH ()-[r:KNOWS]->() DELETE r").consume()
-                assert summary.counters.contains_updates is True
-                assert summary.counters.contains_system_updates is False
-                assert summary.counters.relationships_deleted == 1
+        with driver.session(database="test") as session:
+            summary = session.run("MATCH ()-[r:KNOWS]->() DELETE r").consume()
+            assert summary.counters.contains_updates is True
+            assert summary.counters.contains_system_updates is False
+            assert summary.counters.relationships_deleted == 1
 
-            with driver.session(database="test") as session:
-                summary = session.run("CREATE (n:ALabel)").consume()
-                assert summary.counters.contains_updates is True
-                assert summary.counters.contains_system_updates is False
-                assert summary.counters.labels_added == 1
+        with driver.session(database="test") as session:
+            summary = session.run("CREATE (n:ALabel)").consume()
+            assert summary.counters.contains_updates is True
+            assert summary.counters.contains_system_updates is False
+            assert summary.counters.labels_added == 1
 
-            with driver.session(database="test") as session:
-                summary = session.run("MATCH (n:ALabel) REMOVE n:ALabel").consume()
-                assert summary.counters.contains_updates is True
-                assert summary.counters.contains_system_updates is False
-                assert summary.counters.labels_removed == 1
+        with driver.session(database="test") as session:
+            summary = session.run("MATCH (n:ALabel) REMOVE n:ALabel").consume()
+            assert summary.counters.contains_updates is True
+            assert summary.counters.contains_system_updates is False
+            assert summary.counters.labels_removed == 1
 
-            with driver.session(database="test") as session:
-                summary = session.run("CREATE (n {magic: 42})").consume()
-                assert summary.counters.contains_updates is True
-                assert summary.counters.contains_system_updates is False
-                assert summary.counters.properties_set == 1
+        with driver.session(database="test") as session:
+            summary = session.run("CREATE (n {magic: 42})").consume()
+            assert summary.counters.contains_updates is True
+            assert summary.counters.contains_system_updates is False
+            assert summary.counters.properties_set == 1
 
-            with driver.session(database="test") as session:
-                summary = session.run("CREATE INDEX ON :ALabel(prop)").consume()
-                assert summary.counters.contains_updates is True
-                assert summary.counters.contains_system_updates is False
-                assert summary.counters.indexes_added == 1
+        with driver.session(database="test") as session:
+            summary = session.run("CREATE INDEX ON :ALabel(prop)").consume()
+            assert summary.counters.contains_updates is True
+            assert summary.counters.contains_system_updates is False
+            assert summary.counters.indexes_added == 1
 
-            with driver.session(database="test") as session:
-                summary = session.run("DROP INDEX ON :ALabel(prop)").consume()
-                assert summary.counters.contains_updates is True
-                assert summary.counters.contains_system_updates is False
-                assert summary.counters.indexes_removed == 1
+        with driver.session(database="test") as session:
+            summary = session.run("DROP INDEX ON :ALabel(prop)").consume()
+            assert summary.counters.contains_updates is True
+            assert summary.counters.contains_system_updates is False
+            assert summary.counters.indexes_removed == 1
 
-            with driver.session(database="test") as session:
-                summary = session.run("CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE").consume()
-                assert summary.counters.contains_updates is True
-                assert summary.counters.contains_system_updates is False
-                assert summary.counters.constraints_added == 1
+        with driver.session(database="test") as session:
+            summary = session.run("CREATE CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE").consume()
+            assert summary.counters.contains_updates is True
+            assert summary.counters.contains_system_updates is False
+            assert summary.counters.constraints_added == 1
 
-            with driver.session(database="test") as session:
-                summary = session.run("DROP CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE").consume()
-                assert summary.counters.contains_updates is True
-                assert summary.counters.contains_system_updates is False
-                assert summary.counters.constraints_removed == 1
+        with driver.session(database="test") as session:
+            summary = session.run("DROP CONSTRAINT ON (book:Book) ASSERT book.isbn IS UNIQUE").consume()
+            assert summary.counters.contains_updates is True
+            assert summary.counters.contains_system_updates is False
+            assert summary.counters.constraints_removed == 1
 
-            with driver.session(database="system") as session:
-                session.run("DROP DATABASE test IF EXISTS").consume()
-    except ServiceUnavailable as error:
-        if error.args[0] == "Server does not support routing":
-            # This is because a single instance Neo4j 3.5 does not have dbms.routing.cluster.getRoutingTable() call
-            pytest.skip(error.args[0])
-        elif isinstance(error.__cause__, BoltHandshakeError):
-            pytest.skip(error.args[0])
+        with driver.session(database="system") as session:
+            session.run("DROP DATABASE test IF EXISTS").consume()

--- a/tests/stub/test_directdriver.py
+++ b/tests/stub/test_directdriver.py
@@ -139,6 +139,7 @@ def test_direct_driver_with_wrong_port(driver_info):
     uri = "bolt://127.0.0.1:9002"
     with pytest.raises(ServiceUnavailable):
         driver = GraphDatabase.driver(uri, auth=driver_info["auth_token"], **driver_config)
+        driver.verify_connectivity()
 
 
 @pytest.mark.parametrize(

--- a/tests/stub/test_routingdriver.py
+++ b/tests/stub/test_routingdriver.py
@@ -199,8 +199,9 @@ def test_cannot_discover_servers_on_non_router(driver_info, test_script):
     # python -m pytest tests/stub/test_routingdriver.py -s -v -k test_cannot_discover_servers_on_non_router
     with StubCluster(test_script):
         with pytest.raises(ServiceUnavailable):
-            with GraphDatabase.driver(driver_info["uri_neo4j"], auth=driver_info["auth_token"]):
-                pass
+            with GraphDatabase.driver(driver_info["uri_neo4j"], auth=driver_info["auth_token"]) as driver:
+                assert isinstance(driver, Neo4jDriver)
+                driver.update_routing_table()
 
 
 @pytest.mark.parametrize(
@@ -214,8 +215,9 @@ def test_cannot_discover_servers_on_silent_router(driver_info, test_script):
     # python -m pytest tests/stub/test_routingdriver.py -s -v -k test_cannot_discover_servers_on_silent_router
     with StubCluster(test_script):
         with pytest.raises(BoltRoutingError):
-            with GraphDatabase.driver(driver_info["uri_neo4j"], auth=driver_info["auth_token"]):
-                pass
+            with GraphDatabase.driver(driver_info["uri_neo4j"], auth=driver_info["auth_token"]) as driver:
+                assert isinstance(driver, Neo4jDriver)
+                driver.update_routing_table()
 
 
 @pytest.mark.parametrize(
@@ -229,6 +231,8 @@ def test_should_discover_servers_on_driver_construction(driver_info, test_script
     # python -m pytest tests/stub/test_routingdriver.py -s -v -k test_should_discover_servers_on_driver_construction
     with StubCluster(test_script):
         with GraphDatabase.driver(driver_info["uri_neo4j"], auth=driver_info["auth_token"]) as driver:
+            assert isinstance(driver, Neo4jDriver)
+            driver.update_routing_table()
             table = driver._pool.routing_tables[DEFAULT_DATABASE]
             assert table.routers == {('127.0.0.1', 9001), ('127.0.0.1', 9002),
                                      ('127.0.0.1', 9003)}
@@ -529,7 +533,9 @@ def test_should_error_when_missing_reader(driver_info, test_script):
     # python -m pytest tests/stub/test_routingdriver.py -s -v -k test_should_error_when_missing_reader
     with StubCluster(test_script):
         with pytest.raises(BoltRoutingError):
-            GraphDatabase.driver(driver_info["uri_neo4j"], auth=driver_info["auth_token"])
+            with GraphDatabase.driver(driver_info["uri_neo4j"], auth=driver_info["auth_token"]) as driver:
+                assert isinstance(driver, Neo4jDriver)
+                driver.update_routing_table()
 
 
 @pytest.mark.parametrize(
@@ -595,6 +601,8 @@ def test_forgets_address_on_service_unavailable_error(driver_info, test_scripts,
     # python -m pytest tests/stub/test_routingdriver.py -s -v -k test_forgets_address_on_service_unavailable_error
     with StubCluster(*test_scripts):
         with GraphDatabase.driver(driver_info["uri_neo4j"], auth=driver_info["auth_token"]) as driver:
+            assert isinstance(driver, Neo4jDriver)
+            driver.update_routing_table()
             with driver.session(default_access_mode=READ_ACCESS, fetch_size=-1) as session:
 
                 pool = driver._pool
@@ -629,6 +637,8 @@ def test_forgets_address_on_database_unavailable_error(driver_info, test_scripts
     # python -m pytest tests/stub/test_routingdriver.py -s -v -k test_forgets_address_on_database_unavailable_error
     with StubCluster(*test_scripts):
         with GraphDatabase.driver(driver_info["uri_neo4j"], auth=driver_info["auth_token"]) as driver:
+            assert isinstance(driver, Neo4jDriver)
+            driver.update_routing_table()
             with driver.session(default_access_mode=READ_ACCESS, fetch_size=-1) as session:
 
                 pool = driver._pool


### PR DESCRIPTION
Since driver is typically created at application startup a failure to
connect to a server or cluster that is temporarly down would cause the
application to not start either. Clients should use verify connection to
check for proper configuration.