### PR TITLE
Allow tx timeout to be 0 and send it

### DIFF
--- a/neo4j/_async/io/_bolt3.py
+++ b/neo4j/_async/io/_bolt3.py
@@ -229,11 +229,13 @@ class AsyncBolt3(AsyncBolt):
                 extra["tx_metadata"] = dict(metadata)
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
-        if timeout:
+        if timeout is not None:
             try:
-                extra["tx_timeout"] = int(1000 * timeout)
+                extra["tx_timeout"] = int(1000 * float(timeout))
             except TypeError:
                 raise TypeError("Timeout must be specified as a number of seconds")
+            if extra["tx_timeout"] < 0:
+                raise ValueError("Timeout must be a positive number or 0.")
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port, " ".join(map(repr, fields)))
         if query.upper() == u"COMMIT":
@@ -281,11 +283,13 @@ class AsyncBolt3(AsyncBolt):
                 extra["tx_metadata"] = dict(metadata)
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
-        if timeout:
+        if timeout is not None:
             try:
-                extra["tx_timeout"] = int(1000 * timeout)
+                extra["tx_timeout"] = int(1000 * float(timeout))
             except TypeError:
                 raise TypeError("Timeout must be specified as a number of seconds")
+            if extra["tx_timeout"] < 0:
+                raise ValueError("Timeout must be a positive number or 0.")
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,), Response(self, "begin", **handlers))
 

--- a/neo4j/_async/io/_bolt4.py
+++ b/neo4j/_async/io/_bolt4.py
@@ -181,11 +181,13 @@ class AsyncBolt4x0(AsyncBolt):
                 extra["tx_metadata"] = dict(metadata)
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
-        if timeout:
+        if timeout is not None:
             try:
-                extra["tx_timeout"] = int(1000 * timeout)
+                extra["tx_timeout"] = int(1000 * float(timeout))
             except TypeError:
                 raise TypeError("Timeout must be specified as a number of seconds")
+            if extra["tx_timeout"] < 0:
+                raise ValueError("Timeout must be a positive number or 0.")
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port, " ".join(map(repr, fields)))
         if query.upper() == u"COMMIT":
@@ -232,11 +234,13 @@ class AsyncBolt4x0(AsyncBolt):
                 extra["tx_metadata"] = dict(metadata)
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
-        if timeout:
+        if timeout is not None:
             try:
-                extra["tx_timeout"] = int(1000 * timeout)
+                extra["tx_timeout"] = int(1000 * float(timeout))
             except TypeError:
                 raise TypeError("Timeout must be specified as a number of seconds")
+            if extra["tx_timeout"] < 0:
+                raise ValueError("Timeout must be a positive number or 0.")
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,), Response(self, "begin", **handlers))
 
@@ -492,12 +496,13 @@ class AsyncBolt4x4(AsyncBolt4x3):
                 extra["tx_metadata"] = dict(metadata)
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
-        if timeout:
+        if timeout is not None:
             try:
-                extra["tx_timeout"] = int(1000 * timeout)
+                extra["tx_timeout"] = int(1000 * float(timeout))
             except TypeError:
-                raise TypeError("Timeout must be specified as a number of "
-                                "seconds")
+                raise TypeError("Timeout must be specified as a number of seconds")
+            if extra["tx_timeout"] < 0:
+                raise ValueError("Timeout must be a positive number or 0.")
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port,
                   " ".join(map(repr, fields)))
@@ -527,11 +532,12 @@ class AsyncBolt4x4(AsyncBolt4x3):
                 extra["tx_metadata"] = dict(metadata)
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
-        if timeout:
+        if timeout is not None:
             try:
-                extra["tx_timeout"] = int(1000 * timeout)
+                extra["tx_timeout"] = int(1000 * float(timeout))
             except TypeError:
-                raise TypeError("Timeout must be specified as a number of "
-                                "seconds")
+                raise TypeError("Timeout must be specified as a number of seconds")
+            if extra["tx_timeout"] < 0:
+                raise ValueError("Timeout must be a positive number or 0.")
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,), Response(self, "begin", **handlers))

