### PR TITLE
Include log level in logging by default

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1446,7 +1446,7 @@ Full Controll
     handler = logging.StreamHandler(sys.stdout)
     # configure the handler to your liking
     handler.setFormatter(logging.Formatter(
-        "%(threadName)s(%(thread)d) %(asctime)s  %(message)s"
+        "[%(levelname)-8s] %(threadName)s(%(thread)d) %(asctime)s  %(message)s"
     ))
     # add the handler to the driver's logger
     logging.getLogger("neo4j").addHandler(handler)

--- a/neo4j/debug.py
+++ b/neo4j/debug.py
@@ -96,8 +96,7 @@ class Watcher:
 
         format = "%(threadName)s(%(thread)d) %(asctime)s  %(message)s"
         if not colour:
-            format = "[%(levelname)s] " + format
-
+            format = "[%(levelname)-8s] " + format
         formatter_cls = ColourFormatter if colour else Formatter
         self.formatter = formatter_cls(format)
 

--- a/tests/unit/common/test_debug.py
+++ b/tests/unit/common/test_debug.py
@@ -180,5 +180,5 @@ def test_watcher_format(add_handler_mocker, colour):
     if colour:
         assert format == "%(threadName)s(%(thread)d) %(asctime)s  %(message)s"
     else:
-        assert format == "[%(levelname)s] " \
+        assert format == "[%(levelname)-8s] " \
                          "%(threadName)s(%(thread)d) %(asctime)s  %(message)s"


### PR DESCRIPTION
 - API docs: include log level in example logger config
 - logging helper: add log level if not encoded with color