### PR TITLE
Make testkit backend handle UnsupportedServerProduct properly

### DIFF
--- a/testkitbackend/backend.py
+++ b/testkitbackend/backend.py
@@ -20,7 +20,11 @@ import logging
 import sys
 import traceback
 
-from neo4j.exceptions import Neo4jError, DriverError, ServiceUnavailable
+from neo4j.exceptions import (
+    DriverError,
+    Neo4jError,
+    UnsupportedServerProduct,
+)
 
 import testkitbackend.requests as requests
 
@@ -140,7 +144,7 @@ class Backend:
                     "Backend does not support some properties of the " + name +
                     " request: " + ", ".join(unsused_keys)
                 )
-        except (Neo4jError, DriverError) as e:
+        except (Neo4jError, DriverError, UnsupportedServerProduct) as e:
             log.debug(traceback.format_exc())
             if isinstance(e, Neo4jError):
                 msg = "" if e.message is None else str(e.message)


### PR DESCRIPTION
Arguably, this should be a sub-class of `DriverError`. For now, the testkit backend will just re-write it to be one for all testkit purposes as actually changing it would be a breaking change.