### PR TITLE
Testkit compliance

### DIFF
--- a/neo4j/io/_bolt3.py
+++ b/neo4j/io/_bolt3.py
@@ -45,9 +45,9 @@ from neo4j.exceptions import (
     SessionExpired,
 )
 from neo4j.io import (
-    check_supported_server_product,
     Bolt,
     BoltPool,
+    check_supported_server_product,
 )
 from neo4j.io._common import (
     CommitResponse,
@@ -61,6 +61,7 @@ from neo4j.packstream import (
     Packer,
     Unpacker,
 )
+
 
 log = getLogger("neo4j")
 

--- a/neo4j/io/_bolt4.py
+++ b/neo4j/io/_bolt4.py
@@ -62,6 +62,7 @@ from neo4j.packstream import (
     Packer,
 )
 
+
 log = getLogger("neo4j")
 
 

--- a/neo4j/work/result.py
+++ b/neo4j/work/result.py
@@ -47,7 +47,6 @@ class _ConnectionErrorHandler:
             connection raises of of the caught errors. The callback takes the
             error as argument.
         :type on_network_error callable
-
         """
         self._connection = connection
         self._on_network_error = on_network_error

--- a/testkitbackend/backend.py
+++ b/testkitbackend/backend.py
@@ -152,10 +152,10 @@ class Backend:
             if isinstance(e, Neo4jError):
                 payload["code"] = e.code
             self.send_response("DriverError", payload)
-        except Exception as e:
-            traceback.print_exception(type(e), e, e.__traceback__)
-            self.send_response("BackendError",
-                               {"msg": "%s: %s" % (type(e), e)})
+        except Exception:
+            tb = traceback.format_exc()
+            log.error(tb)
+            self.send_response("BackendError", {"msg": tb})
 
     def send_response(self, name, data):
         """ Sends a response to backend.

--- a/testkitbackend/requests.py
+++ b/testkitbackend/requests.py
@@ -133,9 +133,7 @@ def NewSession(backend, data):
             "default_access_mode": access_mode,
             "bookmarks": data["bookmarks"],
             "database": data["database"],
-            "fetch_size": data.get("fetchSize", None),
-            # testkit breaks up connection after 10 seconds
-            "max_transaction_retry_time": 5,
+            "fetch_size": data.get("fetchSize", None)
     }
     session = driver.session(**config)
     key = backend.next_key()

--- a/testkitbackend/requests.py
+++ b/testkitbackend/requests.py
@@ -133,7 +133,9 @@ def NewSession(backend, data):
             "default_access_mode": access_mode,
             "bookmarks": data["bookmarks"],
             "database": data["database"],
-            "fetch_size": data.get("fetchSize", None)
+            "fetch_size": data.get("fetchSize", None),
+            # testkit breaks up connection after 10 seconds
+            "max_transaction_retry_time": 5,
     }
     session = driver.session(**config)
     key = backend.next_key()

