### PR TITLE
[4.4] Roll back data written to output buffer on packing failure

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -487,7 +487,8 @@ class Bolt(abc.ABC):
         :param fields: the fields of the message as a tuple
         :param response: a response object to handle callbacks
         """
-        self.packer.pack_struct(signature, fields)
+        with self.outbox.tmp_buffer():
+            self.packer.pack_struct(signature, fields)
         self.outbox.wrap_message()
         self.responses.append(response)
 


### PR DESCRIPTION
While packing data to packstream, several errors can occur (integers that
are out of bounds, unknown data types, etc.). On packing failure, the driver
should never send the half-finished packed data over the wire. This will most
likely cause the server to close the connection as the data will be corrupt.

Back port of https://github.com/neo4j/neo4j-python-driver/pull/640