### PR TITLE
[4.4] Deprecate timeout config options introduced in 4.4.5

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -194,6 +194,11 @@ larger than :ref:`update-routing-table-timeout-ref`,
 
 .. versionadded:: 4.4.5
 
+.. deprecated:: 4.4.6
+    Will be removed in 5.0. Use server-side bolt-keep-alive together with
+    :ref:`connection-acquisition-timeout-ref` instead to ensure the driver
+    cannot hang.
+
 
 .. _update-routing-table-timeout-ref:
 
@@ -215,6 +220,11 @@ This setting only has an effect for :ref:`neo4j-driver-ref`, but not for
 :Default: ``90.0``
 
 .. versionadded:: 4.4.5
+
+.. deprecated:: 4.4.6
+    Will be removed in 5.0. Use server-side bolt-keep-alive together with
+    :ref:`connection-acquisition-timeout-ref` instead to ensure the driver
+    cannot hang.
 
 
 .. _connection-acquisition-timeout-ref:

--- a/neo4j/conf.py
+++ b/neo4j/conf.py
@@ -87,6 +87,7 @@ class ConfigType(ABCMeta):
                 fields.append(k)
             if isinstance(v, DeprecatedOption):
                 deprecated_options[k] = v.value
+                attributes[k] = v.value
 
         def keys(_):
             return set(fields)


### PR DESCRIPTION
 * `update_routing_table_timeout`
 * `session_connection_timeout`

Server-side keep-alives communicated through configuration hints together with
`connection_acquisition_timeout` (which, starting with 4.4.5, includes the full
handshake, i.e., with `HELLO` message) are sufficient to avoid the driver
getting stuck.