### PR TITLE
Introduce `(Async)ManagedTransaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,12 @@
     They are now ignored and will be removed in a future release.
   - The undocumented return value has been removed. If you need information
     about the remote server, use `driver.get_server_info()` instead.
+- Transaction functions (a.k.a. managed transactions):  
+  The first argument of transaction functions is now a `ManagedTransaction`
+  object. It behaves exactly like a regular `Transaction` object, except it
+  does not offer the `commit`, `rollback`, `close`, and `closed` methods.  
+  Those methods would have caused a hard to interpreted error previously. Hence,
+  they have been removed.
 
 
 ## Version 4.4

--- a/bin/make-unasync
+++ b/bin/make-unasync
@@ -214,6 +214,7 @@ def apply_unasync(files):
         "_async": "_sync",
         "mark_async_test": "mark_sync_test",
         "assert_awaited_once": "assert_called_once",
+        "assert_awaited_once_with": "assert_called_once_with",
     }
     additional_testkit_backend_replacements = {}
     rules = [

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -422,16 +422,18 @@ Will result in:
 ***********************
 Sessions & Transactions
 ***********************
-All database activity is co-ordinated through two mechanisms: the :class:`neo4j.Session` and the :class:`neo4j.Transaction`.
+All database activity is co-ordinated through two mechanisms:
+**sessions** (:class:`neo4j.AsyncSession`) and **transactions**
+(:class:`neo4j.Transaction`, :class:`neo4j.ManagedTransaction`).
 
-A :class:`neo4j.Session` is a logical container for any number of causally-related transactional units of work.
+A **session** is a logical container for any number of causally-related transactional units of work.
 Sessions automatically provide guarantees of causal consistency within a clustered environment but multiple sessions can also be causally chained if required.
 Sessions provide the top level of containment for database activity.
 Session creation is a lightweight operation and *sessions are not thread safe*.
 
 Connections are drawn from the :class:`neo4j.Driver` connection pool as required.
 
-A :class:`neo4j.Transaction` is a unit of work that is either committed in its entirety or is rolled back on failure.
+A **transaction** is a unit of work that is either committed in its entirety or is rolled back on failure.
 
 
 .. _session-construction-ref:
@@ -724,7 +726,6 @@ Example:
             node_id = create_person_node(tx)
             set_person_name(tx, node_id, name)
             tx.commit()
-            tx.close()
 
     def create_person_node(tx):
         query = "CREATE (a:Person { name: $name }) RETURN id(a) AS node_id"
@@ -752,6 +753,12 @@ These allow a function object representing the transactional unit of work to be 
 This function is called one or more times, within a configurable time limit, until it succeeds.
 Results should be fully consumed within the function and only aggregate or status values should be returned.
 Returning a live result object would prevent the driver from correctly managing connections and would break retry guarantees.
+
+This function will receive a :class:`neo4j.ManagedTransaction` object as its first parameter.
+
+.. autoclass:: neo4j.ManagedTransaction
+
+    .. automethod:: run
 
 Example:
 
@@ -811,7 +818,7 @@ A :class:`neo4j.Result` is attached to an active connection, through a :class:`n
 
     .. automethod:: closed
 
-See https://neo4j.com/docs/driver-manual/current/cypher-workflow/#driver-type-mapping for more about type mapping.
+See https://neo4j.com/docs/python-manual/current/cypher-workflow/#python-driver-type-mapping for more about type mapping.
 
 
 Graph

--- a/docs/source/async_api.rst
+++ b/docs/source/async_api.rst
@@ -235,16 +235,18 @@ Will result in:
 *********************************
 AsyncSessions & AsyncTransactions
 *********************************
-All database activity is co-ordinated through two mechanisms: the :class:`neo4j.AsyncSession` and the :class:`neo4j.AsyncTransaction`.
+All database activity is co-ordinated through two mechanisms:
+**sessions** (:class:`neo4j.AsyncSession`) and **transactions**
+(:class:`neo4j.AsyncTransaction`, :class:`neo4j.AsyncManagedTransaction`).
 
-A :class:`neo4j.AsyncSession` is a logical container for any number of causally-related transactional units of work.
+A **session** is a logical container for any number of causally-related transactional units of work.
 Sessions automatically provide guarantees of causal consistency within a clustered environment but multiple sessions can also be causally chained if required.
 Sessions provide the top level of containment for database activity.
-Session creation is a lightweight operation and *sessions cannot be shared between coroutines*.
+Session creation is a lightweight operation and *sessions are not thread safe*.
 
 Connections are drawn from the :class:`neo4j.AsyncDriver` connection pool as required.
 
-A :class:`neo4j.AsyncTransaction` is a unit of work that is either committed in its entirety or is rolled back on failure.
+A **transaction** is a unit of work that is either committed in its entirety or is rolled back on failure.
 
 
 .. _async-session-construction-ref:
@@ -417,7 +419,6 @@ Example:
             node_id = await create_person_node(tx)
             await set_person_name(tx, node_id, name)
             await tx.commit()
-            await tx.close()
 
     async def create_person_node(tx):
         query = "CREATE (a:Person { name: $name }) RETURN id(a) AS node_id"
@@ -446,6 +447,12 @@ These allow a function object representing the transactional unit of work to be 
 This function is called one or more times, within a configurable time limit, until it succeeds.
 Results should be fully consumed within the function and only aggregate or status values should be returned.
 Returning a live result object would prevent the driver from correctly managing connections and would break retry guarantees.
+
+This function will receive a :class:`neo4j.AsyncManagedTransaction` object as its first parameter.
+
+.. autoclass:: neo4j.AsyncManagedTransaction
+
+    .. automethod:: run
 
 Example:
 
@@ -505,4 +512,4 @@ A :class:`neo4j.AsyncResult` is attached to an active connection, through a :cla
 
     .. automethod:: closed
 
-See https://neo4j.com/docs/driver-manual/current/cypher-workflow/#driver-type-mapping for more about type mapping.
+See https://neo4j.com/docs/python-manual/current/cypher-workflow/#python-driver-type-mapping for more about type mapping.

--- a/neo4j/__init__.py
+++ b/neo4j/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "AsyncDriver",
     "AsyncGraphDatabase",
     "AsyncNeo4jDriver",
+    "AsyncManagedTransaction",
     "AsyncResult",
     "AsyncSession",
     "AsyncTransaction",
