### PR TITLE
[4.4] Don't close stale connections while in use

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -39,6 +39,7 @@ from collections import (
     defaultdict,
     deque,
 )
+import logging
 from logging import getLogger
 from random import choice
 import selectors
@@ -652,11 +653,19 @@ class IOPool:
                 # try to find a free connection in pool
                 for connection in list(self.connections.get(address, [])):
                     if (connection.closed() or connection.defunct()
-                            or connection.stale()):
+                            or (connection.stale() and not connection.in_use)):
                         # `close` is a noop on already closed connections.
                         # This is to make sure that the connection is gracefully
                         # closed, e.g. if it's just marked as `stale` but still
                         # alive.
+                        if log.isEnabledFor(logging.DEBUG):
+                            log.debug(
+                                "[#%04X]  C: <POOL> removing old connection "
+                                "(closed=%s, defunct=%s, stale=%s, in_use=%s)",
+                                connection.local_port,
+                                connection.closed(), connection.defunct(),
+                                connection.stale(), connection.in_use
+                            )
                         connection.close()
                         try:
                             self.connections.get(address, []).remove(connection)


### PR DESCRIPTION
The pool will close connections marked as stale when trying to pick them up
from the pool. It should not do so while the connection is in use (i.e.,
already borrowed from the pool). In concurrent systems, this would lead to all
sorts of errors caused by the connection being managed from different threads:
 * the thread trying to acquire a connection will close the stale connection on
   encounter
 * while the thread that borrowed it might still be using it, e.g., to fetch
   results or run a query