--- a/neo4j/_sync/io/_bolt3.py
+++ b/neo4j/_sync/io/_bolt3.py
@@ -229,11 +229,13 @@ class Bolt3(Bolt):
                 extra["tx_metadata"] = dict(metadata)
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
-        if timeout:
+        if timeout is not None:
             try:
-                extra["tx_timeout"] = int(1000 * timeout)
+                extra["tx_timeout"] = int(1000 * float(timeout))
             except TypeError:
                 raise TypeError("Timeout must be specified as a number of seconds")
+            if extra["tx_timeout"] < 0:
+                raise ValueError("Timeout must be a positive number or 0.")
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port, " ".join(map(repr, fields)))
         if query.upper() == u"COMMIT":
@@ -281,11 +283,13 @@ class Bolt3(Bolt):
                 extra["tx_metadata"] = dict(metadata)
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
-        if timeout:
+        if timeout is not None:
             try:
-                extra["tx_timeout"] = int(1000 * timeout)
+                extra["tx_timeout"] = int(1000 * float(timeout))
             except TypeError:
                 raise TypeError("Timeout must be specified as a number of seconds")
+            if extra["tx_timeout"] < 0:
+                raise ValueError("Timeout must be a positive number or 0.")
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,), Response(self, "begin", **handlers))
 

--- a/neo4j/_sync/io/_bolt4.py
+++ b/neo4j/_sync/io/_bolt4.py
@@ -181,11 +181,13 @@ class Bolt4x0(Bolt):
                 extra["tx_metadata"] = dict(metadata)
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
-        if timeout:
+        if timeout is not None:
             try:
-                extra["tx_timeout"] = int(1000 * timeout)
+                extra["tx_timeout"] = int(1000 * float(timeout))
             except TypeError:
                 raise TypeError("Timeout must be specified as a number of seconds")
+            if extra["tx_timeout"] < 0:
+                raise ValueError("Timeout must be a positive number or 0.")
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port, " ".join(map(repr, fields)))
         if query.upper() == u"COMMIT":
@@ -232,11 +234,13 @@ class Bolt4x0(Bolt):
                 extra["tx_metadata"] = dict(metadata)
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
-        if timeout:
+        if timeout is not None:
             try:
-                extra["tx_timeout"] = int(1000 * timeout)
+                extra["tx_timeout"] = int(1000 * float(timeout))
             except TypeError:
                 raise TypeError("Timeout must be specified as a number of seconds")
+            if extra["tx_timeout"] < 0:
+                raise ValueError("Timeout must be a positive number or 0.")
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,), Response(self, "begin", **handlers))
 
@@ -492,12 +496,13 @@ class Bolt4x4(Bolt4x3):
                 extra["tx_metadata"] = dict(metadata)
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
-        if timeout:
+        if timeout is not None:
             try:
-                extra["tx_timeout"] = int(1000 * timeout)
+                extra["tx_timeout"] = int(1000 * float(timeout))
             except TypeError:
-                raise TypeError("Timeout must be specified as a number of "
-                                "seconds")
+                raise TypeError("Timeout must be specified as a number of seconds")
+            if extra["tx_timeout"] < 0:
+                raise ValueError("Timeout must be a positive number or 0.")
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port,
                   " ".join(map(repr, fields)))
@@ -527,11 +532,12 @@ class Bolt4x4(Bolt4x3):
                 extra["tx_metadata"] = dict(metadata)
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
-        if timeout:
+        if timeout is not None:
             try:
-                extra["tx_timeout"] = int(1000 * timeout)
+                extra["tx_timeout"] = int(1000 * float(timeout))
             except TypeError:
-                raise TypeError("Timeout must be specified as a number of "
-                                "seconds")
+                raise TypeError("Timeout must be specified as a number of seconds")
+            if extra["tx_timeout"] < 0:
+                raise ValueError("Timeout must be a positive number or 0.")
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,), Response(self, "begin", **handlers))

