### PR TITLE
Send BEGIN eagerly on transaction begin

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -29,6 +29,7 @@ the `session` module provides the main user-facing abstractions.
 __all__ = [
     "Bolt",
     "BoltPool",
+    "ConnectionErrorHandler",
     "Neo4jPool",
     "check_supported_server_product",
 ]
@@ -92,6 +93,7 @@ from neo4j.exceptions import (
 )
 from neo4j.io._common import (
     CommitResponse,
+    ConnectionErrorHandler,
     Inbox,
     InitResponse,
     Outbox,

--- a/neo4j/io/_common.py
+++ b/neo4j/io/_common.py
@@ -159,8 +159,8 @@ class ConnectionErrorHandler:
         self.__connection = connection
         self.__on_error = on_error
 
-    def __getattr__(self, item):
-        connection_attr = getattr(self.__connection, item)
+    def __getattr__(self, name):
+        connection_attr = getattr(self.__connection, name)
         if not callable(connection_attr):
             return connection_attr
 
@@ -174,6 +174,13 @@ class ConnectionErrorHandler:
             return inner
 
         return outer(connection_attr)
+
+    def __setattr__(self, name, value):
+        if name.startswith("_" + self.__class__.__name__ + "__"):
+            super().__setattr__(name, value)
+        else:
+            setattr(self.__connection, name, value)
+
 
 
 class Response:

--- a/neo4j/work/result.py
+++ b/neo4j/work/result.py
@@ -23,49 +23,8 @@ from collections import deque
 from warnings import warn
 
 from neo4j.data import DataDehydrator
-from neo4j.exceptions import (
-    Neo4jError,
-    ServiceUnavailable,
-    SessionExpired,
-)
+from neo4j.io import ConnectionErrorHandler
 from neo4j.work.summary import ResultSummary
-
-
-class _ConnectionErrorHandler:
-    """
-    Wrapper class for handling connection errors.
-
-    The class will wrap each method to invoke a callback if the method raises
-    SessionExpired or ServiceUnavailable.
-    The error will be re-raised after the callback.
-    """
-
-    def __init__(self, connection, on_error):
-        """
-        :param connection the connection object to warp
-        :type connection Bolt
-        :param on_error the function to be called when a method of
-            connection raises of of the caught errors.
-        :type on_error callable
-        """
-        self.connection = connection
-        self.on_error = on_error
-
-    def __getattr__(self, item):
-        connection_attr = getattr(self.connection, item)
-        if not callable(connection_attr):
-            return connection_attr
-
-        def outer(func):
-            def inner(*args, **kwargs):
-                try:
-                    func(*args, **kwargs)
-                except (Neo4jError, ServiceUnavailable, SessionExpired) as exc:
-                    self.on_error(exc)
-                    raise
-            return inner
-
-        return outer(connection_attr)
 
 
 class Result:
@@ -76,7 +35,7 @@ class Result:
 
     def __init__(self, connection, hydrant, fetch_size, on_closed,
                  on_error):
-        self._connection = _ConnectionErrorHandler(connection, on_error)
+        self._connection = ConnectionErrorHandler(connection, on_error)
         self._hydrant = hydrant
         self._on_closed = on_closed
         self._metadata = None
@@ -98,7 +57,7 @@ class Result:
 
     @property
     def _qid(self):
-        if self._raw_qid == self._connection.connection.most_recent_qid:
+        if self._raw_qid == self._connection.most_recent_qid:
             return -1
         else:
             return self._raw_qid
@@ -127,7 +86,7 @@ class Result:
             # For auto-commit there is no qid and Bolt 3 does not support qid
             self._raw_qid = metadata.get("qid", -1)
             if self._raw_qid != -1:
-                self._connection.connection.most_recent_qid = self._raw_qid
+                self._connection.most_recent_qid = self._raw_qid
             self._keys = metadata.get("fields")
             self._attached = True
 

--- a/neo4j/work/transaction.py
+++ b/neo4j/work/transaction.py
@@ -73,7 +73,6 @@ class Transaction:
 
     def _error_handler(self, exc):
         self._last_error = exc
-        self._closed = True
         self._on_error(exc)
 
     def _consume_results(self):

--- a/testkitbackend/test_config.json
+++ b/testkitbackend/test_config.json
@@ -6,6 +6,12 @@
       "Driver closes connection to router if DNS resolved name not in routing table",
     "stub.routing.test_routing_v4x3.RoutingV4x3.test_should_retry_write_until_success_with_leader_change_using_tx_function":
       "Driver closes connection to router if DNS resolved name not in routing table",
+    "stub.routing.test_routing_v4x1.RoutingV4x1.test_should_retry_write_until_success_with_leader_change_on_run_using_tx_function":
+      "Driver closes connection to router if DNS resolved name not in routing table",
+    "stub.routing.test_routing_v3.RoutingV3.test_should_retry_write_until_success_with_leader_change_on_run_using_tx_function":
+      "Driver closes connection to router if DNS resolved name not in routing table",
+    "stub.routing.test_routing_v4x3.RoutingV4x3.test_should_retry_write_until_success_with_leader_change_on_run_using_tx_function":
+      "Driver closes connection to router if DNS resolved name not in routing table",
     "stub.routing.test_routing_v4x1.RoutingV4x1.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function":
       "Driver closes connection to router if DNS resolved name not in routing table",
     "stub.routing.test_routing_v3.RoutingV3.test_should_retry_write_until_success_with_leader_shutdown_during_tx_using_tx_function":


### PR DESCRIPTION
By sending `BEGIN` right after starting a transaction instead of waiting for
a query to pipeline `BEGIN` with `RUN`, the driver will notice a broken
connection, lack of permission, and similar problems faster. Meaning potentially
expensive computations in the client code can be avoided if they wouldn't be
able to be persisted in the DB anyway. However, this means an extra rtt.

Waiting for https://github.com/neo4j-drivers/testkit/pull/251 to me merged first (re-run TestKit pipeline afterwards)