### PR TITLE
Remove 4.0 Testkit feature flag

### DIFF
--- a/testkitbackend/test_config.json
+++ b/testkitbackend/test_config.json
@@ -33,7 +33,6 @@
     "Feature:Auth:Custom": true,
     "Feature:Auth:Kerberos": true,
     "Feature:Bolt:3.0": true,
-    "Feature:Bolt:4.0": true,
     "Feature:Bolt:4.1": true,
     "Feature:Bolt:4.2": true,
     "Feature:Bolt:4.3": true,


### PR DESCRIPTION
4.0 is not supported in the 5.0 handshake (full or minimal)