### PR TITLE
Testkit: send server info with summary

### DIFF
--- a/testkitbackend/requests.py
+++ b/testkitbackend/requests.py
@@ -289,8 +289,14 @@ def ResultNext(backend, data):
 
 def ResultConsume(backend, data):
     result = backend.results[data["resultId"]]
-    result.consume()
-    backend.send_response("Summary", {})
+    summary = result.consume()
+    backend.send_response("Summary", {
+        "serverInfo": {
+            "protocolVersion":
+                ".".join(map(str, summary.server.protocol_version)),
+            "agent": summary.server.agent
+        }
+    })
 
 
 def RetryablePositive(backend, data):

--- a/testkitbackend/skipped_tests.json
+++ b/testkitbackend/skipped_tests.json
@@ -1,6 +1,4 @@
 {
-  "stub.retry.TestRetryClustering.test_retry_ForbiddenOnReadOnlyDatabase_ChangingWriter":
-    "Closes connection to router after ROUTE",
   "stub.routing.Routing.test_should_use_resolver_during_rediscovery_when_existing_routers_fail":
     "DNS resolver not implemented",
   "stub.routing.RoutingV3.test_should_use_resolver_during_rediscovery_when_existing_routers_fail":


### PR DESCRIPTION
Implementing testkit back end functionality for this: https://github.com/neo4j-drivers/testkit/pull/88

Additionally, enable test `stub.retry.TestRetryClustering.test_retry_ForbiddenOnReadOnlyDatabase_ChangingWriter` which was fixed with https://github.com/neo4j/neo4j-python-driver/pull/533.