### PR TITLE
Fix pulling results in parallel

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -498,7 +498,7 @@ class Bolt(abc.ABC):
 
     @abc.abstractmethod
     def fetch_message(self):
-        """ Receive at least one message from the server, if available.
+        """ Receive at most one message from the server, if available.
 
         :return: 2-tuple of number of detail messages and number of summary
                  messages fetched

--- a/neo4j/io/_bolt3.py
+++ b/neo4j/io/_bolt3.py
@@ -219,7 +219,7 @@ class Bolt3(Bolt):
         self._is_reset = True
 
     def fetch_message(self):
-        """ Receive at least one message from the server, if available.
+        """ Receive at most one message from the server, if available.
 
         :return: 2-tuple of number of detail messages and number of summary
                  messages fetched

--- a/neo4j/io/_bolt4.py
+++ b/neo4j/io/_bolt4.py
@@ -231,7 +231,7 @@ class Bolt4x0(Bolt):
         self._is_reset = True
 
     def fetch_message(self):
-        """ Receive at least one message from the server, if available.
+        """ Receive at most one message from the server, if available.
 
         :return: 2-tuple of number of detail messages and number of summary
                  messages fetched


### PR DESCRIPTION
Consuming two results in the same TX could cause the driver to send too many
PULL request to the server which led to FAILURE