### PR TITLE
Don't try to rollback a closed transaction

### DIFF
--- a/neo4j/work/simple.py
+++ b/neo4j/work/simple.py
@@ -26,11 +26,11 @@ from time import (
     sleep,
 )
 
-from neo4j.conf import SessionConfig
 from neo4j.api import (
     READ_ACCESS,
     WRITE_ACCESS,
 )
+from neo4j.conf import SessionConfig
 from neo4j.data import DataHydrator
 from neo4j.exceptions import (
     ClientError,
@@ -337,7 +337,7 @@ class Session(Workspace):
                 try:
                     result = transaction_function(tx, *args, **kwargs)
                 except Exception:
-                    tx.rollback()
+                    tx.close()
                     raise
                 else:
                     tx.commit()


### PR DESCRIPTION
Let the transaction object decide if a rollback makes sense on a failed transaction. The transaction might have already been closed.

Note that `tx.close()` is a noop on closed transactions.