### PR TITLE
Fix pool connection ownership

### DIFF
--- a/neo4j/_async/io/_pool.py
+++ b/neo4j/_async/io/_pool.py
@@ -241,13 +241,16 @@ class AsyncIOPool(abc.ABC):
                 connections = self.connections[address]
             except KeyError:  # already removed from the connection pool
                 return
-            for conn in list(connections):
-                if not conn.in_use:
-                    connections.remove(conn)
-                    try:
-                        await conn.close()
-                    except OSError:
-                        pass
+            closable_connections = [
+                conn for conn in connections if not conn.in_use
+            ]
+            # First remove all connections in question, then try to close them.
+            # If closing of a connection fails, we will end up in this method
+            # again.
+            for conn in closable_connections:
+                connections.remove(conn)
+            for conn in closable_connections:
+                await conn.close()
             if not self.connections[address]:
                 del self.connections[address]
 

--- a/neo4j/_sync/io/_pool.py
+++ b/neo4j/_sync/io/_pool.py
@@ -241,13 +241,16 @@ class IOPool(abc.ABC):
                 connections = self.connections[address]
             except KeyError:  # already removed from the connection pool
                 return
-            for conn in list(connections):
-                if not conn.in_use:
-                    connections.remove(conn)
-                    try:
-                        conn.close()
-                    except OSError:
-                        pass
+            closable_connections = [
+                conn for conn in connections if not conn.in_use
+            ]
+            # First remove all connections in question, then try to close them.
+            # If closing of a connection fails, we will end up in this method
+            # again.
+            for conn in closable_connections:
+                connections.remove(conn)
+            for conn in closable_connections:
+                conn.close()
             if not self.connections[address]:
                 del self.connections[address]
 

--- a/tests/unit/async_/io/test_neo4j_pool.py
+++ b/tests/unit/async_/io/test_neo4j_pool.py
@@ -35,10 +35,6 @@ from neo4j.exceptions import (
 )
 
 from ...._async_compat import mark_async_test
-from ..._async_compat import (
-    AsyncMock,
-    mark_async_test,
-)
 from ..work import async_fake_connection_generator
 
 
@@ -389,6 +385,39 @@ async def test_acquire_returns_other_connection_on_failed_liveness_check(
     assert cx1 not in pool.connections[cx1.addr]
     assert cx3 in pool.connections[cx1.addr]
 
+
+@mark_async_test
+async def test_multiple_broken_connections_on_close(opener, mocker):
+    def mock_connection_breaks_on_close(cx):
+        async def close_side_effect():
+            cx.closed.return_value = True
+            cx.defunct.return_value = True
+            await pool.deactivate(READER_ADDRESS)
+
+        cx.attach_mock(mocker.AsyncMock(side_effect=close_side_effect),
+                       "close")
+
+    # create pool with 2 idle connections
+    pool = AsyncNeo4jPool(
+        opener, PoolConfig(), WorkspaceConfig(), ROUTER_ADDRESS
+    )
+    cx1 = await pool.acquire(READ_ACCESS, 30, "test_db", None)
+    cx2 = await pool.acquire(READ_ACCESS, 30, "test_db", None)
+    await pool.release(cx1)
+    await pool.release(cx2)
+
+    # both will loose connection
+    mock_connection_breaks_on_close(cx1)
+    mock_connection_breaks_on_close(cx2)
+
+    # force pool to close cx1, which will make it realize that the server is
+    # unreachable
+    cx1.stale.return_value = True
+
+    cx3 = await pool.acquire(READ_ACCESS, 30, "test_db", None)
+
+    assert cx3 is not cx1
+    assert cx3 is not cx2
 
 
 @mark_async_test


### PR DESCRIPTION
Fixing and testing two faulty corner-cases
 * When a connection fails, all idle connections to that host will be closed.
   If their closure fails, the same action is invoked recursively while being
   in the process of closing idle connections already. This leads to
   inconsistent data.
 * [4.4 only] When opening of a new connection fails, the pool used to
   forcefully close all connections to the host, including lent
   connections. Opening the doors wide for race conditions because connections
   are not thread safe.