### PR TITLE
Add `.is_retriable()` to Neo4jError and DriverError

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -417,7 +417,7 @@ Will result in:
 Sessions & Transactions
 ***********************
 All database activity is co-ordinated through two mechanisms:
-**sessions** (:class:`neo4j.AsyncSession`) and **transactions**
+**sessions** (:class:`neo4j.Session`) and **transactions**
 (:class:`neo4j.Transaction`, :class:`neo4j.ManagedTransaction`).
 
 A **session** is a logical container for any number of causally-related transactional units of work.
@@ -1263,18 +1263,7 @@ Neo4j Execution Errors
 
 
 .. autoclass:: neo4j.exceptions.Neo4jError
-
-    .. autoproperty:: message
-
-    .. autoproperty:: code
-
-    There are many Neo4j status codes, see `status code <https://neo4j.com/docs/status-codes/current/>`_.
-
-    .. autoproperty:: classification
-
-    .. autoproperty:: category
-
-    .. autoproperty:: title
+    :members: message, code, is_retriable
 
 
 .. autoclass:: neo4j.exceptions.ClientError
@@ -1332,7 +1321,7 @@ Connectivity Errors
 
 
 .. autoclass:: neo4j.exceptions.DriverError
-
+    :members: is_retriable
 
 .. autoclass:: neo4j.exceptions.TransactionError
     :show-inheritance:

--- a/neo4j/__init__.py
+++ b/neo4j/__init__.py
@@ -39,6 +39,7 @@ __all__ = [
     "DEFAULT_DATABASE",
     "Driver",
     "ExperimentalWarning",
+    "get_user_agent",
     "GraphDatabase",
     "IPv4Address",
     "IPv6Address",

--- a/neo4j/_sync/work/session.py
+++ b/neo4j/_sync/work/session.py
@@ -30,12 +30,11 @@ from ...conf import SessionConfig
 from ...data import DataHydrator
 from ...exceptions import (
     ClientError,
-    IncompleteCommit,
+    DriverError,
     Neo4jError,
     ServiceUnavailable,
     SessionExpired,
     TransactionError,
-    TransientError,
 )
 from ...meta import (
     deprecated,
@@ -328,8 +327,9 @@ class Session(Workspace):
             self._transaction = None
             self._disconnect()
 
-    def _open_transaction(self, *, tx_cls, access_mode, metadata=None,
-                          timeout=None):
+    def _open_transaction(
+        self, *, tx_cls, access_mode, metadata=None, timeout=None
+    ):
         self._connect(access_mode=access_mode)
         self._transaction = tx_cls(
             self._connection, self._config.fetch_size,
@@ -393,7 +393,11 @@ class Session(Workspace):
         metadata = getattr(transaction_function, "metadata", None)
         timeout = getattr(transaction_function, "timeout", None)
 
-        retry_delay = retry_delay_generator(self._config.initial_retry_delay, self._config.retry_delay_multiplier, self._config.retry_delay_jitter_factor)
+        retry_delay = retry_delay_generator(
+            self._config.initial_retry_delay,
+            self._config.retry_delay_multiplier,
+            self._config.retry_delay_jitter_factor
+        )
 
         errors = []
 
@@ -414,24 +418,22 @@ class Session(Workspace):
                     raise
                 else:
                     tx._commit()
-            except IncompleteCommit:
-                raise
-            except (ServiceUnavailable, SessionExpired) as error:
-                errors.append(error)
+            except (DriverError, Neo4jError) as error:
                 self._disconnect()
-            except TransientError as transient_error:
-                if not transient_error.is_retriable():
+                if not error.is_retriable():
                     raise
-                errors.append(transient_error)
+                errors.append(error)
             else:
                 return result
             if t0 == -1:
-                t0 = perf_counter()  # The timer should be started after the first attempt
+                # The timer should be started after the first attempt
+                t0 = perf_counter()
             t1 = perf_counter()
             if t1 - t0 > self._config.max_transaction_retry_time:
                 break
             delay = next(retry_delay)
-            log.warning("Transaction failed and will be retried in {}s ({})".format(delay, "; ".join(errors[-1].args)))
+            log.warning("Transaction failed and will be retried in {}s ({})"
+                        "".format(delay, "; ".join(errors[-1].args)))
             sleep(delay)
 
         if errors:


### PR DESCRIPTION
This should help users to implement custom retry policies together with explicit
transactions.
This PR also improves documentation around errors and changes the driver's
session code to also use the new flag for determining when to retry a tx.
This will make sure that it's a reliable feature + simplify the driver's code.