### PR TITLE
Fix `neo4j.time`

### DIFF
--- a/neo4j/time/hydration.py
+++ b/neo4j/time/hydration.py
@@ -167,7 +167,8 @@ def dehydrate_datetime(value):
     else:
         # with time offset
         seconds, nanoseconds = seconds_and_nanoseconds(value)
-        return Structure(b"F", seconds, nanoseconds, tz.utcoffset(value).seconds)
+        return Structure(b"F", seconds, nanoseconds,
+                         int(tz.utcoffset(value).total_seconds()))
 
 
 def hydrate_duration(months, days, seconds, nanoseconds):

--- a/tests/unit/common/time/__init__.py
+++ b/tests/unit/common/time/__init__.py
@@ -14,3 +14,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
+from neo4j.time.clock_implementations import (
+    Clock,
+    ClockTime,
+)
+
+
+# The existence of this class will make the driver's custom date time
+# implementation use it instead of a real clock since its precision it higher
+# than all the other clocks (only up to nanoseconds).
+class FixedClock(Clock):
+    @classmethod
+    def available(cls):
+        return True
+
+    @classmethod
+    def precision(cls):
+        return 12
+
+    @classmethod
+    def local_offset(cls):
+        return ClockTime()
+
+    def utc_time(self):
+        return ClockTime(45296, 789000001)

--- a/tests/unit/common/time/test_datetime.py
+++ b/tests/unit/common/time/test_datetime.py
@@ -20,6 +20,7 @@ import copy
 from datetime import (
     datetime,
     timedelta,
+    timezone as datetime_timezone,
 )
 import itertools
 import operator
@@ -41,10 +42,7 @@ from neo4j.time.arithmetic import (
     nano_add,
     nano_div,
 )
-from neo4j.time.clock_implementations import (
-    Clock,
-    ClockTime,
-)
+from neo4j.time.clock_implementations import ClockTime
 
 
 timezone_us_eastern = timezone("US/Eastern")
@@ -56,24 +54,6 @@ timezone_utc = timezone("UTC")
 def seconds_options(seconds, nanoseconds):
     yield seconds, nanoseconds
     yield seconds + nanoseconds / 1000000000,
-
-
-class FixedClock(Clock):
-
-    @classmethod
-    def available(cls):
-        return True
-
-    @classmethod
-    def precision(cls):
-        return 12
-
-    @classmethod
-    def local_offset(cls):
-        return ClockTime()
-
-    def utc_time(self):
-        return ClockTime(45296, 789000000)
 
 
 class TestDateTime:
@@ -151,7 +131,7 @@ class TestDateTime:
         assert t.hour == 12
         assert t.minute == 34
         assert t.second == 56
-        assert t.nanosecond == 789000000
+        assert t.nanosecond == 789000001
 
     def test_now_without_tz(self):
         t = DateTime.now()
@@ -161,7 +141,7 @@ class TestDateTime:
         assert t.hour == 12
         assert t.minute == 34
         assert t.second == 56
-        assert t.nanosecond == 789000000
+        assert t.nanosecond == 789000001
         assert t.tzinfo is None
 
     def test_now_with_tz(self):
@@ -172,10 +152,23 @@ class TestDateTime:
         assert t.hour == 7
         assert t.minute == 34
         assert t.second == 56
-        assert t.nanosecond == 789000000
+        assert t.nanosecond == 789000001
         assert t.utcoffset() == timedelta(seconds=-18000)
         assert t.dst() == timedelta()
         assert t.tzname() == "EST"
+
+    def test_now_with_utc_tz(self):
+        t = DateTime.now(timezone_utc)
+        assert t.year == 1970
+        assert t.month == 1
+        assert t.day == 1
+        assert t.hour == 12
+        assert t.minute == 34
+        assert t.second == 56
+        assert t.nanosecond == 789000001
+        assert t.utcoffset() == timedelta(seconds=0)
+        assert t.dst() == timedelta()
+        assert t.tzname() == "UTC"
 
     def test_utc_now(self):
         t = DateTime.utc_now()