--- a/neo4j/work/query.py
+++ b/neo4j/work/query.py
@@ -24,7 +24,7 @@ class Query:
     :param metadata: metadata attached to the query.
     :type metadata: dict
     :param timeout: seconds.
-    :type timeout: int
+    :type timeout: float or None
     """
     def __init__(self, text, metadata=None, timeout=None):
         self.text = text
@@ -59,8 +59,10 @@ def unit_of_work(metadata=None, timeout=None):
         Transactions that execute longer than the configured timeout will be terminated by the database.
         This functionality allows to limit query/transaction execution time.
         Specified timeout overrides the default timeout configured in the database using ``dbms.transaction.timeout`` setting.
-        Value should not represent a duration of zero or negative duration.
-    :type timeout: int
+        Value should not represent a negative duration.
+        A zero duration will make the transaction execute indefinitely.
+        None will use the default timeout configured in the database.
+    :type timeout: float or None
     """
 
     def wrapper(f):

--- a/testkitbackend/_async/backend.py
+++ b/testkitbackend/_async/backend.py
@@ -25,6 +25,7 @@ from json import (
     dumps,
     loads,
 )
+from pathlib import Path
 import traceback
 
 from neo4j._exceptions import BoltError
@@ -40,6 +41,10 @@ from .._driver_logger import (
     log,
 )
 from ..backend import Request
+
+
+TESTKIT_BACKEND_PATH = Path(__file__).absolute().resolve().parents[1]
+DRIVER_PATH = TESTKIT_BACKEND_PATH.parent / "neo4j"
 
 
 class AsyncBackend:
@@ -81,6 +86,30 @@ class AsyncBackend:
                     request = request + line
         return False
 
+    @staticmethod
+    def _exc_stems_from_driver(exc):
+        stack = traceback.extract_tb(exc.__traceback__)
+        for frame in stack[-1:1:-1]:
+            p = Path(frame.filename)
+            if TESTKIT_BACKEND_PATH in p.parents:
+                return False
+            if DRIVER_PATH in p.parents:
+                return True
+
+    async def _handle_driver_exc(self, exc):
+        log.debug(traceback.format_exc())
+        if isinstance(exc, Neo4jError):
+            msg = "" if exc.message is None else str(exc.message)
+        else:
+            msg = str(exc.args[0]) if exc.args else ""
+
+        key = self.next_key()
+        self.errors[key] = exc
+        payload = {"id": key, "errorType": str(type(exc)), "msg": msg}
+        if isinstance(exc, Neo4jError):
+            payload["code"] = exc.code
+        await self.send_response("DriverError", payload)
+
     async def _process(self, request):
         """ Process a received request by retrieving handler that
         corresponds to the request name.
@@ -104,24 +133,16 @@ class AsyncBackend:
                 )
         except (Neo4jError, DriverError, UnsupportedServerProduct,
                 BoltError) as e:
-            log.debug(traceback.format_exc())
-            if isinstance(e, Neo4jError):
-                msg = "" if e.message is None else str(e.message)
-            else:
-                msg = str(e.args[0]) if e.args else ""
-
-            key = self.next_key()
-            self.errors[key] = e
-            payload = {"id": key, "errorType": str(type(e)), "msg": msg}
-            if isinstance(e, Neo4jError):
-                payload["code"] = e.code
-            await self.send_response("DriverError", payload)
+            await self._handle_driver_exc(e)
         except requests.FrontendError as e:
             await self.send_response("FrontendError", {"msg": str(e)})
-        except Exception:
-            tb = traceback.format_exc()
-            log.error(tb)
-            await self.send_response("BackendError", {"msg": tb})
+        except Exception as e:
+            if self._exc_stems_from_driver(e):
+                await self._handle_driver_exc(e)
+            else:
+                tb = traceback.format_exc()
+                log.error(tb)
+                await self.send_response("BackendError", {"msg": tb})
 
     async def send_response(self, name, data):
         """ Sends a response to backend.

