### PR TITLE
Don't handle raw socket after it's wrapped in connection

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -85,6 +85,7 @@ from neo4j.exceptions import (
 )
 from neo4j.routing import RoutingTable
 
+
 # Set up logger
 log = getLogger("neo4j")
 
@@ -247,9 +248,8 @@ class Bolt:
 
         try:
             connection.hello()
-        except Exception as error:
-            log.debug("[#%04X]  C: <CLOSE> %s", s.getsockname()[1], str(error))
-            _close_socket(s)
+        except Exception:
+            connection.close()
             raise
 
         return connection


### PR DESCRIPTION
When the connection to the server is lost during or right after sending `HELLO`, the driver will attempt to get the address from a closed socket which causes an `OSError`. There is no need to handle the raw socket after a successful handshake anyway as it will be wrapped in a BOLT connection object that already logs networks errors and takes care of the underlying socket. 