### PR TITLE
.run on a failed transaction will also fail

### DIFF
--- a/neo4j/work/simple.py
+++ b/neo4j/work/simple.py
@@ -137,7 +137,7 @@ class Session(Workspace):
             self._autoResult = None
             self._disconnect()
 
-    def _result_network_error(self):
+    def _result_error(self, _):
         if self._autoResult:
             self._autoResult = None
             self._disconnect()
@@ -227,7 +227,7 @@ class Session(Workspace):
 
         self._autoResult = Result(
             cx, hydrant, self._config.fetch_size, self._result_closed,
-            self._result_network_error
+            self._result_error
         )
         self._autoResult._run(
             query, parameters, self._config.database,
@@ -261,7 +261,7 @@ class Session(Workspace):
             self._transaction = None
             self._disconnect()
 
-    def _transaction_network_error_handler(self):
+    def _transaction_error_handler(self, _):
         if self._transaction:
             self._transaction = None
             self._disconnect()
@@ -272,7 +272,7 @@ class Session(Workspace):
         self._transaction = Transaction(
             self._connection, self._config.fetch_size,
             self._transaction_closed_handler,
-            self._transaction_network_error_handler
+            self._transaction_error_handler
         )
         self._transaction._begin(database, self._bookmarks, access_mode,
                                  metadata, timeout)

--- a/testkitbackend/test_config.json
+++ b/testkitbackend/test_config.json
@@ -1,7 +1,5 @@
 {
   "skips": {
-    "neo4j.txrun.TestTxRun.test_should_not_run_valid_query_in_invalid_tx":
-      "Driver allows to run queries in broken transaction",
     "stub.routing.test_routing_v4x1.RoutingV4x1.test_should_retry_write_until_success_with_leader_change_using_tx_function":
       "Driver closes connection to router if DNS resolved name not in routing table",
     "stub.routing.test_routing_v3.RoutingV3.test_should_retry_write_until_success_with_leader_change_using_tx_function":


### PR DESCRIPTION
Mark a transaction as broken on `.run` failure. 

If executing a query fails (for whatever reason), the server will terminate the
transaction. So we might as well mark the transaction as broken on the driver
side and fail fast (before contacting the server), should the client code try to
use the transaction again.