### PR TITLE
API docs: add `CALL {...} IN TRANSACTIONS`

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -653,10 +653,14 @@ Each has pros and cons but if in doubt, use a managed transaction with a `transa
 
 Auto-commit Transactions
 ========================
-Auto-commit transactions are the simplest form of transaction, available via :py:meth:`neo4j.Session.run`.
+Auto-commit transactions are the simplest form of transaction, available via
+:py:meth:`neo4j.Session.run`. These are easy to use but support only one
+statement per transaction and are not automatically retried on failure.
 
-These are easy to use but support only one statement per transaction and are not automatically retried on failure.
-Auto-commit transactions are also the only way to run ``PERIODIC COMMIT`` statements, since this Cypher clause manages its own transactions internally.
+Auto-commit transactions are also the only way to run ``PERIODIC COMMIT``
+(only Neo4j 4.4 and earlier) or ``CALL {...} IN TRANSACTIONS`` (Neo4j 5.0 and
+newer) statements, since those Cypher clauses manage their own transactions
+internally.
 
 Example:
 

--- a/docs/source/async_api.rst
+++ b/docs/source/async_api.rst
@@ -351,12 +351,16 @@ Each has pros and cons but if in doubt, use a managed transaction with a `transa
 
 .. _async-auto-commit-transactions-ref:
 
-Async Auto-commit Transactions
-==============================
-Auto-commit transactions are the simplest form of transaction, available via :py:meth:`neo4j.AsyncSession.run`.
+Auto-commit Transactions
+========================
+Auto-commit transactions are the simplest form of transaction, available via
+:py:meth:`neo4j.Session.run`. These are easy to use but support only one
+statement per transaction and are not automatically retried on failure.
 
-These are easy to use but support only one statement per transaction and are not automatically retried on failure.
-Auto-commit transactions are also the only way to run ``PERIODIC COMMIT`` statements, since this Cypher clause manages its own transactions internally.
+Auto-commit transactions are also the only way to run ``PERIODIC COMMIT``
+(only Neo4j 4.4 and earlier) or ``CALL {...} IN TRANSACTIONS`` (Neo4j 5.0 and
+newer) statements, since those Cypher clauses manage their own transactions
+internally.
 
 Example:
 


### PR DESCRIPTION
Just like auto-commit transactions are required for `PERIODIC COMMIT` queries
(Neo4j <= 4.4) they are required for the new `CALL {...} IN TRANSACTIONS`
queries (Neo4j >= 5.0).