@@ -185,19 +178,22 @@ class TestDateTime:
         assert t.hour == 12
         assert t.minute == 34
         assert t.second == 56
-        assert t.nanosecond == 789000000
+        assert t.nanosecond == 789000001
         assert t.tzinfo is None
 
-    def test_from_timestamp(self):
-        t = DateTime.from_timestamp(0)
-        assert t.year == 1970
-        assert t.month == 1
-        assert t.day == 1
-        assert t.hour == 0
-        assert t.minute == 0
-        assert t.second == 0
-        assert t.nanosecond == 0
-        assert t.tzinfo is None
+    @pytest.mark.parametrize(("tz", "expected"), (
+        (None, (1970, 1, 1, 0, 0, 0, 0)),
+        (timezone_utc, (1970, 1, 1, 0, 0, 0, 0)),
+        (datetime_timezone.utc, (1970, 1, 1, 0, 0, 0, 0)),
+        (FixedOffset(60), (1970, 1, 1, 1, 0, 0, 0)),
+        (datetime_timezone(timedelta(hours=1)), (1970, 1, 1, 1, 0, 0, 0)),
+        (timezone_us_eastern, (1969, 12, 31, 19, 0, 0, 0)),
+    ))
+    def test_from_timestamp(self, tz, expected):
+        t = DateTime.from_timestamp(0, tz=tz)
+        assert t.year_month_day == expected[:3]
+        assert t.hour_minute_second_nanosecond == expected[3:]
+        assert str(t.tzinfo) == str(tz)
 
     def test_from_overflowing_timestamp(self):
         with pytest.raises(ValueError):
@@ -291,23 +287,58 @@ class TestDateTime:
         assert dt.second == native.second
         assert dt.nanosecond == native.microsecond * 1000
 
-    def test_iso_format(self):
-        dt = DateTime(2018, 10, 1, 12, 34, 56, 789123456)
-        assert "2018-10-01T12:34:56.789123456" == dt.iso_format()
-
-    def test_iso_format_with_trailing_zeroes(self):
-        dt = DateTime(2018, 10, 1, 12, 34, 56, 789000000)
-        assert "2018-10-01T12:34:56.789000000" == dt.iso_format()
-
-    def test_iso_format_with_tz(self):
-        dt = timezone_us_eastern.localize(DateTime(2018, 10, 1, 12, 34, 56,
-                                                   789123456))
-        assert "2018-10-01T12:34:56.789123456-04:00" == dt.iso_format()
-
-    def test_iso_format_with_tz_and_trailing_zeroes(self):
-        dt = timezone_us_eastern.localize(DateTime(2018, 10, 1, 12, 34, 56,
-                                                   789000000))
-        assert "2018-10-01T12:34:56.789000000-04:00" == dt.iso_format()
+    @pytest.mark.parametrize(("dt", "expected"), (
+        (
+            DateTime(2018, 10, 1, 12, 34, 56, 789123456),
+            "2018-10-01T12:34:56.789123456"
+        ),
+        (
+            datetime(2018, 10, 1, 12, 34, 56, 789123),
+            "2018-10-01T12:34:56.789123"
+        ),
+        (
+            DateTime(2018, 10, 1, 12, 34, 56, 789000000),
+            "2018-10-01T12:34:56.789000000"
+        ),
+        (
+            datetime(2018, 10, 1, 12, 34, 56, 789000),
+            "2018-10-01T12:34:56.789000"
+        ),
+        (
+            timezone_us_eastern.localize(
+                DateTime(2018, 10, 1, 12, 34, 56, 789123456)
+            ),
+            "2018-10-01T12:34:56.789123456-04:00"
+        ),
+        (
+            timezone_us_eastern.localize(
+                datetime(2018, 10, 1, 12, 34, 56, 789123)
+            ),
+            "2018-10-01T12:34:56.789123-04:00"
+        ),
+        (
+            timezone_us_eastern.localize(
+                DateTime(2018, 10, 1, 12, 34, 56, 789000000)
+            ),
+            "2018-10-01T12:34:56.789000000-04:00"
+        ),
+        (
+            timezone_us_eastern.localize(
+                datetime(2018, 10, 1, 12, 34, 56, 789000)
+            ),
+            "2018-10-01T12:34:56.789000-04:00"
+        ),
+        (
+            utc.localize(DateTime(2018, 10, 1, 12, 34, 56, 789123456)),
+            "2018-10-01T12:34:56.789123456+00:00"
+        ),
+        (
+            utc.localize(datetime(2018, 10, 1, 12, 34, 56, 789123)),
+            "2018-10-01T12:34:56.789123+00:00"
+        ),
+    ))
+    def test_iso_format(self, dt, expected):
+        assert dt.isoformat() == expected
 
     def test_from_iso_format_hour_only(self):
         expected = DateTime(2018, 10, 1, 12, 0, 0)
