### PR TITLE
Clean up API docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -275,8 +275,8 @@ For example:
            raise gaierror("Unexpected socket address %r" % socket_address)
 
    driver = GraphDatabase.driver("neo4j://example.com:9999",
-                auth=("neo4j", "password"),
-                resolver=custom_resolver)
+                                 auth=("neo4j", "password"),
+                                 resolver=custom_resolver)
 
 
 :Default: :const:`None`
@@ -541,9 +541,9 @@ Name of the database to query.
 
 
 .. py:attribute:: neo4j.DEFAULT_DATABASE
-   :noindex:
+    :noindex:
 
-   This will use the default database on the Neo4j instance.
+    This will use the default database on the Neo4j instance.
 
 
 .. Note::
@@ -558,9 +558,10 @@ Name of the database to query.
 
 .. code-block:: python
 
-   from neo4j import GraphDatabase
-   driver = GraphDatabase.driver(uri, auth=(user, password))
-   session = driver.session(database="system")
+    from neo4j import GraphDatabase
+
+    driver = GraphDatabase.driver(uri, auth=(user, password))
+    session = driver.session(database="system")
 
 
 :Default: ``neo4j.DEFAULT_DATABASE``
@@ -593,9 +594,10 @@ context of the impersonated user. For this, the user for which the
 
 .. code-block:: python
 
-   from neo4j import GraphDatabase
-   driver = GraphDatabase.driver(uri, auth=(user, password))
-   session = driver.session(impersonated_user="alice")
+    from neo4j import GraphDatabase
+
+    driver = GraphDatabase.driver(uri, auth=(user, password))
+    session = driver.session(impersonated_user="alice")
 
 
 :Default: :const:`None`
@@ -740,8 +742,8 @@ Example:
     def set_person_name(tx, node_id, name):
         query = "MATCH (a:Person) WHERE id(a) = $id SET a.name = $name"
         result = tx.run(query, id=node_id, name=name)
-        info = result.consume()
-        # use the info for logging etc.
+        summary = result.consume()
+        # use the summary for logging etc.
 
 .. _managed-transactions-ref:
 

--- a/docs/source/async_api.rst
+++ b/docs/source/async_api.rst
@@ -446,8 +446,8 @@ Example:
     async def set_person_name(tx, node_id, name):
         query = "MATCH (a:Person) WHERE id(a) = $id SET a.name = $name"
         result = await tx.run(query, id=node_id, name=name)
-        info = await result.consume()
-        # use the info for logging etc.
+        summary = await result.consume()
+        # use the summary for logging etc.
 
 .. _async-managed-transactions-ref:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,7 +57,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Neo4j Python Driver'
-copyright = '2002-2020 Neo4j, Inc.'
+copyright = 'Neo4j, Inc.'
 author = 'Neo4j, Inc.'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/types/spatial.rst
+++ b/docs/source/types/spatial.rst
@@ -12,7 +12,7 @@ Point
 
 .. autoclass:: neo4j.spatial.Point
     :show-inheritance:
-    :members: srid
+    :members:
 
 
 CartesianPoint
@@ -21,9 +21,6 @@ CartesianPoint
 .. autoclass:: neo4j.spatial.CartesianPoint
     :show-inheritance:
 
-    .. property:: srid
-        :type: int
-
     .. property:: x
         :type: float
 
@@ -39,7 +36,7 @@ CartesianPoint
 
         Same value as ``point[2]``.
 
-        Only available if the point is in space.
+        Only available if the point is in 3D space.
 
 
 Examples
@@ -47,16 +44,20 @@ Examples
 
 .. code-block:: python
 
