### PR TITLE
[4.4] Fix typo in api docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1130,7 +1130,7 @@ Examples
 
     from neo4j.spatial import CartesianPoint
 
-    point = CartesianPoint((1.23, 4.56)
+    point = CartesianPoint((1.23, 4.56))
     print(point.x, point.y, point.srid)
     # 1.23 4.56 7203
 
@@ -1139,7 +1139,7 @@ Examples
 
     from neo4j.spatial import CartesianPoint
 
-    point = CartesianPoint((1.23, 4.56, 7.89)
+    point = CartesianPoint((1.23, 4.56, 7.89))
     print(point.x, point.y, point.z, point.srid)
     # 1.23 4.56 7.8 9157
 


### PR DESCRIPTION
Amend missing closing parentheses.

Backport of https://github.com/neo4j/neo4j-python-driver/pull/740