### PR TITLE
Fix documentation on timeouts

### DIFF
--- a/docs/source/usage_patterns.rst
+++ b/docs/source/usage_patterns.rst
@@ -199,7 +199,7 @@ unit_of_work
     from neo4j import unit_of_work
 
 
-    @unit_of_work(timeout=10)
+    @unit_of_work(timeout=10)  # don't wait longer than 10 seconds for a result
     def test_work(tx, *args, **kwargs):
         query = "RETURN $tag AS $name"
 

--- a/neo4j/work/simple.py
+++ b/neo4j/work/simple.py
@@ -263,7 +263,7 @@ class Session(Workspace):
         :type metadata: dict
 
         :param timeout:
-            the transaction timeout in milliseconds.
+            the transaction timeout in seconds.
             Transactions that execute longer than the configured timeout will be terminated by the database.
             This functionality allows to limit query/transaction execution time.
             Specified timeout overrides the default timeout configured in the database using ``dbms.transaction.timeout`` setting.
@@ -442,7 +442,7 @@ def unit_of_work(metadata=None, timeout=None):
     :type metadata: dict
 
     :param timeout:
-        the transaction timeout in milliseconds.
+        the transaction timeout in seconds.
         Transactions that execute longer than the configured timeout will be terminated by the database.
         This functionality allows to limit query/transaction execution time.
         Specified timeout overrides the default timeout configured in the database using ``dbms.transaction.timeout`` setting.


### PR DESCRIPTION
Timeouts in the python driver are, as opposed to other drivers, specified in seconds.