@@ -42,6 +43,7 @@ __all__ = [
     "IPv4Address",
     "IPv6Address",
     "kerberos_auth",
+    "ManagedTransaction",
     "Neo4jDriver",
     "PoolConfig",
     "Query",
@@ -72,6 +74,7 @@ from ._async.driver import (
     AsyncNeo4jDriver,
 )
 from ._async.work import (
+    AsyncManagedTransaction,
     AsyncResult,
     AsyncSession,
     AsyncTransaction,
@@ -83,6 +86,7 @@ from ._sync.driver import (
     Neo4jDriver,
 )
 from ._sync.work import (
+    ManagedTransaction,
     Result,
     Session,
     Transaction,

--- a/neo4j/_async/work/__init__.py
+++ b/neo4j/_async/work/__init__.py
@@ -19,8 +19,11 @@
 from .session import (
     AsyncResult,
     AsyncSession,
-    AsyncTransaction,
     AsyncWorkspace,
+)
+from .transaction import (
+    AsyncManagedTransaction,
+    AsyncTransaction,
 )
 
 
@@ -28,5 +31,6 @@ __all__ = [
     "AsyncResult",
     "AsyncSession",
     "AsyncTransaction",
+    "AsyncManagedTransaction",
     "AsyncWorkspace",
 ]

--- a/neo4j/_sync/work/__init__.py
+++ b/neo4j/_sync/work/__init__.py
@@ -19,8 +19,11 @@
 from .session import (
     Result,
     Session,
-    Transaction,
     Workspace,
+)
+from .transaction import (
+    ManagedTransaction,
+    Transaction,
 )
 
 
@@ -28,5 +31,6 @@ __all__ = [
     "Result",
     "Session",
     "Transaction",
+    "ManagedTransaction",
     "Workspace",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,6 @@ multi_line_output=3
 order_by_type=false
 remove_redundant_aliases=true
 use_parentheses=true
+
+[tool:pytest]
+mock_use_standalone_module = true

--- a/testkitbackend/_async/requests.py
+++ b/testkitbackend/_async/requests.py
@@ -26,6 +26,7 @@ from .. import (
     fromtestkit,
     totestkit,
 )
+from ..exceptions import MarkdAsDriverException
 
 
 class FrontendError(Exception):
@@ -355,21 +356,36 @@ async def TransactionRun(backend, data):
 async def TransactionCommit(backend, data):
     key = data["txId"]
     tx = backend.transactions[key]
-    await tx.commit()
+    try:
+        commit = tx.commit
+    except AttributeError as e:
+        raise MarkdAsDriverException(e)
+        # raise DriverError("Type does not support commit %s" % type(tx))
+    await commit()
     await backend.send_response("Transaction", {"id": key})
 
 
 async def TransactionRollback(backend, data):
     key = data["txId"]
     tx = backend.transactions[key]
-    await tx.rollback()
+    try:
+        rollback = tx.rollback
+    except AttributeError as e:
+        raise MarkdAsDriverException(e)
+        # raise DriverError("Type does not support rollback %s" % type(tx))
+    await rollback()
     await backend.send_response("Transaction", {"id": key})
 
 
 async def TransactionClose(backend, data):
     key = data["txId"]
     tx = backend.transactions[key]
-    await tx.close()
+    try:
+        close = tx.close
+    except AttributeError as e:
+        raise MarkdAsDriverException(e)
+        # raise DriverError("Type does not support close %s" % type(tx))
+    await close()
     await backend.send_response("Transaction", {"id": key})
 
 

--- a/testkitbackend/_sync/backend.py
+++ b/testkitbackend/_sync/backend.py
@@ -41,6 +41,7 @@ from .._driver_logger import (
     log,
 )
 from ..backend import Request
+from ..exceptions import MarkdAsDriverException
 
 
 TESTKIT_BACKEND_PATH = Path(__file__).absolute().resolve().parents[1]
@@ -96,18 +97,29 @@ class Backend:
             if DRIVER_PATH in p.parents:
                 return True
 
-    def _handle_driver_exc(self, exc):
+    def write_driver_exc(self, exc):
         log.debug(traceback.format_exc())
-        if isinstance(exc, Neo4jError):
-            msg = "" if exc.message is None else str(exc.message)
-        else:
-            msg = str(exc.args[0]) if exc.args else ""
 
         key = self.next_key()
         self.errors[key] = exc
-        payload = {"id": key, "errorType": str(type(exc)), "msg": msg}
-        if isinstance(exc, Neo4jError):
-            payload["code"] = exc.code
+
+        payload = {"id": key, "msg": ""}
+
+        if isinstance(exc, MarkdAsDriverException):
+            wrapped_exc = exc.wrapped_exc
+            payload["errorType"] = str(type(wrapped_exc))
+            if wrapped_exc.args:
+                payload["msg"] = str(wrapped_exc.args[0])
+        else:
+            payload["errorType"] = str(type(exc))
+            if isinstance(exc, Neo4jError) and exc.message is not None:
+                payload["msg"] = str(exc.message)
+            elif exc.args:
+                payload["msg"] = str(exc.args[0])
+
+            if isinstance(exc, Neo4jError):
+                payload["code"] = exc.code
+
         self.send_response("DriverError", payload)
 
     def _process(self, request):
@@ -132,13 +144,13 @@ class Backend:
                     " request: " + ", ".join(unsused_keys)
                 )
         except (Neo4jError, DriverError, UnsupportedServerProduct,
-                BoltError) as e:
-            self._handle_driver_exc(e)
+                BoltError, MarkdAsDriverException) as e:
+            self.write_driver_exc(e)
         except requests.FrontendError as e:
             self.send_response("FrontendError", {"msg": str(e)})
         except Exception as e:
             if self._exc_stems_from_driver(e):
-                self._handle_driver_exc(e)
+                self.write_driver_exc(e)
             else:
                 tb = traceback.format_exc()
                 log.error(tb)

--- a/testkitbackend/_sync/requests.py
+++ b/testkitbackend/_sync/requests.py
@@ -26,6 +26,7 @@ from .. import (
     fromtestkit,
     totestkit,
 )
+from ..exceptions import MarkdAsDriverException
 
 
 class FrontendError(Exception):
@@ -355,21 +356,36 @@ def TransactionRun(backend, data):
 def TransactionCommit(backend, data):
     key = data["txId"]
     tx = backend.transactions[key]
-    tx.commit()
+    try:
+        commit = tx.commit
+    except AttributeError as e:
+        raise MarkdAsDriverException(e)
+        # raise DriverError("Type does not support commit %s" % type(tx))
+    commit()
     backend.send_response("Transaction", {"id": key})
 
 
 def TransactionRollback(backend, data):
     key = data["txId"]
     tx = backend.transactions[key]
-    tx.rollback()
+    try:
+        rollback = tx.rollback
+    except AttributeError as e:
+        raise MarkdAsDriverException(e)
+        # raise DriverError("Type does not support rollback %s" % type(tx))
+    rollback()
     backend.send_response("Transaction", {"id": key})
 
 
 def TransactionClose(backend, data):
     key = data["txId"]
     tx = backend.transactions[key]
-    tx.close()
+    try:
+        close = tx.close
+    except AttributeError as e:
+        raise MarkdAsDriverException(e)
+        # raise DriverError("Type does not support close %s" % type(tx))
+    close()
     backend.send_response("Transaction", {"id": key})
 
 

--- a/testkitbackend/exceptions.py
+++ b/testkitbackend/exceptions.py
@@ -16,7 +16,10 @@
 # limitations under the License.
 
 
-from ._fake_connection import (
-    fake_connection,
-    fake_connection_generator,
-)
+class MarkdAsDriverException(Exception):
+    """
+    Wrap any error as DriverException
+    """
+    def __init__(self, wrapped_exc):
+        super().__init__()
+        self.wrapped_exc = wrapped_exc

--- a/tests/_async_compat/__init__.py
+++ b/tests/_async_compat/__init__.py
@@ -16,37 +16,13 @@
 # limitations under the License.
 
 
-import sys
-
-
-if sys.version_info >= (3, 8):
-    from unittest import mock
-    from unittest.mock import AsyncMockMixin
-else:
-    import mock
-    from mock.mock import AsyncMockMixin
-
 from .mark_decorator import (
     mark_async_test,
     mark_sync_test,
 )
 
 
-AsyncMagicMock = mock.AsyncMock
-MagicMock = mock.MagicMock
-Mock = mock.Mock
-
-
-class AsyncMock(AsyncMockMixin, Mock):
-    pass
-
-
 __all__ = [
     "mark_async_test",
     "mark_sync_test",
-    "AsyncMagicMock",
-    "AsyncMock",
-    "MagicMock",
-    "Mock",
-    "mock",
 ]

--- a/tests/integration/async_/test_custom_ssl_context.py
+++ b/tests/integration/async_/test_custom_ssl_context.py
@@ -21,21 +21,18 @@ import pytest
 
 from neo4j import AsyncGraphDatabase
 
-from ..._async_compat import (
-    mark_async_test,
-    mock,
-)
+from ..._async_compat import mark_async_test
 
 
 @mark_async_test
-async def test_custom_ssl_context_is_wraps_connection(target, auth):
+async def test_custom_ssl_context_is_wraps_connection(target, auth, mocker):
     class NoNeedToGoFurtherException(Exception):
         pass
 
     def wrap_fail(*_, **__):
         raise NoNeedToGoFurtherException()
 
-    fake_ssl_context = mock.create_autospec(SSLContext)
+    fake_ssl_context = mocker.create_autospec(SSLContext)
     fake_ssl_context.wrap_socket.side_effect = wrap_fail
     fake_ssl_context.wrap_bio.side_effect = wrap_fail
     driver = AsyncGraphDatabase.neo4j_driver(

--- a/tests/integration/sync/test_custom_ssl_context.py
+++ b/tests/integration/sync/test_custom_ssl_context.py
@@ -21,21 +21,18 @@ import pytest
 
 from neo4j import GraphDatabase
 
-from ..._async_compat import (
-    mark_sync_test,
-    mock,
-)
+from ..._async_compat import mark_sync_test
 
 
 @mark_sync_test
-def test_custom_ssl_context_is_wraps_connection(target, auth):
+def test_custom_ssl_context_is_wraps_connection(target, auth, mocker):
     class NoNeedToGoFurtherException(Exception):
         pass
 
     def wrap_fail(*_, **__):
         raise NoNeedToGoFurtherException()
 
-    fake_ssl_context = mock.create_autospec(SSLContext)
+    fake_ssl_context = mocker.create_autospec(SSLContext)
     fake_ssl_context.wrap_socket.side_effect = wrap_fail
     fake_ssl_context.wrap_bio.side_effect = wrap_fail
     driver = GraphDatabase.neo4j_driver(

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,6 +5,5 @@ pytest-asyncio>=0.16.0
 pytest-benchmark>=3.4.1
 pytest-cov>=3.0.0
 pytest-mock>=3.6.1
-# brings mock.AsyncMock to Python 3.7 (3.8+ ships with built-in support)
-mock>=4.0.3; python_version < '3.8'
+mock>=4.0.3
 teamcity-messages>=1.29

--- a/tests/unit/async_/io/test_class_bolt3.py
+++ b/tests/unit/async_/io/test_class_bolt3.py
@@ -22,10 +22,7 @@ from neo4j._async.io._bolt3 import AsyncBolt3
 from neo4j.conf import PoolConfig
 from neo4j.exceptions import ConfigurationError
 
-from ...._async_compat import (
-    AsyncMagicMock,
-    mark_async_test,
-)
+from ...._async_compat import mark_async_test
 
 
 @pytest.mark.parametrize("set_stale", (True, False))
@@ -99,11 +96,11 @@ async def test_simple_pull(fake_socket):
 @pytest.mark.parametrize("recv_timeout", (1, -1))
 @mark_async_test
 async def test_hint_recv_timeout_seconds_gets_ignored(
-    fake_socket_pair, recv_timeout
+    fake_socket_pair, recv_timeout, mocker
 ):
     address = ("127.0.0.1", 7687)
     sockets = fake_socket_pair(address)
-    sockets.client.settimeout = AsyncMagicMock()
+    sockets.client.settimeout = mocker.AsyncMock()
     await sockets.server.send_message(0x70, {
         "server": "Neo4j/3.5.0",
         "hints": {"connection.recv_timeout_seconds": recv_timeout},

--- a/tests/unit/async_/io/test_class_bolt4x0.py
+++ b/tests/unit/async_/io/test_class_bolt4x0.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from neo4j._async.io._bolt4 import AsyncBolt4x0
@@ -193,11 +191,11 @@ async def test_n_and_qid_extras_in_pull(fake_socket):
 @pytest.mark.parametrize("recv_timeout", (1, -1))
 @mark_async_test
 async def test_hint_recv_timeout_seconds_gets_ignored(
-    fake_socket_pair, recv_timeout
+    fake_socket_pair, recv_timeout, mocker
 ):
     address = ("127.0.0.1", 7687)
     sockets = fake_socket_pair(address)
-    sockets.client.settimeout = MagicMock()
+    sockets.client.settimeout = mocker.MagicMock()
     await sockets.server.send_message(0x70, {
         "server": "Neo4j/4.0.0",
         "hints": {"connection.recv_timeout_seconds": recv_timeout},

--- a/tests/unit/async_/io/test_class_bolt4x1.py
+++ b/tests/unit/async_/io/test_class_bolt4x1.py
@@ -21,10 +21,7 @@ import pytest
 from neo4j._async.io._bolt4 import AsyncBolt4x1
 from neo4j.conf import PoolConfig
 
-from ...._async_compat import (
-    AsyncMagicMock,
-    mark_async_test,
-)
+from ...._async_compat import mark_async_test
 
 
 @pytest.mark.parametrize("set_stale", (True, False))
@@ -212,11 +209,11 @@ async def test_hello_passes_routing_metadata(fake_socket_pair):
 @pytest.mark.parametrize("recv_timeout", (1, -1))
 @mark_async_test
 async def test_hint_recv_timeout_seconds_gets_ignored(
-    fake_socket_pair, recv_timeout
+    fake_socket_pair, recv_timeout, mocker
 ):
     address = ("127.0.0.1", 7687)
     sockets = fake_socket_pair(address)
-    sockets.client.settimeout = AsyncMagicMock()
+    sockets.client.settimeout = mocker.AsyncMock()
     await sockets.server.send_message(0x70, {
         "server": "Neo4j/4.1.0",
         "hints": {"connection.recv_timeout_seconds": recv_timeout},

--- a/tests/unit/async_/io/test_class_bolt4x2.py
+++ b/tests/unit/async_/io/test_class_bolt4x2.py
@@ -21,10 +21,7 @@ import pytest
 from neo4j._async.io._bolt4 import AsyncBolt4x2
 from neo4j.conf import PoolConfig
 
-from ...._async_compat import (
-    AsyncMagicMock,
-    mark_async_test,
-)
+from ...._async_compat import mark_async_test
 
 
 @pytest.mark.parametrize("set_stale", (True, False))
@@ -212,11 +209,11 @@ async def test_hello_passes_routing_metadata(fake_socket_pair):
 @pytest.mark.parametrize("recv_timeout", (1, -1))
 @mark_async_test
 async def test_hint_recv_timeout_seconds_gets_ignored(
-    fake_socket_pair, recv_timeout
+    fake_socket_pair, recv_timeout, mocker
 ):
     address = ("127.0.0.1", 7687)
     sockets = fake_socket_pair(address)
-    sockets.client.settimeout = AsyncMagicMock()
+    sockets.client.settimeout = mocker.AsyncMock()
     await sockets.server.send_message(0x70, {
         "server": "Neo4j/4.2.0",
         "hints": {"connection.recv_timeout_seconds": recv_timeout},

--- a/tests/unit/async_/io/test_class_bolt4x3.py
+++ b/tests/unit/async_/io/test_class_bolt4x3.py
@@ -23,10 +23,7 @@ import pytest
 from neo4j._async.io._bolt4 import AsyncBolt4x3
 from neo4j.conf import PoolConfig
 
-from ...._async_compat import (
-    AsyncMagicMock,
-    mark_async_test,
-)
+from ...._async_compat import mark_async_test
 
 
 @pytest.mark.parametrize("set_stale", (True, False))
@@ -225,16 +222,17 @@ async def test_hello_passes_routing_metadata(fake_socket_pair):
 ))
 @mark_async_test
 async def test_hint_recv_timeout_seconds(
-    fake_socket_pair, hints, valid, caplog
+    fake_socket_pair, hints, valid, caplog, mocker
 ):
     address = ("127.0.0.1", 7687)
     sockets = fake_socket_pair(address)
-    sockets.client.settimeout = AsyncMagicMock()
+    sockets.client.settimeout = mocker.AsyncMock()
     await sockets.server.send_message(
         0x70, {"server": "Neo4j/4.3.0", "hints": hints}
     )
-    connection = AsyncBolt4x3(address, sockets.client,
-                         PoolConfig.max_connection_lifetime)
+    connection = AsyncBolt4x3(
+        address, sockets.client, PoolConfig.max_connection_lifetime
+    )
     with caplog.at_level(logging.INFO):
         await connection.hello()
     if valid:

--- a/tests/unit/async_/io/test_class_bolt4x4.py
+++ b/tests/unit/async_/io/test_class_bolt4x4.py
@@ -17,17 +17,13 @@
 
 
 import logging
-from unittest.mock import MagicMock
 
 import pytest
 
 from neo4j._async.io._bolt4 import AsyncBolt4x4
 from neo4j.conf import PoolConfig
 
-from ...._async_compat import (
-    AsyncMagicMock,
-    mark_async_test,
-)
+from ...._async_compat import mark_async_test
 
 
 @pytest.mark.parametrize("set_stale", (True, False))
@@ -240,11 +236,11 @@ async def test_hello_passes_routing_metadata(fake_socket_pair):
 ))
 @mark_async_test
 async def test_hint_recv_timeout_seconds(
-    fake_socket_pair, hints, valid, caplog
+    fake_socket_pair, hints, valid, caplog, mocker
 ):
     address = ("127.0.0.1", 7687)
     sockets = fake_socket_pair(address)
-    sockets.client.settimeout = MagicMock()
+    sockets.client.settimeout = mocker.MagicMock()
     await sockets.server.send_message(
         0x70, {"server": "Neo4j/4.3.4", "hints": hints}
     )

--- a/tests/unit/async_/test_addressing.py
+++ b/tests/unit/async_/test_addressing.py
@@ -20,7 +20,6 @@ from socket import (
     AF_INET,
     AF_INET6,
 )
-import unittest.mock as mock
 
 import pytest
 
@@ -32,13 +31,6 @@ from neo4j._async_compat.network import AsyncNetworkUtil
 from neo4j._async_compat.util import AsyncUtil
 
 from ..._async_compat import mark_async_test
-
-
-mock_socket_ipv4 = mock.Mock()
-mock_socket_ipv4.getpeername = lambda: ("127.0.0.1", 7687)  # (address, port)
-
-mock_socket_ipv6 = mock.Mock()
-mock_socket_ipv6.getpeername = lambda: ("[::1]", 7687, 0, 0)  # (address, port, flow info, scope id)
 
 
 @mark_async_test

--- a/tests/unit/async_/test_driver.py
+++ b/tests/unit/async_/test_driver.py
@@ -33,11 +33,7 @@ from neo4j.api import (
 )
 from neo4j.exceptions import ConfigurationError
 
-from ..._async_compat import (
-    mark_async_test,
-    mock,
-)
-from .work import AsyncFakeConnection
+from ..._async_compat import mark_async_test
 
 
 @pytest.mark.parametrize("protocol", ("bolt://", "bolt+s://", "bolt+ssc://"))
@@ -58,7 +54,8 @@ async def test_direct_driver_constructor(protocol, host, port, params, auth_toke
     await driver.close()
 
 
-@pytest.mark.parametrize("protocol", ("neo4j://", "neo4j+s://", "neo4j+ssc://"))
+@pytest.mark.parametrize("protocol",
+                         ("neo4j://", "neo4j+s://", "neo4j+ssc://"))
 @pytest.mark.parametrize("host", ("localhost", "127.0.0.1",
                                   "[::1]", "[0:0:0:0:0:0:0:1]"))
 @pytest.mark.parametrize("port", (":1234", "", ":7687"))
@@ -175,28 +172,26 @@ async def test_driver_opens_write_session_by_default(uri, mocker):
     # to get hold of the actual home database (which won't work in this
     # unittest)
     async with driver.session(database="foobar") as session:
-        with mock.patch.object(
-            session._pool, "acquire", autospec=True
-        ) as acquire_mock:
-            with mock.patch.object(
-                AsyncTransaction, "_begin", autospec=True
-            ) as tx_begin_mock:
-                tx = await session.begin_transaction()
-        acquire_mock.assert_called_once_with(
-            access_mode=WRITE_ACCESS,
-            timeout=mocker.ANY,
-            database=mocker.ANY,
-            bookmarks=mocker.ANY
-        )
-        tx_begin_mock.assert_called_once_with(
-            tx,
-            mocker.ANY,
-            mocker.ANY,
-            mocker.ANY,
-            WRITE_ACCESS,
-            mocker.ANY,
-            mocker.ANY
-        )
+        acquire_mock = mocker.patch.object(session._pool, "acquire",
+                                           autospec=True)
+        tx_begin_mock = mocker.patch.object(AsyncTransaction, "_begin",
+                                            autospec=True)
+        tx = await session.begin_transaction()
+    acquire_mock.assert_called_once_with(
+        access_mode=WRITE_ACCESS,
+        timeout=mocker.ANY,
+        database=mocker.ANY,
+        bookmarks=mocker.ANY
+    )
+    tx_begin_mock.assert_called_once_with(
+        tx,
+        mocker.ANY,
+        mocker.ANY,
+        mocker.ANY,
+        WRITE_ACCESS,
+        mocker.ANY,
+        mocker.ANY
+    )
 
     await driver.close()
 
@@ -206,12 +201,12 @@ async def test_driver_opens_write_session_by_default(uri, mocker):
     "neo4j://127.0.0.1:9000",
 ))
 @mark_async_test
-async def test_verify_connectivity(uri):
+async def test_verify_connectivity(uri, mocker):
     driver = AsyncGraphDatabase.driver(uri)
+    pool_mock = mocker.patch.object(driver, "_pool", autospec=True)
 
     try:
-        with mock.patch.object(driver, "_pool", autospec=True) as pool_mock:
-            ret = await driver.verify_connectivity()
+        ret = await driver.verify_connectivity()
     finally:
         await driver.close()
 
@@ -231,12 +226,13 @@ async def test_verify_connectivity(uri):
     {"fetch_size": 69},
 ))
 @mark_async_test
-async def test_verify_connectivity_parameters_are_deprecated(uri, kwargs):
+async def test_verify_connectivity_parameters_are_deprecated(uri, kwargs,
+                                                             mocker):
     driver = AsyncGraphDatabase.driver(uri)
+    mocker.patch.object(driver, "_pool", autospec=True)
 
     try:
-        with mock.patch.object(driver, "_pool", autospec=True):
-            with pytest.warns(DeprecationWarning, match="configuration"):
-                await driver.verify_connectivity(**kwargs)
+        with pytest.warns(DeprecationWarning, match="configuration"):
+            await driver.verify_connectivity(**kwargs)
     finally:
         await driver.close()

--- a/tests/unit/async_/work/__init__.py
+++ b/tests/unit/async_/work/__init__.py
@@ -18,5 +18,5 @@
 
 from ._fake_connection import (
     async_fake_connection,
-    AsyncFakeConnection,
+    async_fake_connection_generator,
 )

--- a/tests/unit/async_/work/conftest.py
+++ b/tests/unit/async_/work/conftest.py
@@ -1,0 +1,4 @@
+from ._fake_connection import (
+    async_fake_connection,
+    async_fake_connection_generator,
+)

--- a/tests/unit/async_/work/test_transaction.py
+++ b/tests/unit/async_/work/test_transaction.py
@@ -22,11 +22,11 @@ from uuid import uuid4
 import pytest
 
 from neo4j import (
+    AsyncTransaction,
     Query,
-    Transaction,
 )
 
-from ._fake_connection import async_fake_connection
+from ...._async_compat import mark_async_test
 
 
 @pytest.mark.parametrize(("explicit_commit", "close"), (
@@ -34,25 +34,27 @@ from ._fake_connection import async_fake_connection
     (True, False),
     (True, True),
 ))
-def test_transaction_context_when_committing(mocker, async_fake_connection,
-                                             explicit_commit, close):
-    on_closed = MagicMock()
-    on_error = MagicMock()
-    tx = Transaction(async_fake_connection, 2, on_closed, on_error)
-    mock_commit = mocker.patch.object(tx, "commit", wraps=tx.commit)
-    mock_rollback = mocker.patch.object(tx, "rollback", wraps=tx.rollback)
-    with tx as tx_:
+@mark_async_test
+async def test_transaction_context_when_committing(
+    mocker, async_fake_connection, explicit_commit, close
+):
+    on_closed = mocker.AsyncMock()
+    on_error = mocker.AsyncMock()
+    tx = AsyncTransaction(async_fake_connection, 2, on_closed, on_error)
+    mock_commit = mocker.patch.object(tx, "_commit", wraps=tx._commit)
+    mock_rollback = mocker.patch.object(tx, "_rollback", wraps=tx._rollback)
+    async with tx as tx_:
         assert mock_commit.call_count == 0
         assert mock_rollback.call_count == 0
         assert tx is tx_
         if explicit_commit:
-            tx_.commit()
-            mock_commit.assert_called_once_with()
-            assert tx.closed()
-        if close:
-            tx_.close()
+            await tx_.commit()
+            mock_commit.assert_awaited_once_with()
             assert tx_.closed()
-    mock_commit.assert_called_once_with()
+        if close:
+            await tx_.close()
+            assert tx_.closed()
+    mock_commit.assert_awaited_once_with()
     assert mock_rollback.call_count == 0
     assert tx_.closed()
 
@@ -62,47 +64,52 @@ def test_transaction_context_when_committing(mocker, async_fake_connection,
     (False, True),
     (True, True),
 ))
-def test_transaction_context_with_explicit_rollback(mocker, async_fake_connection,
-                                                    rollback, close):
-    on_closed = MagicMock()
-    on_error = MagicMock()
-    tx = Transaction(async_fake_connection, 2, on_closed, on_error)
-    mock_commit = mocker.patch.object(tx, "commit", wraps=tx.commit)
-    mock_rollback = mocker.patch.object(tx, "rollback", wraps=tx.rollback)
-    with tx as tx_:
+@mark_async_test
+async def test_transaction_context_with_explicit_rollback(
+    mocker, async_fake_connection, rollback, close
+):
+    on_closed = mocker.AsyncMock()
+    on_error = mocker.AsyncMock()
+    tx = AsyncTransaction(async_fake_connection, 2, on_closed, on_error)
+    mock_commit = mocker.patch.object(tx, "_commit", wraps=tx._commit)
+    mock_rollback = mocker.patch.object(tx, "_rollback", wraps=tx._rollback)
+    async with tx as tx_:
         assert mock_commit.call_count == 0
         assert mock_rollback.call_count == 0
         assert tx is tx_
         if rollback:
-            tx_.rollback()
-            mock_rollback.assert_called_once_with()
+            await tx_.rollback()
+            mock_rollback.assert_awaited_once_with()
             assert tx_.closed()
         if close:
-            tx_.close()
-            mock_rollback.assert_called_once_with()
+            await tx_.close()
+            mock_rollback.assert_awaited_once_with()
             assert tx_.closed()
     assert mock_commit.call_count == 0
-    mock_rollback.assert_called_once_with()
+    mock_rollback.assert_awaited_once_with()
     assert tx_.closed()
 
 
-def test_transaction_context_calls_rollback_on_error(mocker, async_fake_connection):
+@mark_async_test
+async def test_transaction_context_calls_rollback_on_error(
+    mocker, async_fake_connection
+):
     class OopsError(RuntimeError):
         pass
 
     on_closed = MagicMock()
     on_error = MagicMock()
-    tx = Transaction(async_fake_connection, 2, on_closed, on_error)
-    mock_commit = mocker.patch.object(tx, "commit", wraps=tx.commit)
-    mock_rollback = mocker.patch.object(tx, "rollback", wraps=tx.rollback)
+    tx = AsyncTransaction(async_fake_connection, 2, on_closed, on_error)
+    mock_commit = mocker.patch.object(tx, "_commit", wraps=tx._commit)
+    mock_rollback = mocker.patch.object(tx, "_rollback", wraps=tx._rollback)
     with pytest.raises(OopsError):
-        with tx as tx_:
+        async with tx as tx_:
             assert mock_commit.call_count == 0
             assert mock_rollback.call_count == 0
             assert tx is tx_
             raise OopsError
     assert mock_commit.call_count == 0
-    mock_rollback.assert_called_once_with()
+    mock_rollback.assert_awaited_once_with()
     assert tx_.closed()
 
 
@@ -112,74 +119,93 @@ def test_transaction_context_calls_rollback_on_error(mocker, async_fake_connecti
     ({"x": {(1, 2): '1+2i', (2, 0): '2'}}, TypeError),
     ({"x": uuid4()}, TypeError),
 ))
-def test_transaction_run_with_invalid_parameters(async_fake_connection, parameters,
-                                                 error_type):
+@mark_async_test
+async def test_transaction_run_with_invalid_parameters(
+    async_fake_connection, parameters, error_type
+):
     on_closed = MagicMock()
     on_error = MagicMock()
-    tx = Transaction(async_fake_connection, 2, on_closed, on_error)
+    tx = AsyncTransaction(async_fake_connection, 2, on_closed, on_error)
     with pytest.raises(error_type):
-        tx.run("RETURN $x", **parameters)
+        await tx.run("RETURN $x", **parameters)
 
 
-def test_transaction_run_takes_no_query_object(async_fake_connection):
+@mark_async_test
+async def test_transaction_run_takes_no_query_object(async_fake_connection):
     on_closed = MagicMock()
     on_error = MagicMock()
-    tx = Transaction(async_fake_connection, 2, on_closed, on_error)
+    tx = AsyncTransaction(async_fake_connection, 2, on_closed, on_error)
     with pytest.raises(ValueError):
-        tx.run(Query("RETURN 1"))
+        await tx.run(Query("RETURN 1"))
 
 
-def test_transaction_rollbacks_on_open_connections(async_fake_connection):
-    tx = Transaction(async_fake_connection, 2,
-                     lambda *args, **kwargs: None,
-                     lambda *args, **kwargs: None)
-    with tx as tx_:
+@mark_async_test
+async def test_transaction_rollbacks_on_open_connections(
+    async_fake_connection
+):
+    tx = AsyncTransaction(
+        async_fake_connection, 2, lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None
+    )
+    async with tx as tx_:
         async_fake_connection.is_reset_mock.return_value = False
         async_fake_connection.is_reset_mock.reset_mock()
-        tx_.rollback()
+        await tx_.rollback()
         async_fake_connection.is_reset_mock.assert_called_once()
         async_fake_connection.reset.assert_not_called()
         async_fake_connection.rollback.assert_called_once()
 
 
-def test_transaction_no_rollback_on_reset_connections(async_fake_connection):
-    tx = Transaction(async_fake_connection, 2,
-                     lambda *args, **kwargs: None,
-                     lambda *args, **kwargs: None)
-    with tx as tx_:
+@mark_async_test
+async def test_transaction_no_rollback_on_reset_connections(
+    async_fake_connection
+):
+    tx = AsyncTransaction(
+        async_fake_connection, 2, lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None
+    )
+    async with tx as tx_:
         async_fake_connection.is_reset_mock.return_value = True
         async_fake_connection.is_reset_mock.reset_mock()
-        tx_.rollback()
+        await tx_.rollback()
         async_fake_connection.is_reset_mock.assert_called_once()
-        async_fake_connection.reset.asset_not_called()
-        async_fake_connection.rollback.asset_not_called()
+        async_fake_connection.reset.assert_not_called()
+        async_fake_connection.rollback.assert_not_called()
 
 
-def test_transaction_no_rollback_on_closed_connections(async_fake_connection):
-    tx = Transaction(async_fake_connection, 2,
-                     lambda *args, **kwargs: None,
-                     lambda *args, **kwargs: None)
-    with tx as tx_:
+@mark_async_test
+async def test_transaction_no_rollback_on_closed_connections(
+    async_fake_connection
+):
+    tx = AsyncTransaction(
+        async_fake_connection, 2, lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None
+    )
+    async with tx as tx_:
         async_fake_connection.closed.return_value = True
         async_fake_connection.closed.reset_mock()
         async_fake_connection.is_reset_mock.reset_mock()
-        tx_.rollback()
+        await tx_.rollback()
         async_fake_connection.closed.assert_called_once()
-        async_fake_connection.is_reset_mock.asset_not_called()
-        async_fake_connection.reset.asset_not_called()
-        async_fake_connection.rollback.asset_not_called()
+        async_fake_connection.is_reset_mock.assert_not_called()
+        async_fake_connection.reset.assert_not_called()
+        async_fake_connection.rollback.assert_not_called()
 
 
-def test_transaction_no_rollback_on_defunct_connections(async_fake_connection):
-    tx = Transaction(async_fake_connection, 2,
-                     lambda *args, **kwargs: None,
-                     lambda *args, **kwargs: None)
-    with tx as tx_:
+@mark_async_test
+async def test_transaction_no_rollback_on_defunct_connections(
+    async_fake_connection
+):
+    tx = AsyncTransaction(
+        async_fake_connection, 2, lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None
+    )
+    async with tx as tx_:
         async_fake_connection.defunct.return_value = True
         async_fake_connection.defunct.reset_mock()
         async_fake_connection.is_reset_mock.reset_mock()
-        tx_.rollback()
+        await tx_.rollback()
         async_fake_connection.defunct.assert_called_once()
-        async_fake_connection.is_reset_mock.asset_not_called()
-        async_fake_connection.reset.asset_not_called()
-        async_fake_connection.rollback.asset_not_called()
+        async_fake_connection.is_reset_mock.assert_not_called()
+        async_fake_connection.reset.assert_not_called()
+        async_fake_connection.rollback.assert_not_called()

--- a/tests/unit/mixed/io/test_direct.py
+++ b/tests/unit/mixed/io/test_direct.py
@@ -29,24 +29,10 @@ from threading import (
     Thread,
 )
 import time
-from unittest import (
-    mock,
-    TestCase,
-)
 
 import pytest
 
-from neo4j import (
-    Config,
-    PoolConfig,
-    WorkspaceConfig,
-)
-from neo4j._async.io import AsyncBolt
-from neo4j._async.io._pool import AsyncIOPool
-from neo4j.exceptions import (
-    ClientError,
-    ServiceUnavailable,
-)
+from neo4j.exceptions import ClientError
 
 from ...async_.io.test_direct import AsyncFakeBoltPool
 from ...sync.io.test_direct import FakeBoltPool

--- a/tests/unit/sync/io/test_class_bolt3.py
+++ b/tests/unit/sync/io/test_class_bolt3.py
@@ -22,10 +22,7 @@ from neo4j._sync.io._bolt3 import Bolt3
 from neo4j.conf import PoolConfig
 from neo4j.exceptions import ConfigurationError
 
-from ...._async_compat import (
-    MagicMock,
-    mark_sync_test,
-)
+from ...._async_compat import mark_sync_test
 
 
 @pytest.mark.parametrize("set_stale", (True, False))
@@ -99,11 +96,11 @@ def test_simple_pull(fake_socket):
 @pytest.mark.parametrize("recv_timeout", (1, -1))
 @mark_sync_test
 def test_hint_recv_timeout_seconds_gets_ignored(
-    fake_socket_pair, recv_timeout
+    fake_socket_pair, recv_timeout, mocker
 ):
     address = ("127.0.0.1", 7687)
     sockets = fake_socket_pair(address)
-    sockets.client.settimeout = MagicMock()
+    sockets.client.settimeout = mocker.Mock()
     sockets.server.send_message(0x70, {
         "server": "Neo4j/3.5.0",
         "hints": {"connection.recv_timeout_seconds": recv_timeout},

--- a/tests/unit/sync/io/test_class_bolt4x0.py
+++ b/tests/unit/sync/io/test_class_bolt4x0.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from neo4j._sync.io._bolt4 import Bolt4x0
@@ -193,11 +191,11 @@ def test_n_and_qid_extras_in_pull(fake_socket):
 @pytest.mark.parametrize("recv_timeout", (1, -1))
 @mark_sync_test
 def test_hint_recv_timeout_seconds_gets_ignored(
-    fake_socket_pair, recv_timeout
+    fake_socket_pair, recv_timeout, mocker
 ):
     address = ("127.0.0.1", 7687)
     sockets = fake_socket_pair(address)
-    sockets.client.settimeout = MagicMock()
+    sockets.client.settimeout = mocker.MagicMock()
     sockets.server.send_message(0x70, {
         "server": "Neo4j/4.0.0",
         "hints": {"connection.recv_timeout_seconds": recv_timeout},

--- a/tests/unit/sync/io/test_class_bolt4x1.py
+++ b/tests/unit/sync/io/test_class_bolt4x1.py
@@ -21,10 +21,7 @@ import pytest
 from neo4j._sync.io._bolt4 import Bolt4x1
 from neo4j.conf import PoolConfig
 
-from ...._async_compat import (
-    MagicMock,
-    mark_sync_test,
-)
+from ...._async_compat import mark_sync_test
 
 
 @pytest.mark.parametrize("set_stale", (True, False))
@@ -212,11 +209,11 @@ def test_hello_passes_routing_metadata(fake_socket_pair):
 @pytest.mark.parametrize("recv_timeout", (1, -1))
 @mark_sync_test
 def test_hint_recv_timeout_seconds_gets_ignored(
-    fake_socket_pair, recv_timeout
+    fake_socket_pair, recv_timeout, mocker
 ):
     address = ("127.0.0.1", 7687)
     sockets = fake_socket_pair(address)
-    sockets.client.settimeout = MagicMock()
+    sockets.client.settimeout = mocker.Mock()
     sockets.server.send_message(0x70, {
         "server": "Neo4j/4.1.0",
         "hints": {"connection.recv_timeout_seconds": recv_timeout},

--- a/tests/unit/sync/io/test_class_bolt4x2.py
+++ b/tests/unit/sync/io/test_class_bolt4x2.py
@@ -21,10 +21,7 @@ import pytest
 from neo4j._sync.io._bolt4 import Bolt4x2
 from neo4j.conf import PoolConfig
 
-from ...._async_compat import (
-    MagicMock,
-    mark_sync_test,
-)
+from ...._async_compat import mark_sync_test
 
 
 @pytest.mark.parametrize("set_stale", (True, False))
@@ -212,11 +209,11 @@ def test_hello_passes_routing_metadata(fake_socket_pair):
 @pytest.mark.parametrize("recv_timeout", (1, -1))
 @mark_sync_test
 def test_hint_recv_timeout_seconds_gets_ignored(
-    fake_socket_pair, recv_timeout
+    fake_socket_pair, recv_timeout, mocker
 ):
     address = ("127.0.0.1", 7687)
     sockets = fake_socket_pair(address)
-    sockets.client.settimeout = MagicMock()
+    sockets.client.settimeout = mocker.Mock()
     sockets.server.send_message(0x70, {
         "server": "Neo4j/4.2.0",
         "hints": {"connection.recv_timeout_seconds": recv_timeout},

--- a/tests/unit/sync/io/test_class_bolt4x3.py
+++ b/tests/unit/sync/io/test_class_bolt4x3.py
@@ -23,10 +23,7 @@ import pytest
 from neo4j._sync.io._bolt4 import Bolt4x3
 from neo4j.conf import PoolConfig
 
-from ...._async_compat import (
-    MagicMock,
-    mark_sync_test,
-)
+from ...._async_compat import mark_sync_test
 
 
 @pytest.mark.parametrize("set_stale", (True, False))
@@ -225,16 +222,17 @@ def test_hello_passes_routing_metadata(fake_socket_pair):
 ))
 @mark_sync_test
 def test_hint_recv_timeout_seconds(
-    fake_socket_pair, hints, valid, caplog
+    fake_socket_pair, hints, valid, caplog, mocker
 ):
     address = ("127.0.0.1", 7687)
     sockets = fake_socket_pair(address)
-    sockets.client.settimeout = MagicMock()
+    sockets.client.settimeout = mocker.Mock()
     sockets.server.send_message(
         0x70, {"server": "Neo4j/4.3.0", "hints": hints}
     )
-    connection = Bolt4x3(address, sockets.client,
-                         PoolConfig.max_connection_lifetime)
+    connection = Bolt4x3(
+        address, sockets.client, PoolConfig.max_connection_lifetime
+    )
     with caplog.at_level(logging.INFO):
         connection.hello()
     if valid:

--- a/tests/unit/sync/io/test_class_bolt4x4.py
+++ b/tests/unit/sync/io/test_class_bolt4x4.py
@@ -17,17 +17,13 @@
 
 
 import logging
-from unittest.mock import MagicMock
 
 import pytest
 
 from neo4j._sync.io._bolt4 import Bolt4x4
 from neo4j.conf import PoolConfig
 
-from ...._async_compat import (
-    MagicMock,
-    mark_sync_test,
-)
+from ...._async_compat import mark_sync_test
 
 
 @pytest.mark.parametrize("set_stale", (True, False))
@@ -240,11 +236,11 @@ def test_hello_passes_routing_metadata(fake_socket_pair):
 ))
 @mark_sync_test
 def test_hint_recv_timeout_seconds(
-    fake_socket_pair, hints, valid, caplog
+    fake_socket_pair, hints, valid, caplog, mocker
 ):
     address = ("127.0.0.1", 7687)
     sockets = fake_socket_pair(address)
-    sockets.client.settimeout = MagicMock()
+    sockets.client.settimeout = mocker.MagicMock()
     sockets.server.send_message(
         0x70, {"server": "Neo4j/4.3.4", "hints": hints}
     )

--- a/tests/unit/sync/io/test_neo4j_pool.py
+++ b/tests/unit/sync/io/test_neo4j_pool.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 
-from unittest.mock import Mock
-
 import pytest
 
 from neo4j import (
@@ -36,11 +34,8 @@ from neo4j.exceptions import (
     SessionExpired,
 )
 
-from ...._async_compat import (
-    mark_sync_test,
-    Mock,
-)
-from ..work import FakeConnection
+from ...._async_compat import mark_sync_test
+from ..work import fake_connection_generator
 
 
 ROUTER_ADDRESS = ResolvedAddress(("1.2.3.1", 9001), host_name="host")
@@ -49,12 +44,12 @@ WRITER_ADDRESS = ResolvedAddress(("1.2.3.1", 9003), host_name="host")
 
 
 @pytest.fixture()
-def opener():
+def opener(fake_connection_generator, mocker):
     def open_(addr, timeout):
-        connection = FakeConnection()
+        connection = fake_connection_generator()
         connection.addr = addr
         connection.timeout = timeout
-        route_mock = Mock()
+        route_mock = mocker.Mock()
         route_mock.return_value = [{
             "ttl": 1000,
             "servers": [
@@ -67,7 +62,7 @@ def opener():
         opener_.connections.append(connection)
         return connection
 
-    opener_ = Mock()
+    opener_ = mocker.Mock()
     opener_.connections = []
     opener_.side_effect = open_
     return opener_

--- a/tests/unit/sync/test_addressing.py
+++ b/tests/unit/sync/test_addressing.py
@@ -20,7 +20,6 @@ from socket import (
     AF_INET,
     AF_INET6,
 )
-import unittest.mock as mock
 
 import pytest
 
@@ -32,13 +31,6 @@ from neo4j._async_compat.network import NetworkUtil
 from neo4j._async_compat.util import Util
 
 from ..._async_compat import mark_sync_test
-
-
-mock_socket_ipv4 = mock.Mock()
-mock_socket_ipv4.getpeername = lambda: ("127.0.0.1", 7687)  # (address, port)
-
-mock_socket_ipv6 = mock.Mock()
-mock_socket_ipv6.getpeername = lambda: ("[::1]", 7687, 0, 0)  # (address, port, flow info, scope id)
 
 
 @mark_sync_test

--- a/tests/unit/sync/work/_fake_connection.py
+++ b/tests/unit/sync/work/_fake_connection.py
@@ -23,88 +23,90 @@ import pytest
 from neo4j import ServerInfo
 from neo4j._sync.io import Bolt
 
-from ...._async_compat import (
-    Mock,
-    mock,
-)
 
+@pytest.fixture
+def fake_connection_generator(session_mocker):
+    mock = session_mocker.mock_module
 
-class FakeConnection(mock.NonCallableMagicMock):
-    callbacks = []
-    server_info = ServerInfo("127.0.0.1", (4, 3))
+    class FakeConnection(mock.NonCallableMagicMock):
+        callbacks = []
+        server_info = ServerInfo("127.0.0.1", (4, 3))
 
-    def __init__(self, *args, **kwargs):
-        kwargs["spec"] = Bolt
-        super().__init__(*args, **kwargs)
-        self.attach_mock(Mock(return_value=True), "is_reset_mock")
-        self.attach_mock(Mock(return_value=False), "defunct")
-        self.attach_mock(Mock(return_value=False), "stale")
-        self.attach_mock(Mock(return_value=False), "closed")
-        self.attach_mock(Mock(), "unresolved_address")
+        def __init__(self, *args, **kwargs):
+            kwargs["spec"] = Bolt
+            super().__init__(*args, **kwargs)
+            self.attach_mock(mock.Mock(return_value=True), "is_reset_mock")
+            self.attach_mock(mock.Mock(return_value=False), "defunct")
+            self.attach_mock(mock.Mock(return_value=False), "stale")
+            self.attach_mock(mock.Mock(return_value=False), "closed")
+            self.attach_mock(mock.Mock(), "unresolved_address")
 
-        def close_side_effect():
-            self.closed.return_value = True
+            def close_side_effect():
+                self.closed.return_value = True
 
-        self.attach_mock(Mock(side_effect=close_side_effect),
-                         "close")
+            self.attach_mock(mock.Mock(side_effect=close_side_effect),
+                             "close")
 
-    @property
-    def is_reset(self):
-        if self.closed.return_value or self.defunct.return_value:
-            raise AssertionError(
-                "is_reset should not be called on a closed or defunct "
-                "connection."
-            )
-        return self.is_reset_mock()
+        @property
+        def is_reset(self):
+            if self.closed.return_value or self.defunct.return_value:
+                raise AssertionError(
+                    "is_reset should not be called on a closed or defunct "
+                    "connection."
+                )
+            return self.is_reset_mock()
 
-    def fetch_message(self, *args, **kwargs):
-        if self.callbacks:
-            cb = self.callbacks.pop(0)
-            cb()
-        return super().__getattr__("fetch_message")(*args, **kwargs)
+        def fetch_message(self, *args, **kwargs):
+            if self.callbacks:
+                cb = self.callbacks.pop(0)
+                cb()
+            return super().__getattr__("fetch_message")(*args, **kwargs)
 
-    def fetch_all(self, *args, **kwargs):
-        while self.callbacks:
-            cb = self.callbacks.pop(0)
-            cb()
-        return super().__getattr__("fetch_all")(*args, **kwargs)
+        def fetch_all(self, *args, **kwargs):
+            while self.callbacks:
+                cb = self.callbacks.pop(0)
+                cb()
+            return super().__getattr__("fetch_all")(*args, **kwargs)
 
-    def __getattr__(self, name):
-        parent = super()
+        def __getattr__(self, name):
+            parent = super()
 
-        def build_message_handler(name):
-            def func(*args, **kwargs):
-                def callback():
-                    for cb_name, param_count in (
-                        ("on_success", 1),
-                        ("on_summary", 0)
-                    ):
-                        cb = kwargs.get(cb_name, None)
-                        if callable(cb):
-                            try:
-                                param_count = \
-                                    len(inspect.signature(cb).parameters)
-                            except ValueError:
-                                # e.g. built-in method as cb
-                                pass
-                            if param_count == 1:
-                                res = cb({})
-                            else:
-                                res = cb()
-                            try:
-                                res  # maybe the callback is async
-                            except TypeError:
-                                pass  # or maybe it wasn't ;)
-                self.callbacks.append(callback)
+            def build_message_handler(name):
+                def func(*args, **kwargs):
+                    def callback():
+                        for cb_name, param_count in (
+                            ("on_success", 1),
+                            ("on_summary", 0)
+                        ):
+                            cb = kwargs.get(cb_name, None)
+                            if callable(cb):
+                                try:
+                                    param_count = \
+                                        len(inspect.signature(cb).parameters)
+                                except ValueError:
+                                    # e.g. built-in method as cb
+                                    pass
+                                if param_count == 1:
+                                    res = cb({})
+                                else:
+                                    res = cb()
+                                try:
+                                    res  # maybe the callback is async
+                                except TypeError:
+                                    pass  # or maybe it wasn't ;)
 
-            return func
+                    self.callbacks.append(callback)
 
-        method_mock = parent.__getattr__(name)
-        if name in ("run", "commit", "pull", "rollback", "discard"):
-            method_mock.side_effect = build_message_handler(name)
-        return method_mock
+                return func
+
+            method_mock = parent.__getattr__(name)
+            if name in ("run", "commit", "pull", "rollback", "discard"):
+                method_mock.side_effect = build_message_handler(name)
+            return method_mock
+
+    return FakeConnection
 
 
 @pytest.fixture
-def fake_connection():
-    return FakeConnection()
+def fake_connection(fake_connection_generator):
+    return fake_connection_generator()

--- a/tests/unit/sync/work/conftest.py
+++ b/tests/unit/sync/work/conftest.py
@@ -1,0 +1,4 @@
+from ._fake_connection import (
+    fake_connection,
+    fake_connection_generator,
+)

--- a/tests/unit/sync/work/test_transaction.py
+++ b/tests/unit/sync/work/test_transaction.py
@@ -26,7 +26,7 @@ from neo4j import (
     Transaction,
 )
 
-from ._fake_connection import fake_connection
+from ...._async_compat import mark_sync_test
 
 
 @pytest.mark.parametrize(("explicit_commit", "close"), (
@@ -34,13 +34,15 @@ from ._fake_connection import fake_connection
     (True, False),
     (True, True),
 ))
-def test_transaction_context_when_committing(mocker, fake_connection,
-                                             explicit_commit, close):
-    on_closed = MagicMock()
-    on_error = MagicMock()
+@mark_sync_test
+def test_transaction_context_when_committing(
+    mocker, fake_connection, explicit_commit, close
+):
+    on_closed = mocker.Mock()
+    on_error = mocker.Mock()
     tx = Transaction(fake_connection, 2, on_closed, on_error)
-    mock_commit = mocker.patch.object(tx, "commit", wraps=tx.commit)
-    mock_rollback = mocker.patch.object(tx, "rollback", wraps=tx.rollback)
+    mock_commit = mocker.patch.object(tx, "_commit", wraps=tx._commit)
+    mock_rollback = mocker.patch.object(tx, "_rollback", wraps=tx._rollback)
     with tx as tx_:
         assert mock_commit.call_count == 0
         assert mock_rollback.call_count == 0
@@ -48,7 +50,7 @@ def test_transaction_context_when_committing(mocker, fake_connection,
         if explicit_commit:
             tx_.commit()
             mock_commit.assert_called_once_with()
-            assert tx.closed()
+            assert tx_.closed()
         if close:
             tx_.close()
             assert tx_.closed()
@@ -62,13 +64,15 @@ def test_transaction_context_when_committing(mocker, fake_connection,
     (False, True),
     (True, True),
 ))
-def test_transaction_context_with_explicit_rollback(mocker, fake_connection,
-                                                    rollback, close):
-    on_closed = MagicMock()
-    on_error = MagicMock()
+@mark_sync_test
+def test_transaction_context_with_explicit_rollback(
+    mocker, fake_connection, rollback, close
+):
+    on_closed = mocker.Mock()
+    on_error = mocker.Mock()
     tx = Transaction(fake_connection, 2, on_closed, on_error)
-    mock_commit = mocker.patch.object(tx, "commit", wraps=tx.commit)
-    mock_rollback = mocker.patch.object(tx, "rollback", wraps=tx.rollback)
+    mock_commit = mocker.patch.object(tx, "_commit", wraps=tx._commit)
+    mock_rollback = mocker.patch.object(tx, "_rollback", wraps=tx._rollback)
     with tx as tx_:
         assert mock_commit.call_count == 0
         assert mock_rollback.call_count == 0
@@ -86,15 +90,18 @@ def test_transaction_context_with_explicit_rollback(mocker, fake_connection,
     assert tx_.closed()
 
 
-def test_transaction_context_calls_rollback_on_error(mocker, fake_connection):
+@mark_sync_test
+def test_transaction_context_calls_rollback_on_error(
+    mocker, fake_connection
+):
     class OopsError(RuntimeError):
         pass
 
     on_closed = MagicMock()
     on_error = MagicMock()
     tx = Transaction(fake_connection, 2, on_closed, on_error)
-    mock_commit = mocker.patch.object(tx, "commit", wraps=tx.commit)
-    mock_rollback = mocker.patch.object(tx, "rollback", wraps=tx.rollback)
+    mock_commit = mocker.patch.object(tx, "_commit", wraps=tx._commit)
+    mock_rollback = mocker.patch.object(tx, "_rollback", wraps=tx._rollback)
     with pytest.raises(OopsError):
         with tx as tx_:
             assert mock_commit.call_count == 0
@@ -112,8 +119,10 @@ def test_transaction_context_calls_rollback_on_error(mocker, fake_connection):
     ({"x": {(1, 2): '1+2i', (2, 0): '2'}}, TypeError),
     ({"x": uuid4()}, TypeError),
 ))
-def test_transaction_run_with_invalid_parameters(fake_connection, parameters,
-                                                 error_type):
+@mark_sync_test
+def test_transaction_run_with_invalid_parameters(
+    fake_connection, parameters, error_type
+):
     on_closed = MagicMock()
     on_error = MagicMock()
     tx = Transaction(fake_connection, 2, on_closed, on_error)
@@ -121,6 +130,7 @@ def test_transaction_run_with_invalid_parameters(fake_connection, parameters,
         tx.run("RETURN $x", **parameters)
 
 
+@mark_sync_test
 def test_transaction_run_takes_no_query_object(fake_connection):
     on_closed = MagicMock()
     on_error = MagicMock()
@@ -129,10 +139,14 @@ def test_transaction_run_takes_no_query_object(fake_connection):
         tx.run(Query("RETURN 1"))
 
 
-def test_transaction_rollbacks_on_open_connections(fake_connection):
-    tx = Transaction(fake_connection, 2,
-                     lambda *args, **kwargs: None,
-                     lambda *args, **kwargs: None)
+@mark_sync_test
+def test_transaction_rollbacks_on_open_connections(
+    fake_connection
+):
+    tx = Transaction(
+        fake_connection, 2, lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None
+    )
     with tx as tx_:
         fake_connection.is_reset_mock.return_value = False
         fake_connection.is_reset_mock.reset_mock()
@@ -142,44 +156,56 @@ def test_transaction_rollbacks_on_open_connections(fake_connection):
         fake_connection.rollback.assert_called_once()
 
 
-def test_transaction_no_rollback_on_reset_connections(fake_connection):
-    tx = Transaction(fake_connection, 2,
-                     lambda *args, **kwargs: None,
-                     lambda *args, **kwargs: None)
+@mark_sync_test
+def test_transaction_no_rollback_on_reset_connections(
+    fake_connection
+):
+    tx = Transaction(
+        fake_connection, 2, lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None
+    )
     with tx as tx_:
         fake_connection.is_reset_mock.return_value = True
         fake_connection.is_reset_mock.reset_mock()
         tx_.rollback()
         fake_connection.is_reset_mock.assert_called_once()
-        fake_connection.reset.asset_not_called()
-        fake_connection.rollback.asset_not_called()
+        fake_connection.reset.assert_not_called()
+        fake_connection.rollback.assert_not_called()
 
 
-def test_transaction_no_rollback_on_closed_connections(fake_connection):
-    tx = Transaction(fake_connection, 2,
-                     lambda *args, **kwargs: None,
-                     lambda *args, **kwargs: None)
+@mark_sync_test
+def test_transaction_no_rollback_on_closed_connections(
+    fake_connection
+):
+    tx = Transaction(
+        fake_connection, 2, lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None
+    )
     with tx as tx_:
         fake_connection.closed.return_value = True
         fake_connection.closed.reset_mock()
         fake_connection.is_reset_mock.reset_mock()
         tx_.rollback()
         fake_connection.closed.assert_called_once()
-        fake_connection.is_reset_mock.asset_not_called()
-        fake_connection.reset.asset_not_called()
-        fake_connection.rollback.asset_not_called()
+        fake_connection.is_reset_mock.assert_not_called()
+        fake_connection.reset.assert_not_called()
+        fake_connection.rollback.assert_not_called()
 
 
-def test_transaction_no_rollback_on_defunct_connections(fake_connection):
-    tx = Transaction(fake_connection, 2,
-                     lambda *args, **kwargs: None,
-                     lambda *args, **kwargs: None)
+@mark_sync_test
+def test_transaction_no_rollback_on_defunct_connections(
+    fake_connection
+):
+    tx = Transaction(
+        fake_connection, 2, lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None
+    )
     with tx as tx_:
         fake_connection.defunct.return_value = True
         fake_connection.defunct.reset_mock()
         fake_connection.is_reset_mock.reset_mock()
         tx_.rollback()
         fake_connection.defunct.assert_called_once()
-        fake_connection.is_reset_mock.asset_not_called()
-        fake_connection.reset.asset_not_called()
-        fake_connection.rollback.asset_not_called()
+        fake_connection.is_reset_mock.assert_not_called()
+        fake_connection.reset.assert_not_called()
+        fake_connection.rollback.assert_not_called()


### PR DESCRIPTION
Transaction functions (a.k.a. managed transactions):
The first argument of transaction functions is now a `(Async)ManagedTransaction`
object. It behaves exactly like a regular `(Async)Transaction` object, except it
does not offer the `commit`, `rollback`, `close`, and `closed` methods.
Those methods would have caused a hard to interpreted error previously. Hence,
they have been removed.