### PR TITLE
Raise hydration errors on value access

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1248,7 +1248,6 @@ Neo4j Execution Errors
 .. autoclass:: neo4j.exceptions.Neo4jError
     :members: message, code, is_retriable, is_retryable
 
-
 .. autoclass:: neo4j.exceptions.ClientError
     :show-inheritance:
 
@@ -1328,6 +1327,9 @@ Connectivity Errors
     :show-inheritance:
 
 .. autoclass:: neo4j.exceptions.ReadServiceUnavailable
+    :show-inheritance:
+
+.. autoclass:: neo4j.exceptions.BrokenRecordError
     :show-inheritance:
 
 .. autoclass:: neo4j.exceptions.ConfigurationError

--- a/neo4j/__init__.py
+++ b/neo4j/__init__.py
@@ -108,7 +108,6 @@ __all__ = [
     "BoltDriver",
     "Bookmark",
     "Bookmarks",
-    "Config",
     "custom_auth",
     "DEFAULT_DATABASE",
     "Driver",
@@ -120,7 +119,6 @@ __all__ = [
     "kerberos_auth",
     "ManagedTransaction",
     "Neo4jDriver",
-    "PoolConfig",
     "Query",
     "READ_ACCESS",
     "Record",
@@ -128,7 +126,6 @@ __all__ = [
     "ResultSummary",
     "ServerInfo",
     "Session",
-    "SessionConfig",
     "SummaryCounters",
     "Transaction",
     "TRUST_ALL_CERTIFICATES",
@@ -138,7 +135,6 @@ __all__ = [
     "TrustSystemCAs",
     "unit_of_work",
     "Version",
-    "WorkspaceConfig",
     "WRITE_ACCESS",
 ]
 

--- a/neo4j/_async/work/result.py
+++ b/neo4j/_async/work/result.py
@@ -20,6 +20,7 @@ from collections import deque
 from warnings import warn
 
 from ..._async_compat.util import AsyncUtil
+from ..._codec.hydration import BrokenHydrationObject
 from ..._data import (
     Record,
     RecordTableRowExporter,
@@ -145,6 +146,11 @@ class AsyncResult:
     def _pull(self):
         def on_records(records):
             if not self._discarding:
+                records = (
+                    record.raw_data
+                    if isinstance(record, BrokenHydrationObject) else record
+                    for record in records
+                )
                 self._record_buffer.extend((
                     Record(zip(self._keys, record))
                     for record in records

--- a/neo4j/_codec/hydration/_common.py
+++ b/neo4j/_codec/hydration/_common.py
@@ -16,8 +16,37 @@
 # limitations under the License.
 
 
+from copy import copy
+
 from ...graph import Graph
 from ..packstream import Structure
+
+
+class BrokenHydrationObject:
+    """
+    Represents an object from the server, not understood by the driver.
+
+    A :class:`neo4j.Record` might contain a ``BrokenHydrationObject`` object
+    if the driver received data from the server that it did not understand.
+    This can for instance happen if the server sends a zoned datetime with a
+    zone name unknown to the driver.
+
+    There is no need to explicitly check for this type. Any method on the
+    :class:`neo4j.Record` that would return a ``BrokenHydrationObject``, will
+    raise a :exc:`neo4j.exceptions.BrokenRecordError`
+    with the original exception as cause.
+    """
+
+    def __init__(self, error, raw_data):
+        self.error = error
+        "The exception raised while decoding the received object."
+        self.raw_data = raw_data
+        """The raw data that caused the exception."""
+
+    def exception_copy(self):
+        exc_copy = copy(self.error)
+        exc_copy.with_traceback(self.error.__traceback__)
+        return exc_copy
 
 
 class GraphHydrator:
@@ -27,7 +56,6 @@ class GraphHydrator:
 
 
 class HydrationScope:
-
     def __init__(self, hydration_handler, graph_hydrator):
         self._hydration_handler = hydration_handler
         self._graph_hydrator = graph_hydrator
@@ -37,14 +65,35 @@ class HydrationScope:
         }
         self.hydration_hooks = {
             Structure: self._hydrate_structure,
+            list: self._hydrate_list,
+            dict: self._hydrate_dict,
         }
         self.dehydration_hooks = hydration_handler.dehydration_functions
 
     def _hydrate_structure(self, value):
         f = self._struct_hydration_functions.get(value.tag)
-        if not f:
-            return value
-        return f(*value.fields)
+        try:
+            if not f:
+                raise ValueError(
+                    f"Protocol error: unknown Structure tag: {value.tag!r}"
+                )
+            return f(*value.fields)
+        except Exception as e:
+            return BrokenHydrationObject(e, value)
+
+    @staticmethod
+    def _hydrate_list(value):
+        for v in value:
+            if isinstance(v, BrokenHydrationObject):
+                return BrokenHydrationObject(v.error, value)
+        return value
+
+    @staticmethod
+    def _hydrate_dict(value):
+        for v in value.values():
+            if isinstance(v, BrokenHydrationObject):
+                return BrokenHydrationObject(v.error, value)
+        return value
 
     def get_graph(self):
         return self._graph_hydrator.graph

--- a/neo4j/_sync/work/result.py
+++ b/neo4j/_sync/work/result.py
@@ -20,6 +20,7 @@ from collections import deque
 from warnings import warn
 
 from ..._async_compat.util import Util
+from ..._codec.hydration import BrokenHydrationObject
 from ..._data import (
     Record,
     RecordTableRowExporter,
@@ -145,6 +146,11 @@ class Result:
     def _pull(self):
         def on_records(records):
             if not self._discarding:
+                records = (
+                    record.raw_data
+                    if isinstance(record, BrokenHydrationObject) else record
+                    for record in records
+                )
                 self._record_buffer.extend((
                     Record(zip(self._keys, record))
                     for record in records

--- a/neo4j/exceptions.py
+++ b/neo4j/exceptions.py
@@ -396,6 +396,14 @@ class ServiceUnavailable(DriverError):
         return True
 
 
+class BrokenRecordError(DriverError):
+    """ Raised when accessing a Record's field that couldn't be decoded.
+
+    This can for instance happen when the server sends a zoned datetime with a
+    zone id unknown to the client.
+    """
+
+
 class RoutingServiceUnavailable(ServiceUnavailable):
     """ Raised when no routing service is available.
     """

--- a/testkitbackend/_async/backend.py
+++ b/testkitbackend/_async/backend.py
@@ -97,6 +97,21 @@ class AsyncBackend:
             if DRIVER_PATH in p.parents:
                 return True
 
+    @staticmethod
+    def _exc_msg(exc, max_depth=10):
+        if isinstance(exc, Neo4jError) and exc.message is not None:
+            return str(exc.message)
+
+        depth = 0
+        res = str(exc)
+        while getattr(exc, "__cause__", None) is not None:
+            depth += 1
+            if depth >= max_depth:
+                break
+            res += f"\nCaused by: {exc.__cause__!r}"
+            exc = exc.__cause__
+        return res
+
     async def write_driver_exc(self, exc):
         log.debug(traceback.format_exc())
 
@@ -109,14 +124,10 @@ class AsyncBackend:
             wrapped_exc = exc.wrapped_exc
             payload["errorType"] = str(type(wrapped_exc))
             if wrapped_exc.args:
-                payload["msg"] = str(wrapped_exc.args[0])
+                payload["msg"] = self._exc_msg(wrapped_exc.args[0])
         else:
             payload["errorType"] = str(type(exc))
-            if isinstance(exc, Neo4jError) and exc.message is not None:
-                payload["msg"] = str(exc.message)
-            elif exc.args:
-                payload["msg"] = str(exc.args[0])
-
+            payload["msg"] = self._exc_msg(exc)
             if isinstance(exc, Neo4jError):
                 payload["code"] = exc.code
 

--- a/tests/unit/common/codec/hydration/v1/test_hydration_handler.py
+++ b/tests/unit/common/codec/hydration/v1/test_hydration_handler.py
@@ -60,7 +60,7 @@ class TestHydrationHandler(HydrationHandlerTestBase):
     def test_scope_hydration_keys(self, hydration_scope):
         hooks = hydration_scope.hydration_hooks
         assert isinstance(hooks, dict)
-        assert set(hooks.keys()) == {Structure}
+        assert set(hooks.keys()) == {Structure, list, dict}
 
     def test_scope_dehydration_keys(self, hydration_scope):
         hooks = hydration_scope.dehydration_hooks
@@ -76,3 +76,23 @@ class TestHydrationHandler(HydrationHandlerTestBase):
         assert isinstance(graph, Graph)
         assert not graph.nodes
         assert not graph.relationships
+
+    @pytest.mark.parametrize("data", (
+        [1, 2, 3],
+        ["a", "b", "c"],
+        [object(), object()],
+        [ValueError(), 42, {}, b"foo"],
+    ))
+    def test_list_hydration(self, hydration_scope, data):
+        res = hydration_scope.hydration_hooks[list](data)
+        assert res == data
+
+    @pytest.mark.parametrize("data", (
+        {"a": 1, "b": 2, "c": 3},
+        {"a": "a", "b": "b", "c": "c"},
+        {"a": object(), "b": object()},
+        {"a": ValueError(), "b": 42, "c": {}, "d": b"foo"},
+    ))
+    def test_dict_hydration(self, hydration_scope, data):
+        res = hydration_scope.hydration_hooks[dict](data)
+        assert res == data

--- a/tests/unit/common/codec/hydration/v1/test_temporal_dehydration.py
+++ b/tests/unit/common/codec/hydration/v1/test_temporal_dehydration.py
@@ -145,7 +145,7 @@ class TestUTCPatchedTimeDehydration(TestTimeDehydration):
         return handler
 
     def test_date_time(self, hydration_scope):
-        from ..v2.test_time_dehydration import (
+        from ..v2.test_temporal_dehydration import (
             TestTimeDehydration as TestTimeDehydrationV2,
         )
         TestTimeDehydrationV2().test_date_time(
@@ -153,7 +153,7 @@ class TestUTCPatchedTimeDehydration(TestTimeDehydration):
         )
 
     def test_native_date_time(self, hydration_scope):
-        from ..v2.test_time_dehydration import (
+        from ..v2.test_temporal_dehydration import (
             TestTimeDehydration as TestTimeDehydrationV2,
         )
         TestTimeDehydrationV2().test_native_date_time(
@@ -161,7 +161,7 @@ class TestUTCPatchedTimeDehydration(TestTimeDehydration):
         )
 
     def test_date_time_negative_offset(self, hydration_scope):
-        from ..v2.test_time_dehydration import (
+        from ..v2.test_temporal_dehydration import (
             TestTimeDehydration as TestTimeDehydrationV2,
         )
         TestTimeDehydrationV2().test_date_time_negative_offset(
@@ -169,7 +169,7 @@ class TestUTCPatchedTimeDehydration(TestTimeDehydration):
         )
 
     def test_native_date_time_negative_offset(self, hydration_scope):
-        from ..v2.test_time_dehydration import (
+        from ..v2.test_temporal_dehydration import (
             TestTimeDehydration as TestTimeDehydrationV2,
         )
         TestTimeDehydrationV2().test_native_date_time_negative_offset(
@@ -177,7 +177,7 @@ class TestUTCPatchedTimeDehydration(TestTimeDehydration):
         )
 
     def test_date_time_zone_id(self, hydration_scope):
-        from ..v2.test_time_dehydration import (
+        from ..v2.test_temporal_dehydration import (
             TestTimeDehydration as TestTimeDehydrationV2,
         )
         TestTimeDehydrationV2().test_date_time_zone_id(
@@ -185,7 +185,7 @@ class TestUTCPatchedTimeDehydration(TestTimeDehydration):
         )
 
     def test_native_date_time_zone_id(self, hydration_scope):
-        from ..v2.test_time_dehydration import (
+        from ..v2.test_temporal_dehydration import (
             TestTimeDehydration as TestTimeDehydrationV2,
         )
         TestTimeDehydrationV2().test_native_date_time_zone_id(

--- a/tests/unit/common/codec/hydration/v1/test_unknown_hydration.py
+++ b/tests/unit/common/codec/hydration/v1/test_unknown_hydration.py
@@ -1,0 +1,55 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+from neo4j._codec.hydration import BrokenHydrationObject
+from neo4j._codec.hydration.v1 import HydrationHandler
+from neo4j._codec.packstream import Structure
+
+from ._base import HydrationHandlerTestBase
+
+
+class TestUnknownHydration(HydrationHandlerTestBase):
+    @pytest.fixture
+    def hydration_handler(self):
+        return HydrationHandler()
+
+    def test_unknown_structure_tag(self, hydration_scope):
+        struct = Structure(b"a", "lol wut?")
+        res = hydration_scope.hydration_hooks[Structure](struct)
+        assert isinstance(res, BrokenHydrationObject)
+        error = res.error
+        assert isinstance(error, ValueError)
+        assert repr(b"a") in str(error)
+
+    def test_broken_object_propagates_through_lists(self, hydration_scope):
+        broken_obj = BrokenHydrationObject(Exception("test"), "b")
+        data = [1, broken_obj, 3]
+        res = hydration_scope.hydration_hooks[list](data)
+        assert isinstance(res, BrokenHydrationObject)
+        assert res.raw_data == data
+        assert res.error is broken_obj.error
+
+    def test_broken_object_propagates_through_dicts(self, hydration_scope):
+        broken_obj = BrokenHydrationObject(Exception("test"), "b")
+        data = {"a": 1, "b": broken_obj, "c": 3}
+        res = hydration_scope.hydration_hooks[dict](data)
+        assert isinstance(res, BrokenHydrationObject)
+        assert res.raw_data == data
+        assert res.error is broken_obj.error

--- a/tests/unit/common/codec/hydration/v2/test_graph_hydration.py
+++ b/tests/unit/common/codec/hydration/v2/test_graph_hydration.py
@@ -18,10 +18,9 @@
 
 import pytest
 
-from neo4j._codec.hydration.v1 import HydrationHandler
+from neo4j._codec.hydration.v2 import HydrationHandler
 from neo4j._codec.packstream import Structure
 from neo4j.graph import (
-    Graph,
     Node,
     Relationship,
 )

--- a/tests/unit/common/codec/hydration/v2/test_hydration_handler.py
+++ b/tests/unit/common/codec/hydration/v2/test_hydration_handler.py
@@ -18,7 +18,7 @@
 
 import pytest
 
-from neo4j._codec.hydration.v1 import HydrationHandler
+from neo4j._codec.hydration.v2 import HydrationHandler
 
 from ..v1.test_hydration_handler import (
     TestHydrationHandler as TestHydrationHandlerV1,

--- a/tests/unit/common/codec/hydration/v2/test_spacial_dehydration.py
+++ b/tests/unit/common/codec/hydration/v2/test_spacial_dehydration.py
@@ -18,7 +18,7 @@
 
 import pytest
 
-from neo4j._codec.hydration.v1 import HydrationHandler
+from neo4j._codec.hydration.v2 import HydrationHandler
 
 from ..v1.test_spacial_dehydration import (
     TestSpatialDehydration as _TestSpatialDehydrationV1,

--- a/tests/unit/common/codec/hydration/v2/test_spacial_hydration.py
+++ b/tests/unit/common/codec/hydration/v2/test_spacial_hydration.py
@@ -18,7 +18,7 @@
 
 import pytest
 
-from neo4j._codec.hydration.v1 import HydrationHandler
+from neo4j._codec.hydration.v2 import HydrationHandler
 
 from ..v1.test_spacial_hydration import (
     TestSpatialHydration as _TestSpatialHydrationV1,

--- a/tests/unit/common/codec/hydration/v2/test_temporal_dehydration.py
+++ b/tests/unit/common/codec/hydration/v2/test_temporal_dehydration.py
@@ -25,12 +25,12 @@ from neo4j._codec.hydration.v2 import HydrationHandler
 from neo4j._codec.packstream import Structure
 from neo4j.time import DateTime
 
-from ..v1.test_time_dehydration import (
-    TestTimeDehydration as _TestTimeDehydrationV1,
+from ..v1.test_temporal_dehydration import (
+    TestTimeDehydration as _TestTemporalDehydrationV1,
 )
 
 
-class TestTimeDehydration(_TestTimeDehydrationV1):
+class TestTimeDehydration(_TestTemporalDehydrationV1):
     @pytest.fixture
     def hydration_handler(self):
         return HydrationHandler()

--- a/tests/unit/common/codec/hydration/v2/test_unknown_hydration.py
+++ b/tests/unit/common/codec/hydration/v2/test_unknown_hydration.py
@@ -15,15 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._common import (
-    BrokenHydrationObject,
-    HydrationScope,
+
+import pytest
+
+from neo4j._codec.hydration.v2 import HydrationHandler
+
+from ..v1.test_unknown_hydration import (
+    TestUnknownHydration as _TestUnknownHydration,
 )
-from ._interface import HydrationHandlerABC
 
 
-__all__ = [
-    "BrokenHydrationObject",
-    "HydrationHandlerABC",
-    "HydrationScope",
-]
+class TestUnknownHydration(_TestUnknownHydration):
+    @pytest.fixture
+    def hydration_handler(self):
+        return HydrationHandler()

--- a/tests/unit/sync/work/test_result.py
+++ b/tests/unit/sync/work/test_result.py
@@ -41,7 +41,10 @@ from neo4j._data import (
     Node,
     Relationship,
 )
-from neo4j.exceptions import ResultNotSingleError
+from neo4j.exceptions import (
+    BrokenRecordError,
+    ResultNotSingleError,
+)
 from neo4j.graph import (
     EntitySetView,
     Graph,
@@ -55,18 +58,18 @@ class Records:
         self.fields = tuple(fields)
         self.hydration_scope = HydrationHandler().new_hydration_scope()
         self.records = tuple(records)
-        self._hydrate_records()
-
         assert all(len(self.fields) == len(r) for r in self.records)
+
+        self._hydrate_records()
 
     def _hydrate_records(self):
         def _hydrate(value):
+            if isinstance(value, (list, tuple)):
+                value = type(value)(_hydrate(v) for v in value)
+            elif isinstance(value, dict):
+                value = {k: _hydrate(v) for k, v in value.items()}
             if type(value) in self.hydration_scope.hydration_hooks:
                 return self.hydration_scope.hydration_hooks[type(value)](value)
-            if isinstance(value, (list, tuple)):
-                return type(value)(_hydrate(v) for v in value)
-            if isinstance(value, dict):
-                return {k: _hydrate(v) for k, v in value.items()}
             return value
 
         self.records = tuple(_hydrate(r) for r in self.records)
@@ -605,7 +608,6 @@ def test_data(num_records):
         assert record.data.called_once_with("hello", "world")
 
 
-# TODO: dehydration now happens on a much lower level
 @pytest.mark.parametrize("records", (
     Records(["n"], []),
     Records(["n"], [[42], [69], [420], [1337]]),
@@ -621,19 +623,9 @@ def test_data(num_records):
     ]),
 ))
 @mark_sync_test
-def test_result_graph(records, scripted_connection):
-    scripted_connection.set_script((
-        ("run", {"on_success": ({"fields": records.fields},),
-                 "on_summary": None}),
-        ("pull", {
-            "on_records": (records.records,),
-            "on_success": None,
-            "on_summary": None
-        }),
-    ))
-    scripted_connection.new_hydration_scope.return_value = \
-        records.hydration_scope
-    result = Result(scripted_connection, 1, noop, noop)
+def test_result_graph(records):
+    connection = ConnectionStub(records=records)
+    result = Result(connection, 1, noop, noop)
     result._run("CYPHER", {}, None, None, "r", None)
     graph = result.graph()
     assert isinstance(graph, Graph)
@@ -1095,3 +1087,25 @@ def test_to_df_parse_dates(keys, values, expected_df, expand):
         df = result.to_df(expand=expand, parse_dates=True)
 
     pd.testing.assert_frame_equal(df, expected_df)
+
+
+@pytest.mark.parametrize("nested", [True, False])
+@mark_sync_test
+def test_broken_hydration(nested):
+    value_in = Structure(b"a", "broken")
+    if nested:
+        value_in = [value_in]
+    records_in = Records(["foo", "bar"], [["foobar", value_in]])
+    connection = ConnectionStub(records=records_in)
+    result = Result(connection, 1, noop, noop)
+    result._run("CYPHER", {}, None, None, "r", None)
+    records_out = Util.list(result)
+    assert len(records_out) == 1
+    record_out = records_out[0]
+    assert len(record_out) == 2
+    assert record_out[0] == "foobar"
+    with pytest.raises(BrokenRecordError) as exc:
+        record_out[1]
+    cause = exc.value.__cause__
+    assert isinstance(cause, ValueError)
+    assert repr(b"a") in str(cause)


### PR DESCRIPTION
This has its limitations, thought. If a user returns for instance a list with one invalid value in it, the Record would throw on trying to access the list. So the user still could't salvage the other list entries. I don't think, however, there's a Pythonic way to cater for this use-case.