### PR TITLE
The 4.4 driver only supports Python 3.6+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup_args = {
     "classifiers": classifiers,
     "packages": packages,
     "entry_points": entry_points,
-    "python_requires": ">=3.5",
+    "python_requires": ">=3.6",
 }
 
 setup(**setup_args)


### PR DESCRIPTION
This change could be considered a breaking change. But in fact it's a fix:
it'll make an attempt to install neo4j with a wrong Python version faster.

The supported Python versions were clearly stated in the documentation from the
start. Furthermore, since some compatibility layers for Python 3.5 have been
removed in this driver version, we better fail fast to indicate the
misconfiguration.