### PR TITLE
Prefer python's time.time_ns over libc if available

### DIFF
--- a/neo4j/time/__init__.py
+++ b/neo4j/time/__init__.py
@@ -266,7 +266,10 @@ class Clock:
 
         :raises OverflowError:
         """
-        return ClockTime(-int(mktime(gmtime(0))))
+        # Adding and subtracting two days to avoid passing a pre-epoch time to
+        # `mktime`, which can cause a `OverflowError` on some platforms (e.g.,
+        # Windows).
+        return ClockTime(-int(mktime(gmtime(172800))) + 172800)
 
     def local_time(self):
         """ Read and return the current local time from this clock, measured relative to the Unix Epoch.

--- a/neo4j/time/clock_implementations.py
+++ b/neo4j/time/clock_implementations.py
@@ -45,6 +45,31 @@ class SafeClock(Clock):
         return ClockTime(seconds, nanoseconds * 1000)
 
 
+class PEP564Clock(Clock):
+    """ Clock implementation based on the PEP564 additions to Python 3.7.
+    This clock is guaranteed nanosecond precision.
+    """
+
+    @classmethod
+    def precision(cls):
+        return 9
+
+    @classmethod
+    def available(cls):
+        try:
+            from time import time_ns
+        except ImportError:
+            return False
+        else:
+            return True
+
+    def utc_time(self):
+        from time import time_ns
+        t = time_ns()
+        seconds, nanoseconds = divmod(t, 1000000000)
+        return ClockTime(seconds, nanoseconds)
+
+
 class LibCClock(Clock):
     """ Clock implementation that works only on platforms that provide
     libc. This clock is guaranteed nanosecond precision.
@@ -79,28 +104,3 @@ class LibCClock(Clock):
             return ClockTime(ts.seconds, ts.nanoseconds)
         else:
             raise RuntimeError("clock_gettime failed with status %d" % status)
-
-
-class PEP564Clock(Clock):
-    """ Clock implementation based on the PEP564 additions to Python 3.7.
-    This clock is guaranteed nanosecond precision.
-    """
-
-    @classmethod
-    def precision(cls):
-        return 9
-
-    @classmethod
-    def available(cls):
-        try:
-            from time import time_ns
-        except ImportError:
-            return False
-        else:
-            return True
-
-    def utc_time(self):
-        from time import time_ns
-        t = time_ns()
-        seconds, nanoseconds = divmod(t, 1000000000)
-        return ClockTime(seconds, nanoseconds)

--- a/tests/unit/time/test_clock.py
+++ b/tests/unit/time/test_clock.py
@@ -53,3 +53,19 @@ class ClockTestCase(TestCase):
         clock = object.__new__(Clock)
         offset = clock.local_offset()
         self.assertIsInstance(offset, ClockTime)
+
+    def test_local_time(self):
+        _ = Clock()
+        for impl in Clock._Clock__implementations:
+            self.assert_(issubclass(impl, Clock))
+            clock = object.__new__(impl)
+            time = clock.local_time()
+            self.assertIsInstance(time, ClockTime)
+
+    def test_utc_time(self):
+        _ = Clock()
+        for impl in Clock._Clock__implementations:
+            self.assert_(issubclass(impl, Clock))
+            clock = object.__new__(impl)
+            time = clock.utc_time()
+            self.assertIsInstance(time, ClockTime)


### PR DESCRIPTION
 - prefer to use python's native ns clock implementation if available
 - improve Windows compatibility by shifting range of arguments to low-level time call

This PR might help to resolve https://github.com/neo4j/neo4j-python-driver/issues/302