--- a/testkitbackend/_async/requests.py
+++ b/testkitbackend/_async/requests.py
@@ -253,8 +253,8 @@ async def SessionClose(backend, data):
 async def SessionBeginTransaction(backend, data):
     key = data["sessionId"]
     session = backend.sessions[key].session
-    metadata, timeout = fromtestkit.to_meta_and_timeout(data)
-    tx = await session.begin_transaction(metadata=metadata, timeout=timeout)
+    tx_kwargs = fromtestkit.to_tx_kwargs(data)
+    tx = await session.begin_transaction(**tx_kwargs)
     key = backend.next_key()
     backend.transactions[key] = tx
     await backend.send_response("Transaction", {"id": key})
@@ -272,9 +272,9 @@ async def transactionFunc(backend, data, is_read):
     key = data["sessionId"]
     session_tracker = backend.sessions[key]
     session = session_tracker.session
-    metadata, timeout = fromtestkit.to_meta_and_timeout(data)
+    tx_kwargs = fromtestkit.to_tx_kwargs(data)
 
-    @neo4j.unit_of_work(metadata=metadata, timeout=timeout)
+    @neo4j.unit_of_work(**tx_kwargs)
     async def func(tx):
         txkey = backend.next_key()
         backend.transactions[txkey] = tx

--- a/testkitbackend/_sync/requests.py
+++ b/testkitbackend/_sync/requests.py
@@ -253,8 +253,8 @@ def SessionClose(backend, data):
 def SessionBeginTransaction(backend, data):
     key = data["sessionId"]
     session = backend.sessions[key].session
-    metadata, timeout = fromtestkit.to_meta_and_timeout(data)
-    tx = session.begin_transaction(metadata=metadata, timeout=timeout)
+    tx_kwargs = fromtestkit.to_tx_kwargs(data)
+    tx = session.begin_transaction(**tx_kwargs)
     key = backend.next_key()
     backend.transactions[key] = tx
     backend.send_response("Transaction", {"id": key})
@@ -272,9 +272,9 @@ def transactionFunc(backend, data, is_read):
     key = data["sessionId"]
     session_tracker = backend.sessions[key]
     session = session_tracker.session
-    metadata, timeout = fromtestkit.to_meta_and_timeout(data)
+    tx_kwargs = fromtestkit.to_tx_kwargs(data)
 
-    @neo4j.unit_of_work(metadata=metadata, timeout=timeout)
+    @neo4j.unit_of_work(**tx_kwargs)
     def func(tx):
         txkey = backend.next_key()
         backend.transactions[txkey] = tx

--- a/testkitbackend/fromtestkit.py
+++ b/testkitbackend/fromtestkit.py
@@ -30,21 +30,24 @@ def to_cypher_and_params(data):
     return data["cypher"], params_dict
 
 
-def to_meta_and_timeout(data):
+def to_tx_kwargs(data):
     from .backend import Request
-    metadata = data.get('txMeta', None)
-    if isinstance(metadata, Request):
-        metadata.mark_all_as_read()
-    timeout = data.get('timeout', None)
-    if timeout:
-        timeout = timeout / 1000
-    return metadata, timeout
+    kwargs = {}
+    if "txMeta" in data:
+        kwargs["metadata"] = data["txMeta"]
+        if isinstance(kwargs["metadata"], Request):
+            kwargs["metadata"].mark_all_as_read()
+    if "timeout" in data:
+        kwargs["timeout"] = data["timeout"]
+        if kwargs["timeout"] is not None:
+            kwargs["timeout"] /= 1000
+    return kwargs
 
 
 def to_query_and_params(data):
     cypher, param = to_cypher_and_params(data)
-    metadata, timeout = to_meta_and_timeout(data)
-    query = Query(cypher, metadata=metadata, timeout=timeout)
+    tx_kwargs = to_tx_kwargs(data)
+    query = Query(cypher, **tx_kwargs)
     return query, param
 
 


### PR DESCRIPTION
Altering TestKit back end to treat any exceptions raised inside the driver
code (using trace back stack analysis) as `DriverError`s