### PR TITLE
Remove usage of memoryview calls

### DIFF
--- a/neo4j/_async/io/_bolt.py
+++ b/neo4j/_async/io/_bolt.py
@@ -448,7 +448,7 @@ class AsyncBolt:
         self.responses.append(response)
 
     async def _send_all(self):
-        data = self.outbox.view()
+        data = self.outbox.chunked_data()
         if data:
             try:
                 await self.socket.sendall(data)

--- a/neo4j/_async/io/_common.py
+++ b/neo4j/_async/io/_common.py
@@ -109,7 +109,6 @@ class Outbox:
         )
         num_chunks = num_full_chunks + bool(chunk_rest)
 
-        data_view = memoryview(self._raw_data)
         header_start = len(self._chunked_data)
         data_start = header_start + 2
         raw_data_start = 0
@@ -120,20 +119,19 @@ class Outbox:
                 ">H", chunk_size
             )
             self._chunked_data[data_start:(data_start + chunk_size)] = \
-                data_view[raw_data_start:(raw_data_start + chunk_size)]
+                self._raw_data[raw_data_start:(raw_data_start + chunk_size)]
             header_start += chunk_size + 2
             data_start = header_start + 2
             raw_data_start += chunk_size
-        del data_view
         self._raw_data.clear()
 
     def wrap_message(self):
         self._chunk_data()
         self._chunked_data += b"\x00\x00"
 
-    def view(self):
+    def chunked_data(self):
         self._chunk_data()
-        return memoryview(self._chunked_data)
+        return self._chunked_data
 
 
 class ConnectionErrorHandler:
@@ -272,9 +270,9 @@ async def receive_into_buffer(sock, buffer, n_bytes):
     end = buffer.used + n_bytes
     if end > len(buffer.data):
         buffer.data += bytearray(end - len(buffer.data))
-    view = memoryview(buffer.data)
-    while buffer.used < end:
-        n = await sock.recv_into(view[buffer.used:end], end - buffer.used)
-        if n == 0:
-            raise OSError("No data")
-        buffer.used += n
+    with memoryview(buffer.data) as view:
+        while buffer.used < end:
+            n = await sock.recv_into(view[buffer.used:end], end - buffer.used)
+            if n == 0:
+                raise OSError("No data")
+            buffer.used += n

--- a/neo4j/_sync/io/_bolt.py
+++ b/neo4j/_sync/io/_bolt.py
@@ -448,7 +448,7 @@ class Bolt:
         self.responses.append(response)
 
     def _send_all(self):
-        data = self.outbox.view()
+        data = self.outbox.chunked_data()
         if data:
             try:
                 self.socket.sendall(data)

--- a/neo4j/packstream.py
+++ b/neo4j/packstream.py
@@ -292,13 +292,13 @@ class Unpacker:
         # Bytes
         elif marker == 0xCC:
             size, = struct_unpack(">B", self.read(1))
-            return self.read(size).tobytes()
+            return bytes(self.read(size))
         elif marker == 0xCD:
             size, = struct_unpack(">H", self.read(2))
-            return self.read(size).tobytes()
+            return bytes(self.read(size))
         elif marker == 0xCE:
             size, = struct_unpack(">I", self.read(4))
-            return self.read(size).tobytes()
+            return bytes(self.read(size))
 
         else:
             marker_high = marker & 0xF0
@@ -424,8 +424,8 @@ class Unpacker:
     def _unpack_structure_header(self, marker):
         marker_high = marker & 0xF0
         if marker_high == 0xB0:  # TINY_STRUCT
-            signature = self.read(1).tobytes()
-            return marker & 0x0F, signature
+            signature = self.read(1)
+            return marker & 0x0F, bytes(signature)
         else:
             raise ValueError("Expected structure, found marker %02X" % marker)
 
@@ -448,11 +448,10 @@ class UnpackableBuffer:
         self.p = 0
 
     def read(self, n=1):
-        view = memoryview(self.data)
         q = self.p + n
-        subview = view[self.p:q]
+        data = self.data[self.p:q]
         self.p = q
-        return subview
+        return data
 
     def read_u8(self):
         if self.used - self.p >= 1:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -266,8 +266,8 @@ def neo4j_uri(service, target):
 
 
 @pytest.fixture(scope="session")
-def uri(bolt_uri):
-    return bolt_uri
+def uri(neo4j_uri):
+    return neo4j_uri
 
 
 # @fixture(scope="session")
@@ -340,8 +340,8 @@ def driver(neo4j_driver):
 
 
 @pytest.fixture()
