### PR TITLE
Remove legacy handling for `"COMMIT"` query

### DIFF
--- a/neo4j/_async/io/_bolt3.py
+++ b/neo4j/_async/io/_bolt3.py
@@ -238,11 +238,7 @@ class AsyncBolt3(AsyncBolt):
                 raise ValueError("Timeout must be a positive number or 0.")
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port, " ".join(map(repr, fields)))
-        if query.upper() == u"COMMIT":
-            self._append(b"\x10", fields, CommitResponse(self, "run",
-                                                         **handlers))
-        else:
-            self._append(b"\x10", fields, Response(self, "run", **handlers))
+        self._append(b"\x10", fields, Response(self, "run", **handlers))
 
     def discard(self, n=-1, qid=-1, **handlers):
         # Just ignore n and qid, it is not supported in the Bolt 3 Protocol.

--- a/neo4j/_async/io/_bolt4.py
+++ b/neo4j/_async/io/_bolt4.py
@@ -186,11 +186,7 @@ class AsyncBolt4x0(AsyncBolt):
                 raise ValueError("Timeout must be a positive number or 0.")
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port, " ".join(map(repr, fields)))
-        if query.upper() == u"COMMIT":
-            self._append(b"\x10", fields, CommitResponse(self, "run",
-                                                         **handlers))
-        else:
-            self._append(b"\x10", fields, Response(self, "run", **handlers))
+        self._append(b"\x10", fields, Response(self, "run", **handlers))
 
     def discard(self, n=-1, qid=-1, **handlers):
         extra = {"n": n}
@@ -467,11 +463,7 @@ class AsyncBolt4x4(AsyncBolt4x3):
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port,
                   " ".join(map(repr, fields)))
-        if query.upper() == u"COMMIT":
-            self._append(b"\x10", fields, CommitResponse(self, "run",
-                                                         **handlers))
-        else:
-            self._append(b"\x10", fields, Response(self, "run", **handlers))
+        self._append(b"\x10", fields, Response(self, "run", **handlers))
 
     def begin(self, mode=None, bookmarks=None, metadata=None, timeout=None,
               db=None, imp_user=None, **handlers):

--- a/neo4j/_async/io/_bolt5.py
+++ b/neo4j/_async/io/_bolt5.py
@@ -184,11 +184,7 @@ class AsyncBolt5x0(AsyncBolt):
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port,
                   " ".join(map(repr, fields)))
-        if query.upper() == u"COMMIT":
-            self._append(b"\x10", fields, CommitResponse(self, "run",
-                                                         **handlers))
-        else:
-            self._append(b"\x10", fields, Response(self, "run", **handlers))
+        self._append(b"\x10", fields, Response(self, "run", **handlers))
 
     def discard(self, n=-1, qid=-1, **handlers):
         extra = {"n": n}

--- a/neo4j/_sync/io/_bolt3.py
+++ b/neo4j/_sync/io/_bolt3.py
@@ -238,11 +238,7 @@ class Bolt3(Bolt):
                 raise ValueError("Timeout must be a positive number or 0.")
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port, " ".join(map(repr, fields)))
-        if query.upper() == u"COMMIT":
-            self._append(b"\x10", fields, CommitResponse(self, "run",
-                                                         **handlers))
-        else:
-            self._append(b"\x10", fields, Response(self, "run", **handlers))
+        self._append(b"\x10", fields, Response(self, "run", **handlers))
 
     def discard(self, n=-1, qid=-1, **handlers):
         # Just ignore n and qid, it is not supported in the Bolt 3 Protocol.

--- a/neo4j/_sync/io/_bolt4.py
+++ b/neo4j/_sync/io/_bolt4.py
@@ -186,11 +186,7 @@ class Bolt4x0(Bolt):
                 raise ValueError("Timeout must be a positive number or 0.")
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port, " ".join(map(repr, fields)))
-        if query.upper() == u"COMMIT":
-            self._append(b"\x10", fields, CommitResponse(self, "run",
-                                                         **handlers))
-        else:
-            self._append(b"\x10", fields, Response(self, "run", **handlers))
+        self._append(b"\x10", fields, Response(self, "run", **handlers))
 
     def discard(self, n=-1, qid=-1, **handlers):
         extra = {"n": n}
@@ -467,11 +463,7 @@ class Bolt4x4(Bolt4x3):
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port,
                   " ".join(map(repr, fields)))
-        if query.upper() == u"COMMIT":
-            self._append(b"\x10", fields, CommitResponse(self, "run",
-                                                         **handlers))
-        else:
-            self._append(b"\x10", fields, Response(self, "run", **handlers))
+        self._append(b"\x10", fields, Response(self, "run", **handlers))
 
     def begin(self, mode=None, bookmarks=None, metadata=None, timeout=None,
               db=None, imp_user=None, **handlers):

--- a/neo4j/_sync/io/_bolt5.py
+++ b/neo4j/_sync/io/_bolt5.py
@@ -184,11 +184,7 @@ class Bolt5x0(Bolt):
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port,
                   " ".join(map(repr, fields)))
-        if query.upper() == u"COMMIT":
-            self._append(b"\x10", fields, CommitResponse(self, "run",
-                                                         **handlers))
-        else:
-            self._append(b"\x10", fields, Response(self, "run", **handlers))
+        self._append(b"\x10", fields, Response(self, "run", **handlers))
 
     def discard(self, n=-1, qid=-1, **handlers):
         extra = {"n": n}


### PR DESCRIPTION
In BOLT <= v2, transactions would be committed with a `"COMMIT"` query, for
which the driver had some special handling. Since this query is not in use
anymore, this special handling (which got carried over) can be removed.