### PR TITLE
[4.0] Remove deleted method `sync` from docs

### DIFF
--- a/docs/source/transactions.rst
+++ b/docs/source/transactions.rst
@@ -33,8 +33,6 @@ To construct a :class:`.Session` use the :meth:`.Driver.session` method.
 
     .. automethod:: run
 
-    .. automethod:: sync
-
     .. automethod:: detach
 
     .. automethod:: next_bookmarks
@@ -78,8 +76,6 @@ It also gives applications the ability to directly control `commit` and `rollbac
 .. class:: .Transaction
 
     .. automethod:: run
-
-    .. automethod:: sync
 
     .. automethod:: closed
 

--- a/neo4j/work/transaction.py
+++ b/neo4j/work/transaction.py
@@ -72,10 +72,6 @@ class Transaction:
     def run(self, query, parameters=None, **kwparameters):
         """ Run a Cypher query within the context of this transaction.
 
-        The query is sent to the server lazily, when its result is
-        consumed. To force the query to be sent to the server, use
-        the :meth:`.Transaction.sync` method.
-
         Cypher is typically expressed as a query template plus a
         set of named parameters. In Python, parameters may be expressed
         through a dictionary of parameters, through individual parameter


### PR DESCRIPTION
Backport of https://github.com/neo4j/neo4j-python-driver/pull/584