### PR TITLE
Don't attempt to reset closed connections.

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -726,9 +726,9 @@ class IOPool:
         """
         with self.lock:
             for connection in connections:
-                if not (connection.is_reset
-                        or connection.defunct()
-                        or connection.closed()):
+                if not (connection.defunct()
+                        or connection.closed()
+                        or connection.is_reset):
                     try:
                         connection.reset()
                     except (Neo4jError, DriverError, BoltError) as e:

--- a/neo4j/io/_bolt3.py
+++ b/neo4j/io/_bolt3.py
@@ -124,11 +124,12 @@ class Bolt3(Bolt):
 
     @property
     def is_reset(self):
-        if self.responses:
-            # We can't be sure of the server's state as there are still pending
-            # responses. Unless the last message we sent was RESET. In that case
-            # the server state will always be READY when we're done.
-            return self.responses[-1].message == "reset"
+        # We can't be sure of the server's state if there are still pending
+        # responses. Unless the last message we sent was RESET. In that case
+        # the server state will always be READY when we're done.
+        if (self.responses and self.responses[-1]
+                and self.responses[-1].message == "reset"):
+            return True
         return self._server_state_manager.state == ServerStates.READY
 
     @property

--- a/neo4j/io/_bolt4.py
+++ b/neo4j/io/_bolt4.py
@@ -82,11 +82,12 @@ class Bolt4x0(Bolt):
 
     @property
     def is_reset(self):
-        if self.responses:
-            # We can't be sure of the server's state as there are still pending
-            # responses. Unless the last message we sent was RESET. In that case
-            # the server state will always be READY when we're done.
-            return self.responses[-1].message == "reset"
+        # We can't be sure of the server's state if there are still pending
+        # responses. Unless the last message we sent was RESET. In that case
+        # the server state will always be READY when we're done.
+        if (self.responses and self.responses[-1]
+                and self.responses[-1].message == "reset"):
+            return True
         return self._server_state_manager.state == ServerStates.READY
 
     @property

--- a/neo4j/work/simple.py
+++ b/neo4j/work/simple.py
@@ -91,7 +91,7 @@ class Session(Workspace):
     def __del__(self):
         try:
             self.close()
-        except OSError:
+        except (OSError, ServiceUnavailable, SessionExpired):
             pass
 
     def __enter__(self):

--- a/neo4j/work/transaction.py
+++ b/neo4j/work/transaction.py
@@ -172,7 +172,9 @@ class Transaction:
 
         metadata = {}
         try:
-            if not self._connection.is_reset:
+            if not (self._connection.defunct()
+                    or self._connection.closed()
+                    or self._connection.is_reset):
                 # DISCARD pending records then do a rollback.
                 self._consume_results()
                 self._connection.rollback(on_success=metadata.update)


### PR DESCRIPTION
Also fix AttributeError on connection clean-up
This shouldn't happen in the first place: higher level components should check if the connection is still intact before checking `is_reset`. However, more resilience, more good ;)