### PR TITLE
Send RESET when putting a connection back into the pool

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -83,6 +83,7 @@ from neo4j.exceptions import (
     ConfigurationError,
     DriverError,
     IncompleteCommit,
+    Neo4jError,
     ReadServiceUnavailable,
     ServiceUnavailable,
     SessionExpired,
@@ -121,6 +122,9 @@ class Bolt(abc.ABC):
 
     PROTOCOL_VERSION = None
 
+    # flag if connection needs RESET to go back to READY state
+    _is_reset = True
+
     # The socket
     in_use = False
 
@@ -144,7 +148,6 @@ class Bolt(abc.ABC):
         self.responses = deque()
         self._max_connection_lifetime = max_connection_lifetime
         self._creation_timestamp = perf_counter()
-        self._is_reset = True
         self.routing_context = routing_context
 
         # Determine the user agent
@@ -447,6 +450,10 @@ class Bolt(abc.ABC):
         """ Appends a ROLLBACK message to the output queue."""
         pass
 
+    @property
+    def is_reset(self):
+        return self._is_reset
+
     @abc.abstractmethod
     def reset(self):
         """ Appends a RESET message to the outgoing queue, sends it and consumes
@@ -564,23 +571,26 @@ class Bolt(abc.ABC):
     def stale(self):
         return (self._stale
                 or (0 <= self._max_connection_lifetime
-                    <= perf_counter()- self._creation_timestamp))
+                    <= perf_counter() - self._creation_timestamp))
 
     _stale = False
 
     def set_stale(self):
         self._stale = True
 
+    @abc.abstractmethod
     def close(self):
         """ Close the connection.
         """
-        raise NotImplementedError
+        pass
 
+    @abc.abstractmethod
     def closed(self):
-        raise NotImplementedError
+        pass
 
+    @abc.abstractmethod
     def defunct(self):
-        raise NotImplementedError
+        pass
 
 
 class IOPool:
@@ -682,6 +692,13 @@ class IOPool:
         """
         with self.lock:
             for connection in connections:
+                if not connection.is_reset:
+                    try:
+                        connection.reset()
+                    except (Neo4jError, DriverError, BoltError) as e:
+                        log.debug(
+                            "Reset on IOPool.release failed: {}".format(e)
+                        )
                 connection.in_use = False
             self.cond.notify_all()
 

--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -937,7 +937,7 @@ class Neo4jPool(IOPool):
         try:
             new_routing_info = self.fetch_routing_info(address, database,
                                                        bookmarks, timeout)
-        except ServiceUnavailable:
+        except (ServiceUnavailable, SessionExpired):
             new_routing_info = None
         if not new_routing_info:
             log.debug("Failed to fetch routing info %s", address)

--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -697,7 +697,7 @@ class IOPool:
                         connection.reset()
                     except (Neo4jError, DriverError, BoltError) as e:
                         log.debug(
-                            "Reset on IOPool.release failed: {}".format(e)
+                            "Failed to reset connection on release: %s", e
                         )
                 connection.in_use = False
             self.cond.notify_all()

--- a/neo4j/io/_bolt4.py
+++ b/neo4j/io/_bolt4.py
@@ -61,18 +61,6 @@ class Bolt4x0(Bolt):
 
     PROTOCOL_VERSION = Version(4, 0)
 
-    # The socket
-    in_use = False
-
-    # The socket
-    _closed = False
-
-    # The socket
-    _defunct = False
-
-    #: The pool of which this connection is a member
-    pool = None
-
     supports_multiple_results = True
 
     supports_multiple_databases = True

--- a/neo4j/work/transaction.py
+++ b/neo4j/work/transaction.py
@@ -160,7 +160,7 @@ class Transaction:
             raise TransactionError("Transaction closed")
         metadata = {}
         try:
-            if not self._connection._is_reset:
+            if not self._connection.is_reset:
                 # DISCARD pending records then do a rollback.
                 self._consume_results()
                 self._connection.rollback(on_success=metadata.update)

--- a/testkitbackend/skipped_tests.json
+++ b/testkitbackend/skipped_tests.json
@@ -1,68 +1,22 @@
 {
-  "stub.routing.Routing.test_should_use_resolver_during_rediscovery_when_existing_routers_fail":
-    "DNS resolver not implemented",
-  "stub.routing.RoutingV3.test_should_use_resolver_during_rediscovery_when_existing_routers_fail":
-    "DNS resolver not implemented",
-  "stub.routing.RoutingV4.test_should_use_resolver_during_rediscovery_when_existing_routers_fail":
-    "DNS resolver not implemented",
-  "stub.routing.NoRouting.test_should_use_resolver_during_rediscovery_when_existing_routers_fail":
-    "DNS resolver not implemented",
-  "stub.routing.Routing.test_should_request_rt_from_all_initial_routers_until_successful":
-    "DNS resolver not implemented",
-  "stub.routing.RoutingV3.test_should_request_rt_from_all_initial_routers_until_successful":
-    "DNS resolver not implemented",
-  "stub.routing.RoutingV4.test_should_request_rt_from_all_initial_routers_until_successful":
-    "DNS resolver not implemented",
-  "stub.routing.NoRouting.test_should_request_rt_from_all_initial_routers_until_successful":
-    "DNS resolver not implemented",
-  "stub.routing.Routing.test_should_successfully_acquire_rt_when_router_ip_changes":
-    "DNS resolver not implemented",
-  "stub.routing.RoutingV3.test_should_successfully_acquire_rt_when_router_ip_changes":
-    "DNS resolver not implemented",
-  "stub.routing.RoutingV4.test_should_successfully_acquire_rt_when_router_ip_changes":
-    "DNS resolver not implemented",
-  "stub.routing.NoRouting.test_should_successfully_acquire_rt_when_router_ip_changes":
-    "DNS resolver not implemented",
-  "stub.routing.Routing.test_should_read_successfully_on_empty_discovery_result_using_session_run":
-    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
-  "stub.routing.RoutingV3.test_should_read_successfully_on_empty_discovery_result_using_session_run":
-    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
-  "stub.routing.RoutingV4.test_should_read_successfully_on_empty_discovery_result_using_session_run":
-    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
-  "stub.routing.NoRouting.test_should_read_successfully_on_empty_discovery_result_using_session_run":
-    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
-  "stub.routing.Routing.test_should_retry_read_tx_and_rediscovery_until_success":
-    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
-  "stub.routing.RoutingV3.test_should_retry_read_tx_and_rediscovery_until_success":
-    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
-  "stub.routing.RoutingV4.test_should_retry_read_tx_and_rediscovery_until_success":
-    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
-  "stub.routing.NoRouting.test_should_retry_read_tx_and_rediscovery_until_success":
-    "Driver iterates over results of custom resolver and settles on first connection yielding a successful handshake",
   "stub.routing.Routing.test_should_retry_write_until_success_with_leader_change_using_tx_function":
-    "Driver opens a new connection each time to get a fresh routing table",
+    "Driver closes connection to router if DNS resolved name not in routing table",
   "stub.routing.RoutingV3.test_should_retry_write_until_success_with_leader_change_using_tx_function":
-    "Driver opens a new connection each time to get a fresh routing table",
+    "Driver closes connection to router if DNS resolved name not in routing table",
   "stub.routing.RoutingV4.test_should_retry_write_until_success_with_leader_change_using_tx_function":
-    "Driver opens a new connection each time to get a fresh routing table",
-  "stub.routing.NoRouting.test_should_retry_write_until_success_with_leader_change_using_tx_function":
-    "Driver opens a new connection each time to get a fresh routing table",
+    "Driver closes connection to router if DNS resolved name not in routing table",
   "stub.routing.Routing.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function":
-    "Driver opens a new connection each time to get a fresh routing table",
+    "Driver closes connection to router if DNS resolved name not in routing table",
   "stub.routing.RoutingV3.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function":
-    "Driver opens a new connection each time to get a fresh routing table",
+    "Driver closes connection to router if DNS resolved name not in routing table",
   "stub.routing.RoutingV4.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function":
-    "Driver opens a new connection each time to get a fresh routing table",
-  "stub.routing.NoRouting.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function":
-    "Driver opens a new connection each time to get a fresh routing table",
-  "stub.routing.Routing.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors":
-    "Driver uses custom resolver for each connection, not only initial seeding",
-  "stub.routing.RoutingV3.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors":
-    "Driver uses custom resolver for each connection, not only initial seeding",
-  "stub.routing.RoutingV4.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors":
-    "Driver uses custom resolver for each connection, not only initial seeding",
-  "stub.routing.NoRouting.test_should_revert_to_initial_router_if_known_router_throws_protocol_errors":
-    "Driver uses custom resolver for each connection, not only initial seeding",
+    "Driver closes connection to router if DNS resolved name not in routing table",
+  "stub.routing.Routing.test_should_successfully_acquire_rt_when_router_ip_changes":
+    "Test makes assumptions about how verify_connectivity is implemented",
+  "stub.routing.RoutingV3.test_should_successfully_acquire_rt_when_router_ip_changes":
+    "Test makes assumptions about how verify_connectivity is implemented",
+  "stub.routing.RoutingV4.test_should_successfully_acquire_rt_when_router_ip_changes":
+    "Test makes assumptions about how verify_connectivity is implemented",
   "stub.retry.TestRetryClustering.test_retry_ForbiddenOnReadOnlyDatabase_ChangingWriter":
     "Test makes assumptions about how verify_connectivity is implemented",
   "stub.authorization.AuthorizationTests.test_should_retry_on_auth_expired_on_begin_using_tx_function":

--- a/testkitbackend/skipped_tests.json
+++ b/testkitbackend/skipped_tests.json
@@ -65,8 +65,6 @@
     "Driver uses custom resolver for each connection, not only initial seeding",
   "stub.retry.TestRetryClustering.test_retry_ForbiddenOnReadOnlyDatabase_ChangingWriter":
     "Test makes assumptions about how verify_connectivity is implemented",
-  "stub.disconnected.SessionRunDisconnected.test_fail_on_reset":
-    "It is not reseting connection when putting back to pool",
   "stub.authorization.AuthorizationTests.test_should_retry_on_auth_expired_on_begin_using_tx_function":
     "Flaky: test requires the driver to contact servers in a specific order",
   "stub.authorization.AuthorizationTestsV3.test_should_retry_on_auth_expired_on_begin_using_tx_function":


### PR DESCRIPTION
Sending RESETs whenever a connection is put back into the pool makes sure there is no work outstanding on an idle connection. Unconsumed records, unacknowledged errors, or open transactions.