### PR TITLE
Make driver reject unknown query type in summary

### DIFF
--- a/neo4j/work/result.py
+++ b/neo4j/work/result.py
@@ -232,9 +232,14 @@ class Result:
         """
         if self._summary is None:
             if self._metadata:
-                self._summary = ResultSummary(**self._metadata)
+                self._summary = ResultSummary(
+                    self._connection.unresolved_address, **self._metadata
+                )
             elif self._connection:
-                self._summary = ResultSummary(server=self._connection.server_info)
+                self._summary = ResultSummary(
+                    self._connection.unresolved_address,
+                    server=self._connection.server_info
+                )
 
         return self._summary
 

--- a/testkitbackend/backend.py
+++ b/testkitbackend/backend.py
@@ -24,6 +24,9 @@ import logging
 import sys
 import traceback
 
+from neo4j._exceptions import (
+    BoltError
+)
 from neo4j.exceptions import (
     DriverError,
     Neo4jError,
@@ -152,7 +155,8 @@ class Backend:
                     "Backend does not support some properties of the " + name +
                     " request: " + ", ".join(unsused_keys)
                 )
-        except (Neo4jError, DriverError, UnsupportedServerProduct) as e:
+        except (Neo4jError, DriverError, UnsupportedServerProduct,
+                BoltError) as e:
             log.debug(traceback.format_exc())
             if isinstance(e, Neo4jError):
                 msg = "" if e.message is None else str(e.message)

--- a/tests/unit/work/test_result.py
+++ b/tests/unit/work/test_result.py
@@ -98,6 +98,7 @@ class ConnectionStub:
         self.run_meta = run_meta
         self.summary_meta = summary_meta
         ConnectionStub.server_info.update({"server": "Neo4j/4.3.0"})
+        self.unresolved_address = None
 
     def send_all(self):
         self.sent += self.queued


### PR DESCRIPTION
Drivers should only accept know query types in the result summary
(`"r"`, `"w"`, `"rw"`, `"s"`) or if the key is missing altogether.

Waiting for https://github.com/neo4j-drivers/testkit/pull/270 to me merged first.
The re-run the TestKit pipeline.