--- a/testkitbackend/skipped_tests.json
+++ b/testkitbackend/skipped_tests.json
@@ -1,1 +1,68 @@
-{}
+{
+  "stub.retry.TestRetryClustering.test_retry_ForbiddenOnReadOnlyDatabase_ChangingWriter":
+    "Closes connection to router after ROUTE",
+  "stub.routing.Routing.test_should_use_resolver_during_rediscovery_when_existing_routers_fail":
+    "DNS resolver not implemented",
+  "stub.routing.RoutingV3.test_should_use_resolver_during_rediscovery_when_existing_routers_fail":
+    "DNS resolver not implemented",
+  "stub.routing.RoutingV4.test_should_use_resolver_during_rediscovery_when_existing_routers_fail":
+    "DNS resolver not implemented",
+  "stub.routing.NoRouting.test_should_use_resolver_during_rediscovery_when_existing_routers_fail":
+    "DNS resolver not implemented",
+  "stub.routing.Routing.test_should_request_rt_from_all_initial_routers_until_successful":
+    "DNS resolver not implemented",
+  "stub.routing.RoutingV3.test_should_request_rt_from_all_initial_routers_until_successful":
+    "DNS resolver not implemented",
+  "stub.routing.RoutingV4.test_should_request_rt_from_all_initial_routers_until_successful":
+    "DNS resolver not implemented",
+  "stub.routing.NoRouting.test_should_request_rt_from_all_initial_routers_until_successful":
+    "DNS resolver not implemented",
+  "stub.routing.Routing.test_should_successfully_acquire_rt_when_router_ip_changes":
+    "DNS resolver not implemented",
+  "stub.routing.RoutingV3.test_should_successfully_acquire_rt_when_router_ip_changes":
+    "DNS resolver not implemented",
+  "stub.routing.RoutingV4.test_should_successfully_acquire_rt_when_router_ip_changes":
+    "DNS resolver not implemented",
+  "stub.routing.NoRouting.test_should_successfully_acquire_rt_when_router_ip_changes":
+    "DNS resolver not implemented",
+  "stub.routing.Routing.test_should_read_successfully_on_empty_discovery_result_using_session_run":
+    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
+  "stub.routing.RoutingV3.test_should_read_successfully_on_empty_discovery_result_using_session_run":
+    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
+  "stub.routing.RoutingV4.test_should_read_successfully_on_empty_discovery_result_using_session_run":
+    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
+  "stub.routing.NoRouting.test_should_read_successfully_on_empty_discovery_result_using_session_run":
+    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
+  "stub.routing.Routing.test_should_retry_read_tx_and_rediscovery_until_success":
+    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
+  "stub.routing.RoutingV3.test_should_retry_read_tx_and_rediscovery_until_success":
+    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
+  "stub.routing.RoutingV4.test_should_retry_read_tx_and_rediscovery_until_success":
+    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
+  "stub.routing.NoRouting.test_should_retry_read_tx_and_rediscovery_until_success":
+    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
+  "stub.routing.Routing.test_should_retry_write_until_success_with_leader_change_using_tx_function":
+    "Driver opens a new connection each time to get a fresh routing table",
+  "stub.routing.RoutingV3.test_should_retry_write_until_success_with_leader_change_using_tx_function":
+    "Driver opens a new connection each time to get a fresh routing table",
+  "stub.routing.RoutingV4.test_should_retry_write_until_success_with_leader_change_using_tx_function":
+    "Driver opens a new connection each time to get a fresh routing table",
+  "stub.routing.NoRouting.test_should_retry_write_until_success_with_leader_change_using_tx_function":
+    "Driver opens a new connection each time to get a fresh routing table",
+  "stub.routing.Routing.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function":
+    "Driver opens a new connection each time to get a fresh routing table",
+  "stub.routing.RoutingV3.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function":
+    "Driver opens a new connection each time to get a fresh routing table",
+  "stub.routing.RoutingV4.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function":
+    "Driver opens a new connection each time to get a fresh routing table",
+  "stub.routing.NoRouting.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function":
+    "Driver opens a new connection each time to get a fresh routing table",
+  "stub.routing.Routing.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors":
+    "Driver uses custom resolver for each connection, not only initial seeding",
+  "stub.routing.RoutingV3.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors":
+    "Driver uses custom resolver for each connection, not only initial seeding",
+  "stub.routing.RoutingV4.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors":
+    "Driver uses custom resolver for each connection, not only initial seeding",
+  "stub.routing.NoRouting.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors":
+    "Driver uses custom resolver for each connection, not only initial seeding"
+}


### PR DESCRIPTION
Adding and adjusting testkit back end to
 * Skip tests.
 * Reduce the time the driver attempts retries.
   Testkit will cut the connection to the driver back end if the driver takes too long (10 seconds) to respond. In a controlled environment like testkit, there shouldn't be a need for very long retry periods anyway.
 * Send a traceback with errors so it's easier to debug failed tests.