### PR TITLE
Warn about using ssl_context config option

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -323,7 +323,7 @@ If given, ``encrypted`` and ``trusted_certificates`` have no effect.
 .. warning::
     This option may compromise your application's security if used improperly.
 
-    Its usage is strongly discouraged and and comes without any guarantees.
+    Its usage is strongly discouraged and comes without any guarantees.
 
 :Type: :class:`ssl.SSLContext` or :const:`None`
 :Default: :const:`None`

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -318,7 +318,12 @@ This setting does not have any effect if ``encrypted`` is set to ``False``.
 ---------------
 Specify a custom SSL context to use for wrapping connections.
 
-If give, ``encrypted`` and ``trusted_certificates`` have no effect.
+If given, ``encrypted`` and ``trusted_certificates`` have no effect.
+
+.. warning::
+    This option may compromise your application's security if used improperly.
+
+    Its usage is strongly discouraged and and comes without any guarantees.
 
 :Type: :class:`ssl.SSLContext` or :const:`None`
 :Default: :const:`None`


### PR DESCRIPTION
Update docs added with https://github.com/neo4j/neo4j-python-driver/pull/639