-    point=CartesianPoint((1.23, 4.56)
+    from neo4j.spatial import CartesianPoint
 
-    print(point.x, point.y)
+    point = CartesianPoint((1.23, 4.56)
+    print(point.x, point.y, point.srid)
+    # 1.23 4.56 7203
 
 
 .. code-block:: python
 
-    point=CartesianPoint((1.23, 4.56, 7.89)
+    from neo4j.spatial import CartesianPoint
 
-    print(point.x, point.y, point.z)
+    point = CartesianPoint((1.23, 4.56, 7.89)
+    print(point.x, point.y, point.z, point.srid)
+    # 1.23 4.56 7.8 9157
 
 
 WGS84Point
@@ -65,9 +66,6 @@ WGS84Point
 .. autoclass:: neo4j.spatial.WGS84Point
     :show-inheritance:
 
-    .. property:: srid
-        :type: int
-
     .. property:: x
         :type: float
 
@@ -83,7 +81,7 @@ WGS84Point
 
         Same value as ``point[2]``.
 
-        Only available if the point is in space.
+        Only available if the point is in 3D space.
 
     .. property:: longitude
         :type: float
@@ -100,7 +98,7 @@ WGS84Point
 
         Alias for :attr:`.z`.
 
-        Only available if the point is in space.
+        Only available if the point is in 3D space.
 
 
 Examples
@@ -108,11 +106,17 @@ Examples
 
 .. code-block:: python
 
-    point=WGS84Point((1.23, 4.56))
-    print(point.longitude, point.latitude)
+    from neo4j.spatial import WGS84Point
+
+    point = WGS84Point((1.23, 4.56))
+    print(point.longitude, point.latitude, point.srid)
+    # 1.23 4.56 4326
 
 
 .. code-block:: python
 
-    point=WGS84Point((1.23, 4.56, 7.89))
-    print(point.longitude, point.latitude, point.height)
+    from neo4j.spatial import WGS84Point
+
+    point = WGS84Point((1.23, 4.56, 7.89))
+    print(point.longitude, point.latitude, point.height, point.srid)
+    # 1.23 4.56 7.89 4979

--- a/neo4j/_async/work/session.py
+++ b/neo4j/_async/work/session.py
@@ -468,9 +468,12 @@ class AsyncSession(AsyncWorkspace):
                     if len(values) >= 2:
                         break
                     values.append(record.values())
+                # or shorter: values = [record.values()
+                #                       for record in await result.fetch(2)]
+
                 # discard the remaining records if there are any
-                info = await result.consume()
-                # use the info for logging etc.
+                summary = await result.consume()
+                # use the summary for logging etc.
                 return values
 
             async with driver.session() as session:

--- a/neo4j/_conf.py
+++ b/neo4j/_conf.py
@@ -30,7 +30,7 @@ class TrustSystemCAs(TrustStore):
 
     For example::
 
-        import noe4j
+        import neo4j
 
         driver = neo4j.GraphDatabase.driver(
             url, auth=auth, trusted_certificates=neo4j.TrustSystemCAs()
@@ -50,7 +50,7 @@ class TrustAll(TrustStore):
 
     For example::
 
-        import noe4j
+        import neo4j
 
         driver = neo4j.GraphDatabase.driver(
             url, auth=auth, trusted_certificates=neo4j.TrustAll()
@@ -73,7 +73,7 @@ class TrustCustomCAs(TrustStore):
 
     For example::
 
-        import noe4j
+        import neo4j
 
         driver = neo4j.GraphDatabase.driver(
             url, auth=auth,

--- a/neo4j/_conf.py
+++ b/neo4j/_conf.py
@@ -30,6 +30,8 @@ class TrustSystemCAs(TrustStore):
 
     For example::
 
+        import noe4j
+
         driver = neo4j.GraphDatabase.driver(
             url, auth=auth, trusted_certificates=neo4j.TrustSystemCAs()
         )
@@ -47,6 +49,8 @@ class TrustAll(TrustStore):
 
 
     For example::
+
+        import noe4j
 
         driver = neo4j.GraphDatabase.driver(
             url, auth=auth, trusted_certificates=neo4j.TrustAll()
@@ -68,6 +72,8 @@ class TrustCustomCAs(TrustStore):
         certificate.
 
     For example::
+
+        import noe4j
 
         driver = neo4j.GraphDatabase.driver(
             url, auth=auth,

--- a/neo4j/_sync/work/session.py
+++ b/neo4j/_sync/work/session.py
@@ -468,9 +468,12 @@ class Session(Workspace):
                     if len(values) >= 2:
                         break
                     values.append(record.values())
+                # or shorter: values = [record.values()
+                #                       for record in result.fetch(2)]
+
                 # discard the remaining records if there are any
-                info = result.consume()
-                # use the info for logging etc.
+                summary = result.consume()
+                # use the summary for logging etc.
                 return values
 
             with driver.session() as session:

--- a/neo4j/spatial/__init__.py
+++ b/neo4j/spatial/__init__.py
@@ -56,7 +56,9 @@ class Point(tuple):
     #: The SRID (spatial reference identifier) of the spatial data.
     #: A number that identifies the coordinate system the spatial type is to be
     #: interpreted in.
-    srid = None  # type: int
+    #:
+    #: :type: int
+    srid = None
 
     def __new__(cls, iterable):
         return tuple.__new__(cls, map(float, iterable))

--- a/neo4j/work/query.py
+++ b/neo4j/work/query.py
@@ -24,7 +24,7 @@ class Query:
     :param metadata: metadata attached to the query.
     :type metadata: dict
     :param timeout: seconds.
-    :type timeout: float or None
+    :type timeout: float or :const:`None`
     """
     def __init__(self, text, metadata=None, timeout=None):
         self.text = text
@@ -40,6 +40,8 @@ def unit_of_work(metadata=None, timeout=None):
     """This function is a decorator for transaction functions that allows extra control over how the transaction is carried out.
 
     For example, a timeout may be applied::
+
+        from neo4j import unit_of_work
 
         @unit_of_work(timeout=100)
         def count_people_tx(tx):
@@ -62,7 +64,7 @@ def unit_of_work(metadata=None, timeout=None):
         Value should not represent a negative duration.
         A zero duration will make the transaction execute indefinitely.
         None will use the default timeout configured in the database.
-    :type timeout: float or None
+    :type timeout: float or :const:`None`
     """
 
     def wrapper(f):


### PR DESCRIPTION
 * remove year from copy-right
 * amend imports where missing
 * improve code readability
 * document `srid` values of spatial types
 * document `ResultConsumedError` can be raised from `Result.fetch`