### PR TITLE
[4.4] Fix pool connection ownership 4.4

### DIFF
--- a/tests/unit/io/test_neo4j_pool.py
+++ b/tests/unit/io/test_neo4j_pool.py
@@ -232,6 +232,36 @@ def test_release_does_not_resets_defunct_connections(opener):
     cx1.reset.asset_not_called()
 
 
+def test_multiple_broken_connections_on_close(opener):
+    def mock_connection_breaks_on_close(cx):
+        def close_side_effect():
+            cx.closed.return_value = True
+            cx.defunct.return_value = True
+            pool.deactivate(READER_ADDRESS)
+
+        cx.attach_mock(Mock(side_effect=close_side_effect), "close")
+
+    # create pool with 2 idle connections
+    pool = Neo4jPool(opener, PoolConfig(), WorkspaceConfig(), ROUTER_ADDRESS)
+    cx1 = pool.acquire(READ_ACCESS, 30, "test_db", None)
+    cx2 = pool.acquire(READ_ACCESS, 30, "test_db", None)
+    pool.release(cx1)
+    pool.release(cx2)
+
+    # both will loose connection
+    mock_connection_breaks_on_close(cx1)
+    mock_connection_breaks_on_close(cx2)
+
+    # force pool to close cx1, which will make it realize that the server is
+    # unreachable
+    cx1.stale.return_value = True
+
+    cx3 = pool.acquire(READ_ACCESS, 30, "test_db", None)
+
+    assert cx3 is not cx1
+    assert cx3 is not cx2
+
+
 def test_failing_opener_leaves_connections_in_use_alone(opener):
     pool = Neo4jPool(opener, PoolConfig(), WorkspaceConfig(), ROUTER_ADDRESS)
     cx1 = pool.acquire(READ_ACCESS, 30, "test_db", None)


### PR DESCRIPTION
Backport or https://github.com/neo4j/neo4j-python-driver/pull/732

Fixing and testing two faulty corner-cases
 * When a connection fails, all idle connections to that host will be closed.
   If their closure fails, the same action is invoked recursively while being
   in the process of closing idle connections already. This leads to
   inconsistent data.
 * [4.4 only] When opening of a new connection fails, the pool used to
   forcefully close all connections to the host, including lent
   connections. Opening the doors wide for race conditions because connections
   are not thread safe.