### PR TITLE
Re-design SSL config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
   or call the `dbms.components` procedure instead.
 - SSL configuration options have been changed:
   - `trust` has been deprecated and will be removed in a future release.  
-    Use `trusted_certificates` instead which expects `None` or a `list`. See the
-    API documentation for more details.
+    Use `trusted_certificates` instead.
+    See the API documentation for more details.
 - `neo4j.time` module:
   - `Duration`
     - The constructor does not accept `subseconds` anymore.  

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -330,25 +330,14 @@ Specify how to determine the authenticity of encryption certificates provided by
 This setting does not have any effect if ``encrypted`` is set to ``False`` or a
 custom ``ssl_context`` is configured.
 
-:Type: :class:`list` or :const:`None`
+:Type: :class:`.TrustSystemCAs`, :class:`.TrustAll`, or :class:`.TrustCustomCAs`
+:Default: :const:`neo4j.TrustSystemCAs()`
 
-**None** (default)
-    Trust server certificates that can be verified against the system
-    certificate authority. This option is primarily intended for use with
-    full certificates.
+.. autoclass:: neo4j.TrustSystemCAs
 
-**[] (empty list)**
-    Trust any server certificate. This ensures that communication
-    is encrypted but does not verify the server certificate against a
-    certificate authority. This option is primarily intended for use with
-    the default auto-generated server certificate.
+.. autoclass:: neo4j.TrustAll
 
-**["<path>", ...]**
-    Trust server certificates that can be verified against the certificate
-    authority at the specified paths. This option is primarily intended for
-    self-signed and custom certificates.
-
-:Default: :const:`None`
+.. autoclass:: neo4j.TrustCustomCAs
 
 .. versionadded:: 5.0
 

