### PR TITLE
Disable test for unsupported bolt version

### DIFF
--- a/tests/integration/test_pipelines.py
+++ b/tests/integration/test_pipelines.py
@@ -197,7 +197,7 @@ def test_can_handle_cypher_error(bolt_driver):
             next(pipeline.pull())
 
 
-def test_should_not_allow_empty_statements(bolt_driver):
+def test_should_not_allow_empty_statements(bolt_driver, requires_bolt_4x):
     with bolt_driver.pipeline(flush_every=0) as pipeline:
         pipeline.push("")
         with pytest.raises(CypherSyntaxError):


### PR DESCRIPTION
3.5 servers will re-run the last query if they receive an empty query.
This was intended to be an optimization of tx retries.