### PR TITLE
Fix SSL deprecation in tests

### DIFF
--- a/tests/unit/async_/test_driver.py
+++ b/tests/unit/async_/test_driver.py
@@ -136,7 +136,7 @@ async def test_routing_driver_constructor(protocol, host, port, params, auth_tok
             ConfigurationError, "The config settings"
         ),
         (
-            {"ssl_context": ssl.SSLContext(ssl.PROTOCOL_TLSv1)},
+            {"ssl_context": ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)},
             ConfigurationError, "The config settings"
         ),
     )

--- a/tests/unit/sync/test_driver.py
+++ b/tests/unit/sync/test_driver.py
@@ -136,7 +136,7 @@ def test_routing_driver_constructor(protocol, host, port, params, auth_token):
             ConfigurationError, "The config settings"
         ),
         (
-            {"ssl_context": ssl.SSLContext(ssl.PROTOCOL_TLSv1)},
+            {"ssl_context": ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)},
             ConfigurationError, "The config settings"
         ),
     )


### PR DESCRIPTION
`ssl.PROTOCOL_TLSv1` has been deprecated since Python 3.6. For test purposes,
it's fine to be replaced with pretty much anything else.