-def session(bolt_driver):
-    session = bolt_driver.session()
+def session(neo4j_driver):
+    session = neo4j_driver.session()
     try:
         yield session
     finally:
@@ -356,7 +356,7 @@ def protocol_version(session):
 
 
 @pytest.fixture()
-def cypher_eval(bolt_driver):
+def cypher_eval(neo4j_driver):
 
     def run_and_rollback(tx, cypher, **parameters):
         result = tx.run(cypher, **parameters)
@@ -365,7 +365,7 @@ def cypher_eval(bolt_driver):
         return value
 
     def f(cypher, **parameters):
-        with bolt_driver.session() as session:
+        with neo4j_driver.session() as session:
             return session.write_transaction(run_and_rollback, cypher, **parameters)
 
     return f

--- a/tests/integration/examples/test_transaction_function_example.py
+++ b/tests/integration/examples/test_transaction_function_example.py
@@ -46,8 +46,8 @@ class TransactionFunctionExample:
         return add_person(self.driver, name)
 
 
-def test_example(bolt_driver):
-    eg = TransactionFunctionExample(bolt_driver)
+def test_example(neo4j_driver):
+    eg = TransactionFunctionExample(neo4j_driver)
     with eg.driver.session() as session:
         session.run("MATCH (_) DETACH DELETE _")
         eg.add_person("Alice")

--- a/tests/integration/examples/test_transaction_metadata_config_example.py
+++ b/tests/integration/examples/test_transaction_metadata_config_example.py
@@ -44,8 +44,8 @@ class TransactionMetadataConfigExample:
         return add_person(self.driver, name)
 
 
-def test_example(bolt_driver):
-    eg = TransactionMetadataConfigExample(bolt_driver)
+def test_example(neo4j_driver):
+    eg = TransactionMetadataConfigExample(neo4j_driver)
     with eg.driver.session() as session:
         session.run("MATCH (_) DETACH DELETE _")
         eg.add_person("Alice")

--- a/tests/integration/examples/test_transaction_timeout_config_example.py
+++ b/tests/integration/examples/test_transaction_timeout_config_example.py
@@ -44,8 +44,8 @@ class TransactionTimeoutConfigExample:
         return add_person(self.driver, name)
 
 
-def test_example(bolt_driver):
-    eg = TransactionTimeoutConfigExample(bolt_driver)
+def test_example(neo4j_driver):
+    eg = TransactionTimeoutConfigExample(neo4j_driver)
     with eg.driver.session() as session:
         session.run("MATCH (_) DETACH DELETE _")
         eg.add_person("Alice")

--- a/tests/unit/async_/io/test__common.py
+++ b/tests/unit/async_/io/test__common.py
@@ -40,11 +40,11 @@ from neo4j._async.io._common import Outbox
 ))
 def test_async_outbox_chunking(chunk_size, data, result):
     outbox = Outbox(max_chunk_size=chunk_size)
-    assert bytes(outbox.view()) == b""
+    assert bytes(outbox.chunked_data()) == b""
     for d in data:
         outbox.write(d)
-    assert bytes(outbox.view()) == result
+    assert bytes(outbox.chunked_data()) == result
     # make sure this works multiple times
-    assert bytes(outbox.view()) == result
+    assert bytes(outbox.chunked_data()) == result
     outbox.clear()
-    assert bytes(outbox.view()) == b""
+    assert bytes(outbox.chunked_data()) == b""

--- a/tests/unit/sync/io/test__common.py
+++ b/tests/unit/sync/io/test__common.py
@@ -40,11 +40,11 @@ from neo4j._sync.io._common import Outbox
 ))
 def test_async_outbox_chunking(chunk_size, data, result):
     outbox = Outbox(max_chunk_size=chunk_size)
-    assert bytes(outbox.view()) == b""
+    assert bytes(outbox.chunked_data()) == b""
     for d in data:
         outbox.write(d)
-    assert bytes(outbox.view()) == result
+    assert bytes(outbox.chunked_data()) == result
     # make sure this works multiple times
-    assert bytes(outbox.view()) == result
+    assert bytes(outbox.chunked_data()) == result
     outbox.clear()
-    assert bytes(outbox.view()) == b""
+    assert bytes(outbox.chunked_data()) == b""


### PR DESCRIPTION
On paper, memoryviews seem like a good tool to increase the driver's efficiency.
In practice, they seem to yield no measurable performance improvement (probably
due to the overhead of their creation and lifetime handling), but instead cause
issues if not properly used.

:warning: DO NOT MERGE :warning: 
This PR is only meant to run the pipelines