@@ -452,6 +483,72 @@ def test_from_native_case_2():
     assert dt.second == native.second
     assert dt.nanosecond == native.microsecond * 1000
     assert dt.tzinfo == FixedOffset(0)
+
+
+@pytest.mark.parametrize("datetime_cls", (DateTime, datetime))
+def test_transition_to_summertime(datetime_cls):
+    dt = datetime_cls(2022, 3, 27, 1, 30)
+    dt = timezone_berlin.localize(dt)
+    assert dt.utcoffset() == timedelta(hours=1)
+    assert isinstance(dt, datetime_cls)
+    time = dt.time()
+    assert (time.hour, time.minute) == (1, 30)
+
+    dt += timedelta(hours=1)
+
+    # The native datetime object just bluntly carries over the timezone. You'd
+    # have to manually convert to UTC, do the calculation, and then convert
+    # back. Not pretty, but we should make sure our implementation does
+    assert dt.utcoffset() == timedelta(hours=1)
+    assert isinstance(dt, datetime_cls)
+    time = dt.time()
+    assert (time.hour, time.minute) == (2, 30)
+
+
+@pytest.mark.parametrize("datetime_cls", (DateTime, datetime))
+@pytest.mark.parametrize("utc_impl", (
+    utc,
+    datetime_timezone(timedelta(0)),
+))
+@pytest.mark.parametrize("tz", (
+    timezone_berlin, datetime_timezone(timedelta(hours=-1))
+))
+def test_transition_to_summertime_in_utc_space(datetime_cls, utc_impl, tz):
+    if datetime_cls == DateTime:
+        dt = datetime_cls(2022, 3, 27, 1, 30, 1, 123456789)
+    else:
+        dt = datetime_cls(2022, 3, 27, 1, 30, 1, 123456)
+    dt = timezone_berlin.localize(dt)
+    assert isinstance(dt, datetime_cls)
+    assert dt.utcoffset() == timedelta(hours=1)
+    time = dt.time()
+    assert (time.hour, time.minute, time.second) == (1, 30, 1)
+    if datetime_cls == DateTime:
+        assert time.nanosecond == 123456789
+    else:
+        assert time.microsecond == 123456
+
+    dt = dt.astimezone(utc_impl)
+    assert isinstance(dt, datetime_cls)
+    assert dt.utcoffset() == timedelta(0)
+    time = dt.time()
+    assert (time.hour, time.minute) == (0, 30)
+
+    dt += timedelta(hours=1)
+    assert isinstance(dt, datetime_cls)
+    assert dt.utcoffset() == timedelta(0)
+    time = dt.time()
+    assert (time.hour, time.minute) == (1, 30)
+
+    dt = dt.astimezone(timezone_berlin)
+    assert isinstance(dt, datetime_cls)
+    assert dt.utcoffset() == timedelta(hours=2)
+    time = dt.time()
+    assert (time.hour, time.minute) == (3, 30)
+    if datetime_cls == DateTime:
+        assert time.nanosecond == 123456789
+    else:
+        assert time.microsecond == 123456
 
 
 @pytest.mark.parametrize(("dt1", "dt2"), (

--- a/tests/unit/common/time/test_dehydration.py
+++ b/tests/unit/common/time/test_dehydration.py
@@ -1,0 +1,135 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [http://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import datetime
+from unittest import TestCase
+
+import pytz
+
+from neo4j.data import DataDehydrator
+from neo4j.packstream import Structure
+from neo4j.time import (
+    Date,
+    DateTime,
+    Duration,
+    Time,
+)
+
+
+class TestTemporalDehydration(TestCase):
+
+    def setUp(self):
+        self.dehydrator = DataDehydrator()
+
+    def test_date(self):
+        date = Date(1991, 8, 24)
+        struct, = self.dehydrator.dehydrate((date,))
+        assert struct == Structure(b"D", 7905)
+
+    def test_native_date(self):
+        date = datetime.date(1991, 8, 24)
+        struct, = self.dehydrator.dehydrate((date,))
+        assert struct == Structure(b"D", 7905)
+
+    def test_time(self):
+        time = Time(1, 2, 3, 4, pytz.FixedOffset(60))
+        struct, = self.dehydrator.dehydrate((time,))
+        assert struct == Structure(b"T", 3723000000004, 3600)
+
+    def test_native_time(self):
+        time = datetime.time(1, 2, 3, 4, pytz.FixedOffset(60))
+        struct, = self.dehydrator.dehydrate((time,))
+        assert struct == Structure(b"T", 3723000004000, 3600)
+
+    def test_local_time(self):
+        time = Time(1, 2, 3, 4)
+        struct, = self.dehydrator.dehydrate((time,))
+        assert struct == Structure(b"t", 3723000000004)
+
+    def test_local_native_time(self):
+        time = datetime.time(1, 2, 3, 4)
+        struct, = self.dehydrator.dehydrate((time,))
+        assert struct == Structure(b"t", 3723000004000)
+
+    def test_date_time(self):
+        dt = DateTime(2018, 10, 12, 11, 37, 41, 474716862,
+                      pytz.FixedOffset(60))
+        struct, = self.dehydrator.dehydrate((dt,))
+        assert struct == Structure(b"F", 1539344261, 474716862, 3600)
+
+    def test_native_date_time(self):
+        dt = datetime.datetime(2018, 10, 12, 11, 37, 41, 474716,
+                               pytz.FixedOffset(60))
+        struct, = self.dehydrator.dehydrate((dt,))
+        assert struct == Structure(b"F", 1539344261, 474716000, 3600)
+
+    def test_date_time_negative_offset(self):
+        dt = DateTime(2018, 10, 12, 11, 37, 41, 474716862,
+                      pytz.FixedOffset(-60))
+        struct, = self.dehydrator.dehydrate((dt,))
+        assert struct == Structure(b"F", 1539344261, 474716862, -3600)
+
+    def test_native_date_time_negative_offset(self):
+        dt = datetime.datetime(2018, 10, 12, 11, 37, 41, 474716,
+                               pytz.FixedOffset(-60))
+        struct, = self.dehydrator.dehydrate((dt,))
+        assert struct == Structure(b"F", 1539344261, 474716000, -3600)
+
+    def test_date_time_zone_id(self):
+        dt = DateTime(2018, 10, 12, 11, 37, 41, 474716862,
+                      pytz.timezone("Europe/Stockholm"))
+        struct, = self.dehydrator.dehydrate((dt,))
+        assert struct == Structure(b"f", 1539344261, 474716862,
+                                   "Europe/Stockholm")
+
+    def test_native_date_time_zone_id(self):
+        dt = datetime.datetime(2018, 10, 12, 11, 37, 41, 474716,
+                               pytz.timezone("Europe/Stockholm"))
+        struct, = self.dehydrator.dehydrate((dt,))
+        assert struct == Structure(b"f", 1539344261, 474716000,
+                                   "Europe/Stockholm")
+
+    def test_local_date_time(self):
+        dt = DateTime(2018, 10, 12, 11, 37, 41, 474716862)
+        struct, = self.dehydrator.dehydrate((dt,))
+        assert struct == Structure(b"d", 1539344261, 474716862)
+
+    def test_native_local_date_time(self):
+        dt = datetime.datetime(2018, 10, 12, 11, 37, 41, 474716)
+        struct, = self.dehydrator.dehydrate((dt,))
+        assert struct == Structure(b"d", 1539344261, 474716000)
+
+    def test_duration(self):
+        duration = Duration(months=1, days=2, seconds=3, nanoseconds=4)
+        struct, = self.dehydrator.dehydrate((duration,))
+        assert struct == Structure(b"E", 1, 2, 3, 4)
+
+    def test_native_duration(self):
+        duration = datetime.timedelta(days=1, seconds=2, microseconds=3)
+        struct, = self.dehydrator.dehydrate((duration,))
+        assert struct == Structure(b"E", 0, 1, 2, 3000)
+
+    def test_duration_mixed_sign(self):
+        duration = Duration(months=1, days=-2, seconds=3, nanoseconds=4)
+        struct, = self.dehydrator.dehydrate((duration,))
+        assert struct == Structure(b"E", 1, -2, 3, 4)
+
+    def test_native_duration_mixed_sign(self):
+        duration = datetime.timedelta(days=-1, seconds=2, microseconds=3)
+        struct, = self.dehydrator.dehydrate((duration,))
+        assert struct == Structure(b"E", 0, -1, 2, 3000)

--- a/tests/unit/common/time/test_time.py
+++ b/tests/unit/common/time/test_time.py
@@ -17,12 +17,14 @@
 
 
 from datetime import time
-from decimal import Decimal
+import itertools
+import operator
 
 import pytest
 from pytz import (
     FixedOffset,
     timezone,
+    utc,
 )
 
 from neo4j.time import Time
@@ -236,3 +238,227 @@ class TestTime:
         assert t.second == native.second
         assert t.nanosecond == native.microsecond * 1000
         assert t.tzinfo == FixedOffset(0)
+
+    @pytest.mark.parametrize(("t1", "t2"), (
+        (time(12, 34, 56, 789123), Time(12, 34, 56, 789123000)),
+        (Time(12, 34, 56, 789123456), Time(12, 34, 56, 789123456)),
+        (
+            time(12, 34, 56, 789123, FixedOffset(1)),
+            Time(12, 34, 56, 789123000, FixedOffset(1))
+        ),
+        (
+            time(12, 34, 56, 789123, FixedOffset(-1)),
+            Time(12, 34, 56, 789123000, FixedOffset(-1))
+        ),
+        (
+            Time(12, 34, 56, 789123456, FixedOffset(1)),
+            Time(12, 34, 56, 789123456, FixedOffset(1))
+        ),
+        (
+            Time(12, 34, 56, 789123456, FixedOffset(-1)),
+            Time(12, 34, 56, 789123456, FixedOffset(-1))
+        ),
+        (
+            Time(12, 35, 56, 789123456, FixedOffset(1)),
+            Time(12, 34, 56, 789123456, FixedOffset(0))
+        ),
+        (
+            # Not testing our library directly, but asserting that Python's
+            # time implementation is aligned with ours.
+            time(12, 35, 56, 789123, FixedOffset(1)),
+            time(12, 34, 56, 789123, FixedOffset(0))
+        ),
+        (
+            time(12, 35, 56, 789123, FixedOffset(1)),
+            Time(12, 34, 56, 789123000, FixedOffset(0))
+        ),
+        (
+            Time(12, 35, 56, 789123123, FixedOffset(1)),
+            Time(12, 34, 56, 789123123, FixedOffset(0))
+        ),
+    ))
+    def test_equality(self, t1, t2):
+        assert t1 == t2
+        assert t2 == t1
+        assert t1 <= t2
+        assert t2 <= t1
+        assert t1 >= t2
+        assert t2 >= t1
+
+    @pytest.mark.parametrize(("t1", "t2"), (
+        (time(12, 34, 56, 789123), Time(12, 34, 56, 789123001)),
+        (time(12, 34, 56, 789123), Time(12, 34, 56, 789124000)),
+        (time(12, 34, 56, 789123), Time(12, 34, 57, 789123000)),
+        (time(12, 34, 56, 789123), Time(12, 35, 56, 789123000)),
+        (time(12, 34, 56, 789123), Time(13, 34, 56, 789123000)),
+        (Time(12, 34, 56, 789123456), Time(12, 34, 56, 789123450)),
+        (Time(12, 34, 56, 789123456), Time(12, 34, 57, 789123456)),
+        (Time(12, 34, 56, 789123456), Time(12, 35, 56, 789123456)),
+        (Time(12, 34, 56, 789123456), Time(13, 34, 56, 789123456)),
+        (
+            time(12, 34, 56, 789123, FixedOffset(2)),
+            Time(12, 34, 56, 789123000, FixedOffset(1))
+        ),
+        (
+            time(12, 34, 56, 789123, FixedOffset(-2)),
+            Time(12, 34, 56, 789123000, FixedOffset(-1))
+        ),
+        (
+            time(12, 34, 56, 789123),
+            Time(12, 34, 56, 789123000, FixedOffset(0))
+        ),
+        (
+            Time(12, 34, 56, 789123456, FixedOffset(2)),
+            Time(12, 34, 56, 789123456, FixedOffset(1))
+        ),
+        (
+            Time(12, 34, 56, 789123456, FixedOffset(-2)),
+            Time(12, 34, 56, 789123456, FixedOffset(-1))
+        ),
+        (
+            Time(12, 34, 56, 789123456),
+            Time(12, 34, 56, 789123456, FixedOffset(0))
+        ),
+        (
+            Time(13, 34, 56, 789123456, FixedOffset(1)),
+            Time(12, 34, 56, 789123456, FixedOffset(0))
+        ),
+        (
+            Time(11, 34, 56, 789123456, FixedOffset(1)),
+            Time(12, 34, 56, 789123456, FixedOffset(0))
+        ),
+    ))
+    def test_inequality(self, t1, t2):
+        assert t1 != t2
+        assert t2 != t1
+
+    @pytest.mark.parametrize(
+        ("t1", "t2"),
+        itertools.product(
+            (
+                time(12, 34, 56, 789123),
+                Time(12, 34, 56, 789123000),
+                time(12, 34, 56, 789123, FixedOffset(0)),
+                Time(12, 34, 56, 789123456, FixedOffset(0)),
+                time(12, 35, 56, 789123, FixedOffset(1)),
+                Time(12, 35, 56, 789123456, FixedOffset(1)),
+                time(12, 34, 56, 789123, FixedOffset(-1)),
+                Time(12, 34, 56, 789123456, FixedOffset(-1)),
+                time(12, 34, 56, 789123, FixedOffset(60 * -16)),
+                Time(12, 34, 56, 789123000, FixedOffset(60 * -16)),
+                time(11, 34, 56, 789123, FixedOffset(60 * -17)),
+                Time(11, 34, 56, 789123000, FixedOffset(60 * -17)),
+                Time(12, 34, 56, 789123456, FixedOffset(60 * -16)),
+                Time(11, 34, 56, 789123456, FixedOffset(60 * -17)),
+            ),
+            repeat=2
+        )
+    )
+    def test_hashed_equality(self, t1, t2):
+        if t1 == t2:
+            s = {t1}
+            assert t1 in s
+            assert t2 in s
+            s = {t2}
+            assert t1 in s
+            assert t2 in s
+        else:
+            s = {t1}
+            assert t1 in s
+            assert t2 not in s
+            s = {t2}
+            assert t1 not in s
+            assert t2 in s
+
+    @pytest.mark.parametrize(("t1", "t2"), (
+        itertools.product(
+            (
+                time(12, 34, 56, 789123),
+                Time(12, 34, 56, 789123000),
+                Time(12, 34, 56, 789123001),
+            ),
+            repeat=2
+        )
+    ))
+    @pytest.mark.parametrize("tz", (
+        FixedOffset(0), FixedOffset(1), FixedOffset(-1), utc,
+    ))
+    @pytest.mark.parametrize("op", (
+        operator.lt, operator.le, operator.gt, operator.ge,
+    ))
+    def test_comparison_with_only_one_naive_fails(self, t1, t2, tz, op):
+        t1 = t1.replace(tzinfo=tz)
+        with pytest.raises(TypeError, match="naive"):
+            op(t1, t2)
+
+    @pytest.mark.parametrize(
+        ("t1", "t2"),
+        itertools.product(
+            (
+                time(12, 34, 56, 789123),
+                Time(12, 34, 56, 789123000),
+                Time(12, 34, 56, 789123001),
+            ),
+            repeat=2
+        )
+    )
+    @pytest.mark.parametrize("tz", (
+        timezone("Europe/Paris"), timezone("Europe/Berlin"),
+    ))
+    @pytest.mark.parametrize("op", (
+        operator.lt, operator.le, operator.gt, operator.ge,
+    ))
+    def test_comparison_with_one_naive_and_not_fixed_tz(self, t1, t2, tz, op):
+        t1tz = t1.replace(tzinfo=tz)
+        res = op(t1tz, t2)
+        expected = op(t1, t2)
+        assert res is expected
+
+    @pytest.mark.parametrize(("t1", "t2"), (
+        (time(12, 34, 56, 789123), time(12, 34, 56, 789124)),
+        (Time(12, 34, 56, 789123000), time(12, 34, 56, 789124)),
+        (time(12, 34, 56, 789123), Time(12, 34, 56, 789124000)),
+        (Time(12, 34, 56, 789123000), Time(12, 34, 56, 789124000)),
+        (
+            time(12, 34, 56, 789123, FixedOffset(1)),
+            time(12, 34, 56, 789124, FixedOffset(1)),
+        ),
+        (
+            Time(12, 34, 56, 789123000, FixedOffset(1)),
+            time(12, 34, 56, 789124, FixedOffset(1)),
+        ),
+        (
+            Time(12, 34, 56, 789123000, FixedOffset(1)),
+            Time(12, 34, 56, 789124000, FixedOffset(1)),
+        ),
+        (
+            Time(12, 34, 56, 789123000, FixedOffset(1)),
+            Time(12, 34, 56, 789123001, FixedOffset(1)),
+        ),
+
+        (
+            time(12, 36, 56, 789123, FixedOffset(1)),
+            time(12, 34, 56, 789124, FixedOffset(-1)),
+        ),
+        (
+            Time(12, 36, 56, 789123000, FixedOffset(1)),
+            time(12, 34, 56, 789124, FixedOffset(-1)),
+        ),
+        (
+            Time(12, 36, 56, 789123000, FixedOffset(1)),
+            Time(12, 34, 56, 789124000, FixedOffset(-1)),
+        ),
+        (
+            Time(12, 36, 56, 789123000, FixedOffset(1)),
+            Time(12, 34, 56, 789123001, FixedOffset(-1)),
+        ),
+    ))
+    def test_comparison(self, t1, t2):
+        assert t1 < t2
+        assert not t2 < t1
+        assert t1 <= t2
+        assert not t2 <= t1
+        assert t2 > t1
+        assert not t1 > t2
+        assert t2 >= t1
+        assert not t1 >= t2


### PR DESCRIPTION
 * Similarly to https://github.com/neo4j/neo4j-python-driver/pull/616,
   `DateTime` objects with fixed negative UTC offset were incorrectly
   serialized before sent to the database.
 * Comparison operators of several temporal types was incorrect.