--- a/neo4j/__init__.py
+++ b/neo4j/__init__.py
@@ -22,8 +22,8 @@ __all__ = [
     "AsyncBoltDriver",
     "AsyncDriver",
     "AsyncGraphDatabase",
-    "AsyncNeo4jDriver",
     "AsyncManagedTransaction",
+    "AsyncNeo4jDriver",
     "AsyncResult",
     "AsyncSession",
     "AsyncTransaction",
@@ -58,6 +58,9 @@ __all__ = [
     "Transaction",
     "TRUST_ALL_CERTIFICATES",
     "TRUST_SYSTEM_CA_SIGNED_CERTIFICATES",
+    "TrustAll",
+    "TrustCustomCAs",
+    "TrustSystemCAs",
     "unit_of_work",
     "Version",
     "WorkspaceConfig",
@@ -78,6 +81,11 @@ from ._async.work import (
     AsyncResult,
     AsyncSession,
     AsyncTransaction,
+)
+from ._conf import (
+    TrustAll,
+    TrustCustomCAs,
+    TrustSystemCAs,
 )
 from ._sync.driver import (
     BoltDriver,

--- a/neo4j/_conf.py
+++ b/neo4j/_conf.py
@@ -1,0 +1,80 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [http://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class TrustStore:
+    # Base class for trust stores. For internal type-checking only.
+    pass
+
+
+class TrustSystemCAs(TrustStore):
+    """Used to configure the driver to trust system CAs (default).
+
+    Trust server certificates that can be verified against the system
+    certificate authority. This option is primarily intended for use with
+    full certificates.
+
+    For example::
+
+        driver = neo4j.GraphDatabase.driver(
+            url, auth=auth, trusted_certificates=neo4j.TrustSystemCAs()
+        )
+    """
+    pass
+
+
+class TrustAll(TrustStore):
+    """Used to configure the driver to trust all certificates.
+
+    Trust any server certificate. This ensures that communication
+    is encrypted but does not verify the server certificate against a
+    certificate authority. This option is primarily intended for use with
+    the default auto-generated server certificate.
+
+
+    For example::
+
+        driver = neo4j.GraphDatabase.driver(
+            url, auth=auth, trusted_certificates=neo4j.TrustAll()
+        )
+    """
+    pass
+
+
+class TrustCustomCAs(TrustStore):
+    """Used to configure the driver to trust custom CAs.
+
+    Trust server certificates that can be verified against the certificate
+    authority at the specified paths. This option is primarily intended for
+    self-signed and custom certificates.
+
+    :param certificates (str): paths to the certificates to trust.
+        Those are not the certificates you expect to see from the server but
+        the CA certificates you expect to be used to sign the server's
+        certificate.
+
+    For example::
+
+        driver = neo4j.GraphDatabase.driver(
+            url, auth=auth,
+            trusted_certificates=neo4j.TrustCustomCAs(
+                "/path/to/ca1.crt", "/path/to/ca2.crt",
+            )
+        )
+    """
+    def __init__(self, *certificates):
+        self.certs = certificates

--- a/neo4j/_sync/driver.py
+++ b/neo4j/_sync/driver.py
@@ -16,9 +16,11 @@
 # limitations under the License.
 
 
-import asyncio
-
 from .._async_compat.util import Util
+from .._conf import (
+    TrustAll,
+    TrustStore,
+)
 from ..addressing import Address
 from ..api import (
     READ_ACCESS,
@@ -30,10 +32,6 @@ from ..conf import (
     PoolConfig,
     SessionConfig,
     WorkspaceConfig,
-)
-from ..exceptions import (
-    ServiceUnavailable,
-    SessionExpired,
 )
 from ..meta import (
     deprecation_warn,
@@ -66,7 +64,6 @@ class GraphDatabase:
             DRIVER_NEO4j,
             parse_neo4j_uri,
             parse_routing_context,
-            SECURITY_TYPE_NOT_SECURE,
             SECURITY_TYPE_SECURE,
             SECURITY_TYPE_SELF_SIGNED_CERTIFICATE,
             URI_SCHEME_BOLT,
@@ -93,6 +90,17 @@ class GraphDatabase:
                         ]
                     )
                 )
+
+        if ("trusted_certificates" in config.keys()
+            and not isinstance(config["trusted_certificates"],
+                               TrustStore)):
+            raise ConnectionError(
+                "The config setting `trusted_certificates` must be of type "
+                "neo4j.TrustAll, neo4j.TrustCustomCAs, or"
+                "neo4j.TrustSystemCAs but was {}".format(
+                    type(config["trusted_certificates"])
+                )
+            )
 
         if (security_type in [SECURITY_TYPE_SELF_SIGNED_CERTIFICATE, SECURITY_TYPE_SECURE]
             and ("encrypted" in config.keys()
@@ -125,7 +133,7 @@ class GraphDatabase:
             config["encrypted"] = True
         elif security_type == SECURITY_TYPE_SELF_SIGNED_CERTIFICATE:
             config["encrypted"] = True
-            config["trusted_certificates"] = []
+            config["trusted_certificates"] = TrustAll()
 
         if driver_type == DRIVER_BOLT:
             if parse_routing_context(parsed.query):

--- a/testkitbackend/_async/requests.py
+++ b/testkitbackend/_async/requests.py
@@ -103,12 +103,14 @@ async def NewDriver(backend, data):
     if "encrypted" in data:
         kwargs["encrypted"] = data["encrypted"]
     if "trustedCertificates" in data:
-        kwargs["trusted_certificates"] = data["trustedCertificates"]
-        if isinstance(kwargs["trusted_certificates"], list):
-            kwargs["trusted_certificates"] = [
-                "/usr/local/share/custom-ca-certificates/" + cert
-                for cert in kwargs["trusted_certificates"]
-            ]
+        if data["trustedCertificates"] is None:
+            kwargs["trusted_certificates"] = neo4j.TrustSystemCAs()
+        elif not data["trustedCertificates"]:
+            kwargs["trusted_certificates"] = neo4j.TrustAll()
+        else:
+            cert_paths = ("/usr/local/share/custom-ca-certificates/" + cert
+                          for cert in data["trustedCertificates"])
+            kwargs["trusted_certificates"] = neo4j.TrustCustomCAs(*cert_paths)
 
     data.mark_item_as_read("domainNameResolverRegistered")
     driver = neo4j.AsyncGraphDatabase.driver(

--- a/testkitbackend/_sync/requests.py
+++ b/testkitbackend/_sync/requests.py
@@ -103,12 +103,14 @@ def NewDriver(backend, data):
     if "encrypted" in data:
         kwargs["encrypted"] = data["encrypted"]
     if "trustedCertificates" in data:
-        kwargs["trusted_certificates"] = data["trustedCertificates"]
-        if isinstance(kwargs["trusted_certificates"], list):
-            kwargs["trusted_certificates"] = [
-                "/usr/local/share/custom-ca-certificates/" + cert
-                for cert in kwargs["trusted_certificates"]
-            ]
+        if data["trustedCertificates"] is None:
+            kwargs["trusted_certificates"] = neo4j.TrustSystemCAs()
+        elif not data["trustedCertificates"]:
+            kwargs["trusted_certificates"] = neo4j.TrustAll()
+        else:
+            cert_paths = ("/usr/local/share/custom-ca-certificates/" + cert
+                          for cert in data["trustedCertificates"])
+            kwargs["trusted_certificates"] = neo4j.TrustCustomCAs(*cert_paths)
 
     data.mark_item_as_read("domainNameResolverRegistered")
     driver = neo4j.GraphDatabase.driver(

--- a/tests/integration/examples/test_config_secure_example.py
+++ b/tests/integration/examples/test_config_secure_example.py
@@ -25,6 +25,7 @@ from tests.integration.examples import DriverSetupExample
 
 # isort: off
 # tag::config-secure-import[]
+import neo4j
 from neo4j import GraphDatabase
 # end::config-secure-import[]
 # isort: off
@@ -37,11 +38,16 @@ class ConfigSecureExample(DriverSetupExample):
     # tag::config-secure[]
     def __init__(self, uri, auth):
         # trusted_certificates:
-        # None :  (default) trust certificates from system store)
-        # [] : trust all certificates
-        # ["<path>", ...] : specify a list of paths to certificates to trust
-        self.driver = GraphDatabase.driver(uri, auth=auth, encrypted=True,
-                                           trusted_certificates=None)
+        # neo4j.TrustSystemCAs()
+        #     (default) trust certificates from system store)
+        # neo4j.TrustAll()
+        #     trust all certificates
+        # neo4j.TrustCustomCAs("<path>", ...)
+        #     specify a list of paths to certificates to trust
+        self.driver = GraphDatabase.driver(
+            uri, auth=auth, encrypted=True,
+            trusted_certificates=neo4j.TrustSystemCAs(),
+        )
         # or omit trusted_certificates as None is the default
     # end::config-secure[]
 

--- a/tests/integration/examples/test_config_trust_example.py
+++ b/tests/integration/examples/test_config_trust_example.py
@@ -23,6 +23,7 @@ from tests.integration.examples import DriverSetupExample
 
 # isort: off
 # tag::config-trust-import[]
+import neo4j
 from neo4j import GraphDatabase
 # end::config-trust-import[]
 # isort: on
@@ -33,11 +34,16 @@ class ConfigTrustExample(DriverSetupExample):
     # tag::config-trust[]
     def __init__(self, uri, auth):
         # trusted_certificates:
-        # None :  (default) trust certificates from system store)
-        # [] : trust all certificates
-        # ["<path>", ...] : specify a list of paths to certificates to trust
-        self.driver = GraphDatabase.driver(uri, auth=auth, encrypted=True,
-                                           trusted_certificates=[])
+        # neo4j.TrustSystemCAs()
+        #     (default) trust certificates from system store)
+        # neo4j.TrustAll()
+        #     trust all certificates
+        # neo4j.TrustCustomCAs("<path>", ...)
+        #     specify a list of paths to certificates to trust
+        self.driver = GraphDatabase.driver(
+            uri, auth=auth, encrypted=True,
+            trusted_certificates=neo4j.TrustAll()
+        )
     # end::config-trust[]
 
 

--- a/tests/unit/async_/test_driver.py
+++ b/tests/unit/async_/test_driver.py
@@ -26,6 +26,9 @@ from neo4j import (
     AsyncNeo4jDriver,
     TRUST_ALL_CERTIFICATES,
     TRUST_SYSTEM_CA_SIGNED_CERTIFICATES,
+    TrustAll,
+    TrustCustomCAs,
+    TrustSystemCAs,
 )
 from neo4j.api import (
     READ_ACCESS,
@@ -95,19 +98,19 @@ async def test_routing_driver_constructor(protocol, host, port, params, auth_tok
             ConfigurationError, "The config settings"
         ),
         (
-            {"encrypted": True, "trusted_certificates": []},
+            {"encrypted": True, "trusted_certificates": TrustAll()},
             ConfigurationError, "The config settings"
         ),
         (
-            {"trusted_certificates": []},
+            {"trusted_certificates": TrustAll()},
             ConfigurationError, "The config settings"
         ),
         (
-            {"trusted_certificates": None},
+            {"trusted_certificates": TrustSystemCAs()},
             ConfigurationError, "The config settings"
         ),
         (
-            {"trusted_certificates": ["foo", "bar"]},
+            {"trusted_certificates": TrustCustomCAs("foo", "bar")},
             ConfigurationError, "The config settings"
         ),
         (

--- a/tests/unit/sync/test_driver.py
+++ b/tests/unit/sync/test_driver.py
@@ -26,6 +26,9 @@ from neo4j import (
     Neo4jDriver,
     TRUST_ALL_CERTIFICATES,
     TRUST_SYSTEM_CA_SIGNED_CERTIFICATES,
+    TrustAll,
+    TrustCustomCAs,
+    TrustSystemCAs,
 )
 from neo4j.api import (
     READ_ACCESS,
@@ -95,19 +98,19 @@ def test_routing_driver_constructor(protocol, host, port, params, auth_token):
             ConfigurationError, "The config settings"
         ),
         (
-            {"encrypted": True, "trusted_certificates": []},
+            {"encrypted": True, "trusted_certificates": TrustAll()},
             ConfigurationError, "The config settings"
         ),
         (
-            {"trusted_certificates": []},
+            {"trusted_certificates": TrustAll()},
             ConfigurationError, "The config settings"
         ),
         (
-            {"trusted_certificates": None},
+            {"trusted_certificates": TrustSystemCAs()},
             ConfigurationError, "The config settings"
         ),
         (
-            {"trusted_certificates": ["foo", "bar"]},
+            {"trusted_certificates": TrustCustomCAs("foo", "bar")},
             ConfigurationError, "The config settings"
         ),
         (


### PR DESCRIPTION
To avoid magic values (e.g., like it was before: an empty list would mean
"trust any certificate"), we introduce helper classes for configuring the
driver when it comes to trusted certificates.