### PR TITLE
Only send qid with PULL and DISCARD when necessary

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -137,6 +137,11 @@ class Bolt(abc.ABC):
     #: The pool of which this connection is a member
     pool = None
 
+    # Store the id of the most recent ran query to be able reduce sent bits by
+    # using the default (-1) to refer to the most recent query when pulling
+    # results for it.
+    most_recent_qid = None
+
     def __init__(self, unresolved_address, sock, max_connection_lifetime, *, auth=None, user_agent=None, routing_context=None):
         self.unresolved_address = unresolved_address
         self.socket = sock

--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -137,7 +137,7 @@ class Bolt(abc.ABC):
     #: The pool of which this connection is a member
     pool = None
 
-    # Store the id of the most recent ran query to be able reduce sent bits by
+    # Store the id of the most recent ran query to be able to reduce sent bits by
     # using the default (-1) to refer to the most recent query when pulling
     # results for it.
     most_recent_qid = None

--- a/neo4j/work/result.py
+++ b/neo4j/work/result.py
@@ -124,7 +124,7 @@ class Result:
 
         def on_attached(metadata):
             self._metadata.update(metadata)
-            # For auto-commit there is no qid and Bolt 3 do not support qid
+            # For auto-commit there is no qid and Bolt 3 does not support qid
             self._raw_qid = metadata.get("qid", -1)
             if self._raw_qid != -1:
                 self._connection.connection.most_recent_qid = self._raw_qid

--- a/tests/unit/work/test_result.py
+++ b/tests/unit/work/test_result.py
@@ -89,6 +89,7 @@ class ConnectionStub:
             self._use_qid = force_qid
         self.fetch_idx = 0
         self._qid = -1
+        self.most_recent_qid = None
         self.record_idxs = [0] * len(self._records)
         self.to_pull = [None] * len(self._records)
         self._exhausted = [False] * len(self._records)


### PR DESCRIPTION
Waiting for neo4j-drivers/testkit#249 to me merged first (re-run TestKit pipeline afterwards)