### PR TITLE
Fast failing discovery on certain errors.

### DIFF
--- a/neo4j/__init__.py
+++ b/neo4j/__init__.py
@@ -435,8 +435,11 @@ class Neo4jDriver(Routing, Driver):
         return self._verify_routing_connectivity()
 
     def _verify_routing_connectivity(self):
-        from neo4j.exceptions import ServiceUnavailable
-        from neo4j._exceptions import BoltHandshakeError
+        from neo4j.exceptions import (
+            Neo4jError,
+            ServiceUnavailable,
+            SessionExpired,
+        )
 
         table = self._pool.get_routing_table_for_default_database()
         routing_info = {}
@@ -450,9 +453,8 @@ class Neo4jDriver(Routing, Driver):
                     timeout=self._default_workspace_config
                                 .connection_acquisition_timeout
                 )
-            except BoltHandshakeError as error:
+            except (ServiceUnavailable, SessionExpired, Neo4jError):
                 routing_info[ix] = None
-
         for key, val in routing_info.items():
             if val is not None:
                 return routing_info

--- a/neo4j/_exceptions.py
+++ b/neo4j/_exceptions.py
@@ -102,11 +102,6 @@ class BoltTransactionError(BoltError):
     # TODO: pass the transaction object in as an argument
 
 
-class BoltRoutingError(BoltError):
-    """ Raised when a fault occurs with obtaining a routing table.
-    """
-
-
 class BoltFailure(BoltError):
     """ Holds a Cypher failure.
     """

--- a/neo4j/exceptions.py
+++ b/neo4j/exceptions.py
@@ -130,6 +130,21 @@ class Neo4jError(Exception):
     def invalidates_all_connections(self):
         return self.code == "Neo.ClientError.Security.AuthorizationExpired"
 
+    def is_fatal_during_discovery(self):
+        # checks if the code is an error that is caused by the client. In this
+        # case the driver should fail fast during discovery.
+        if not isinstance(self.code, str):
+            return False
+        if self.code in ("Neo.ClientError.Database.DatabaseNotFound",
+                         "Neo.ClientError.Transaction.InvalidBookmark",
+                         "Neo.ClientError.Transaction.InvalidBookmarkMixture"):
+            return True
+        if (self.code.startswith("Neo.ClientError.Security.")
+                and self.code != "Neo.ClientError.Security."
+                                 "AuthorizationExpired"):
+            return True
+        return False
+
     def __str__(self):
         return "{{code: {code}}} {{message: {message}}}".format(code=self.code, message=self.message)
 

--- a/neo4j/io/_bolt3.py
+++ b/neo4j/io/_bolt3.py
@@ -186,13 +186,6 @@ class Bolt3(Bolt):
         metadata = {}
         records = []
 
-        def fail(md):
-            from neo4j._exceptions import BoltRoutingError
-            if md.get("code") == "Neo.ClientError.Procedure.ProcedureNotFound":
-                raise BoltRoutingError("Server does not support routing", self.unresolved_address)
-            else:
-                raise BoltRoutingError("Routing support broken on server", self.unresolved_address)
-
         # Ignoring database and bookmarks because there is no multi-db support.
         # The bookmarks are only relevant for making sure a previously created
         # db exists before querying a routing table for it.
@@ -200,7 +193,7 @@ class Bolt3(Bolt):
             "CALL dbms.cluster.routing.getRoutingTable($context)",  # This is an internal procedure call. Only available if the Neo4j 3.5 is setup with clustering.
             {"context": self.routing_context},
             mode="r",                                               # Bolt Protocol Version(3, 0) supports mode="r"
-            on_success=metadata.update, on_failure=fail
+            on_success=metadata.update
         )
         self.pull(on_success=metadata.update, on_records=records.extend)
         self.send_all()

--- a/neo4j/io/_common.py
+++ b/neo4j/io/_common.py
@@ -242,11 +242,12 @@ class InitResponse(Response):
 
     def on_failure(self, metadata):
         code = metadata.get("code")
-        message = metadata.get("message", "Connection initialisation failed")
         if code == "Neo.ClientError.Security.Unauthorized":
-            raise AuthError(message)
+            raise Neo4jError.hydrate(**metadata)
         else:
-            raise ServiceUnavailable(message)
+            raise ServiceUnavailable(
+                metadata.get("message", "Connection initialisation failed")
+            )
 
 
 class CommitResponse(Response):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -55,7 +55,6 @@ from neo4j.exceptions import (
 from neo4j._exceptions import (
     BoltError,
     BoltHandshakeError,
-    BoltRoutingError,
     BoltConnectionError,
     BoltSecurityError,
     BoltConnectionBroken,


### PR DESCRIPTION
The driver tries its best to fetch a routing table. It will try all possible
routers while skipping routers on most errors. However, there are a few errors
that are caused by the client. Those errors should be surfaced to the user for
a better UX/DX and should fail fast: there is no reason to try another router
if we expect it tho return the same error.

Those errors are:
 - `Neo.ClientError.Database.DatabaseNotFound`
 - all `Neo.ClientError.Security.*`
   - except `Neo.ClientError.Security.AuthorizationExpired`
 - `Neo.ClientError.Transaction.InvalidBookmark`
 - `Neo.ClientError.Transaction.InvalidBookmarkMixture`

This PR also changes auth errors to be properly hydrated when received as HELLO response