### PR TITLE
Close stale connections before removing them from the pool

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -639,7 +639,13 @@ class IOPool:
             while True:
                 # try to find a free connection in pool
                 for connection in list(connections):
-                    if connection.closed() or connection.defunct() or connection.stale():
+                    if (connection.closed() or connection.defunct()
+                            or connection.stale()):
+                        # `close` is a noop on already closed connections.
+                        # This is to make sure that the connection is gracefully
+                        # closed, e.g. if it's just marked as `stale` but still
+                        # alive.
+                        connection.close()
                         connections.remove(connection)
                         continue
                     if not connection.in_use:


### PR DESCRIPTION
The driver would not actively close stale (e.g., auth expired) connections (i.e., send `GOODBYE` and close the socket) when removing them from the connection pool. The socket would probably still be closed sooner or later by the GC. This, however, would cause a warning, be non-deterministic in timing, and not send `GOODBYE`.