### PR TITLE
[4.4] Warnings overhaul

### DIFF
--- a/neo4j/__init__.py
+++ b/neo4j/__init__.py
@@ -383,13 +383,11 @@ class BoltDriver(Direct, Driver):
         """
         from neo4j.work.simple import Session
         session_config = SessionConfig(self._default_workspace_config, config)
-        SessionConfig.consume(config)  # Consume the config
         return Session(self._pool, session_config)
 
     def pipeline(self, **config):
         from neo4j.work.pipelining import Pipeline, PipelineConfig
         pipeline_config = PipelineConfig(self._default_workspace_config, config)
-        PipelineConfig.consume(config)  # Consume the config
         return Pipeline(self._pool, pipeline_config)
 
     @experimental("The configuration may change in the future.")
@@ -427,13 +425,11 @@ class Neo4jDriver(Routing, Driver):
 
     def session(self, **config):
         session_config = SessionConfig(self._default_workspace_config, config)
-        SessionConfig.consume(config)  # Consume the config
         return Session(self._pool, session_config)
 
     def pipeline(self, **config):
         from neo4j.work.pipelining import Pipeline, PipelineConfig
         pipeline_config = PipelineConfig(self._default_workspace_config, config)
-        PipelineConfig.consume(config)  # Consume the config
         return Pipeline(self._pool, pipeline_config)
 
     @experimental("The configuration may change in the future.")

--- a/neo4j/conf.py
+++ b/neo4j/conf.py
@@ -170,9 +170,19 @@ class Config(Mapping, metaclass=ConfigType):
             else:
                 raise AttributeError(k)
 
+        rejected_keys = []
         for key, value in data_dict.items():
             if value is not None:
-                set_attr(key, value)
+                try:
+                    set_attr(key, value)
+                except AttributeError as exc:
+                    if not exc.args == (key,):
+                        raise
+                    rejected_keys.append(key)
+
+            if rejected_keys:
+                raise ConfigurationError("Unexpected config keys: "
+                                         + ", ".join(rejected_keys))
 
     def __init__(self, *args, **kwargs):
         for arg in args:

--- a/neo4j/io/_socket.py
+++ b/neo4j/io/_socket.py
@@ -259,7 +259,7 @@ class BoltSocket:
     def close_socket(cls, socket_):
         try:
             if isinstance(socket_, BoltSocket):
-                socket.close()
+                socket_.close()
             else:
                 socket_.shutdown(SHUT_RDWR)
                 socket_.close()

--- a/neo4j/time/__init__.py
+++ b/neo4j/time/__init__.py
@@ -482,7 +482,7 @@ class Duration(tuple):
         :rtype: Duration
         """
         if isinstance(other, float):
-            deprecation_warn("Multiplication with float will be deprecated in "
+            deprecation_warn("Multiplication with float will be removed in "
                              "5.0.")
         if isinstance(other, (int, float)):
             return Duration(
@@ -1627,7 +1627,7 @@ class Time(metaclass=TimeType):
         ts = clock_time.seconds % 86400
         nanoseconds = int(NANO_SECONDS * ts + clock_time.nanoseconds)
         ticks = (epoch.time().ticks_ns + nanoseconds) % (86400 * NANO_SECONDS)
-        return Time.from_ticks_ns(ticks)
+        return cls.from_ticks_ns(ticks)
 
     @classmethod
     def __normalize_hour(cls, hour):
@@ -1657,8 +1657,8 @@ class Time(metaclass=TimeType):
         # TODO 5.0: remove -----------------------------------------------------
         seconds, extra_ns = divmod(second, 1)
         if extra_ns:
-            deprecation_warn("Float support second will be removed in 5.0. "
-                             "Use `nanosecond` instead.")
+            deprecation_warn("Float support for `second` will be removed in "
+                             "5.0. Use `nanosecond` instead.")
         # ----------------------------------------------------------------------
         hour, minute, second = cls.__normalize_second(hour, minute, second)
         nanosecond = int(nanosecond
@@ -1753,7 +1753,7 @@ class Time(metaclass=TimeType):
         return self.__nanosecond
 
     @property
-    @deprecated("hour_minute_second will be removed in 5.0. "
+    @deprecated("`hour_minute_second` will be removed in 5.0. "
                 "Use `hour_minute_second_nanosecond` instead.")
     def hour_minute_second(self):
         """The time as a tuple of (hour, minute, second).

--- a/testkit/Dockerfile
+++ b/testkit/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
         libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev \
-        libxml2-dev libxmlsec1-dev libffi-dev \
+        libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
         ca-certificates && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/testkit/backend.py
+++ b/testkit/backend.py
@@ -3,6 +3,6 @@ import sys
 
 if __name__ == "__main__":
     subprocess.check_call(
-        ["python", "-m", "testkitbackend"],
+        ["python", "-W", "error", "-m", "testkitbackend"],
         stdout=sys.stdout, stderr=sys.stderr
     )

--- a/testkit/stress.py
+++ b/testkit/stress.py
@@ -1,7 +1,5 @@
 import subprocess
-import os
 import sys
-
 
 if __name__ == "__main__":
     # Until below works
@@ -16,4 +14,4 @@ if __name__ == "__main__":
             "NEO4J_PASSWORD": os.environ["TEST_NEO4J_PASS"],
             "NEO4J_URI": uri}
     subprocess.check_call(cmd, universal_newlines=True,
-                          stderr=subprocess.STDOUT, env=env)
+                          stdout=sys.stdout, stderr=sys.stderr, env=env)

--- a/testkit/unittests.py
+++ b/testkit/unittests.py
@@ -1,9 +1,12 @@
 import subprocess
+import sys
 
 
 def run(args):
     subprocess.run(
-        args, universal_newlines=True, stderr=subprocess.STDOUT, check=True)
+        args, universal_newlines=True, stdout=sys.stdout, stderr=sys.stderr,
+        check=True
+    )
 
 
 if __name__ == "__main__":

--- a/testkitbackend/__main__.py
+++ b/testkitbackend/__main__.py
@@ -1,6 +1,10 @@
+import warnings
+
 from .server import Server
 
+
 if __name__ == "__main__":
+    warnings.simplefilter("error")
     server = Server(("0.0.0.0", 9876))
     while True:
         server.handle_request()

--- a/testkitbackend/_warning_check.py
+++ b/testkitbackend/_warning_check.py
@@ -1,0 +1,64 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import re
+import warnings
+from contextlib import contextmanager
+
+
+@contextmanager
+def warning_check(category, message):
+    with warnings.catch_warnings(record=True) as warn_log:
+        warnings.filterwarnings("always", category=category, message=message)
+        yield
+    if len(warn_log) != 1:
+        raise AssertionError("Expected 1 warning, found %d: %s"
+                             % (len(warn_log), warn_log))
+
+
+@contextmanager
+def warnings_check(category_message_pairs):
+    with warnings.catch_warnings(record=True) as warn_log:
+        for category, message in category_message_pairs:
+            warnings.filterwarnings("always", category=category,
+                                    message=message)
+        yield
+    if len(warn_log) != len(category_message_pairs):
+        raise AssertionError(
+            "Expected %d warnings, found %d: %s"
+            % (len(category_message_pairs), len(warn_log), warn_log)
+        )
+    category_message_pairs = [
+        (category, re.compile(message, re.I))
+        for category, message in category_message_pairs
+    ]
+    for category, matcher in category_message_pairs:
+        match = None
+        for i, warning in enumerate(warn_log):
+            if (
+                warning.category == category
+                and matcher.match(warning.message.args[0])
+            ):
+                match = i
+                break
+        if match is None:
+            raise AssertionError(
+                "Expected warning not found: %r %r"
+                % (category, matcher.pattern)
+            )
+        warn_log.pop(match)

--- a/testkitbackend/requests.py
+++ b/testkitbackend/requests.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 import json
 from os import path
+import warnings
 
 import neo4j
 import testkitbackend.fromtestkit as fromtestkit
@@ -108,7 +109,9 @@ def NewDriver(backend, data):
 def VerifyConnectivity(backend, data):
     driver_id = data["driverId"]
     driver = backend.drivers[driver_id]
-    driver.verify_connectivity()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=neo4j.ExperimentalWarning)
+        driver.verify_connectivity()
     backend.send_response("Driver", {"id": driver_id})
 
 

--- a/testkitbackend/server.py
+++ b/testkitbackend/server.py
@@ -25,7 +25,10 @@ class Server(TCPServer):
         class Handler(StreamRequestHandler):
             def handle(self):
                 backend = Backend(self.rfile, self.wfile)
-                while backend.process_request():
-                    pass
+                try:
+                    while backend.process_request():
+                        pass
+                finally:
+                    backend.close()
                 print("Disconnected")
         super(Server, self).__init__(address, Handler)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,14 +43,14 @@ from neo4j.io import Bolt
 NEO4J_RELEASES = getenv("NEO4J_RELEASES", "snapshot-enterprise 3.5-enterprise").split()
 NEO4J_HOST = "localhost"
 NEO4J_PORTS = {
-    "bolt": 7687,
+    "bolt": 17601,
     "http": 17401,
     "https": 17301,
 }
-NEO4J_CORES = 1
-NEO4J_REPLICAS = 0
+NEO4J_CORES = 3
+NEO4J_REPLICAS = 2
 NEO4J_USER = "neo4j"
-NEO4J_PASSWORD = "pass"
+NEO4J_PASSWORD = "password"
 NEO4J_AUTH = (NEO4J_USER, NEO4J_PASSWORD)
 NEO4J_LOCK = RLock()
 NEO4J_SERVICE = None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,14 +43,14 @@ from neo4j.io import Bolt
 NEO4J_RELEASES = getenv("NEO4J_RELEASES", "snapshot-enterprise 3.5-enterprise").split()
 NEO4J_HOST = "localhost"
 NEO4J_PORTS = {
-    "bolt": 17601,
+    "bolt": 7687,
     "http": 17401,
     "https": 17301,
 }
-NEO4J_CORES = 3
-NEO4J_REPLICAS = 2
+NEO4J_CORES = 1
+NEO4J_REPLICAS = 0
 NEO4J_USER = "neo4j"
-NEO4J_PASSWORD = "password"
+NEO4J_PASSWORD = "pass"
 NEO4J_AUTH = (NEO4J_USER, NEO4J_PASSWORD)
 NEO4J_LOCK = RLock()
 NEO4J_SERVICE = None

--- a/tests/integration/examples/test_database_selection_example.py
+++ b/tests/integration/examples/test_database_selection_example.py
@@ -46,8 +46,10 @@ class DatabaseSelectionExample:
         with self.driver.session(database="system") as session:
             while True:
                 try:
-                    session.run(f"DROP DATABASE example IF EXISTS{self._wait}")\
+                    session\
+                        .run(f"DROP DATABASE example IF EXISTS{self._wait}")\
                         .consume()
+                    break
                 except neo4j.exceptions.CypherSyntaxError:
                     if not self._wait:
                         raise

--- a/tests/integration/examples/test_database_selection_example.py
+++ b/tests/integration/examples/test_database_selection_example.py
@@ -42,12 +42,12 @@ class DatabaseSelectionExample:
     def __init__(self, uri, user, password):
         self.driver = GraphDatabase.driver(uri, auth=(user, password))
         with self.driver.session(database="system") as session:
-            session.run("DROP DATABASE example IF EXISTS").consume()
-            session.run("CREATE DATABASE example").consume()
+            session.run("DROP DATABASE example IF EXISTS WAIT").consume()
+            session.run("CREATE DATABASE example WAIT").consume()
 
     def close(self):
         with self.driver.session(database="system") as session:
-            session.run("DROP DATABASE example").consume()
+            session.run("DROP DATABASE example WAIT").consume()
         self.driver.close()
 
     def run_example_code(self):

--- a/tests/integration/examples/test_database_selection_example.py
+++ b/tests/integration/examples/test_database_selection_example.py
@@ -28,6 +28,7 @@ from io import StringIO
 from neo4j import GraphDatabase
 # tag::database-selection-import[]
 from neo4j import READ_ACCESS
+import neo4j.exceptions
 # end::database-selection-import[]
 
 from neo4j.exceptions import ServiceUnavailable
@@ -41,13 +42,21 @@ class DatabaseSelectionExample:
 
     def __init__(self, uri, user, password):
         self.driver = GraphDatabase.driver(uri, auth=(user, password))
+        self._wait = " WAIT"
         with self.driver.session(database="system") as session:
-            session.run("DROP DATABASE example IF EXISTS WAIT").consume()
-            session.run("CREATE DATABASE example WAIT").consume()
+            while True:
+                try:
+                    session.run(f"DROP DATABASE example IF EXISTS{self._wait}")\
+                        .consume()
+                except neo4j.exceptions.CypherSyntaxError:
+                    if not self._wait:
+                        raise
+                    self._wait = ""
+            session.run(f"CREATE DATABASE example{self._wait}").consume()
 
     def close(self):
         with self.driver.session(database="system") as session:
-            session.run("DROP DATABASE example WAIT").consume()
+            session.run(f"DROP DATABASE example{self._wait}").consume()
         self.driver.close()
 
     def run_example_code(self):

--- a/tests/integration/test_temporal_types.py
+++ b/tests/integration/test_temporal_types.py
@@ -89,7 +89,7 @@ def test_whole_second_time_input(cypher_eval):
 def test_nanosecond_resolution_time_input(cypher_eval):
     result = cypher_eval("CYPHER runtime=interpreted WITH $x AS x "
                          "RETURN [x.hour, x.minute, x.second, x.nanosecond]",
-                         x=Time(12, 34, 56.789012345))
+                         x=Time(12, 34, 56, 789012345))
     hour, minute, second, nanosecond = result
     assert hour == 12
     assert minute == 34
@@ -101,7 +101,7 @@ def test_time_with_numeric_time_offset_input(cypher_eval):
     result = cypher_eval("CYPHER runtime=interpreted WITH $x AS x "
                          "RETURN [x.hour, x.minute, x.second, "
                          "        x.nanosecond, x.offset]",
-                         x=Time(12, 34, 56.789012345, tzinfo=FixedOffset(90)))
+                         x=Time(12, 34, 56, 789012345, tzinfo=FixedOffset(90)))
     hour, minute, second, nanosecond, offset = result
     assert hour == 12
     assert minute == 34
@@ -150,7 +150,7 @@ def test_nanosecond_resolution_datetime_input(cypher_eval):
     result = cypher_eval("CYPHER runtime=interpreted WITH $x AS x "
                          "RETURN [x.year, x.month, x.day, "
                          "        x.hour, x.minute, x.second, x.nanosecond]",
-                         x=DateTime(1976, 6, 13, 12, 34, 56.789012345))
+                         x=DateTime(1976, 6, 13, 12, 34, 56, 789012345))
     year, month, day, hour, minute, second, nanosecond = result
     assert year == 1976
     assert month == 6
@@ -166,7 +166,7 @@ def test_datetime_with_numeric_time_offset_input(cypher_eval):
                          "RETURN [x.year, x.month, x.day, "
                          "        x.hour, x.minute, x.second, "
                          "        x.nanosecond, x.offset]",
-                         x=DateTime(1976, 6, 13, 12, 34, 56.789012345,
+                         x=DateTime(1976, 6, 13, 12, 34, 56, 789012345,
                                     tzinfo=FixedOffset(90)))
     year, month, day, hour, minute, second, nanosecond, offset = result
     assert year == 1976
@@ -180,7 +180,7 @@ def test_datetime_with_numeric_time_offset_input(cypher_eval):
 
 
 def test_datetime_with_named_time_zone_input(cypher_eval):
-    dt = DateTime(1976, 6, 13, 12, 34, 56.789012345)
+    dt = DateTime(1976, 6, 13, 12, 34, 56, 789012345)
     input_value = timezone("US/Pacific").localize(dt)
     result = cypher_eval("CYPHER runtime=interpreted WITH $x AS x "
                          "RETURN [x.year, x.month, x.day, "
@@ -199,7 +199,7 @@ def test_datetime_with_named_time_zone_input(cypher_eval):
 
 
 def test_datetime_array_input(cypher_eval):
-    data = [DateTime(2018, 4, 6, 13, 4, 42.516120), DateTime(1976, 6, 13)]
+    data = [DateTime(2018, 4, 6, 13, 4, 42, 516120), DateTime(1976, 6, 13)]
     value = cypher_eval("CREATE (a {x:$x}) RETURN a.x", x=data)
     assert value == data
 
@@ -209,7 +209,7 @@ def test_duration_input(cypher_eval):
                          "RETURN [x.months, x.days, x.seconds, "
                          "        x.microsecondsOfSecond]",
                          x=Duration(years=1, months=2, days=3, hours=4,
-                                    minutes=5, seconds=6.789012))
+                                    minutes=5, seconds=6, microseconds=789012))
     months, days, seconds, microseconds = result
     assert months == 14
     assert days == 3
@@ -258,13 +258,13 @@ def test_whole_second_time_output(cypher_eval):
 def test_nanosecond_resolution_time_output(cypher_eval):
     value = cypher_eval("RETURN time('12:34:56.789012345')")
     assert isinstance(value, Time)
-    assert value == Time(12, 34, 56.789012345, tzinfo=FixedOffset(0))
+    assert value == Time(12, 34, 56, 789012345, tzinfo=FixedOffset(0))
 
 
 def test_time_with_numeric_time_offset_output(cypher_eval):
     value = cypher_eval("RETURN time('12:34:56.789012345+0130')")
     assert isinstance(value, Time)
-    assert value == Time(12, 34, 56.789012345, tzinfo=FixedOffset(90))
+    assert value == Time(12, 34, 56, 789012345, tzinfo=FixedOffset(90))
 
 
 def test_whole_second_localtime_output(cypher_eval):
@@ -276,7 +276,7 @@ def test_whole_second_localtime_output(cypher_eval):
 def test_nanosecond_resolution_localtime_output(cypher_eval):
     value = cypher_eval("RETURN localtime('12:34:56.789012345')")
     assert isinstance(value, Time)
-    assert value == Time(12, 34, 56.789012345)
+    assert value == Time(12, 34, 56, 789012345)
 
 
 def test_whole_second_datetime_output(cypher_eval):
@@ -288,14 +288,14 @@ def test_whole_second_datetime_output(cypher_eval):
 def test_nanosecond_resolution_datetime_output(cypher_eval):
     value = cypher_eval("RETURN datetime('1976-06-13T12:34:56.789012345')")
     assert isinstance(value, DateTime)
-    assert value == DateTime(1976, 6, 13, 12, 34, 56.789012345, tzinfo=utc)
+    assert value == DateTime(1976, 6, 13, 12, 34, 56, 789012345, tzinfo=utc)
 
 
 def test_datetime_with_numeric_time_offset_output(cypher_eval):
     value = cypher_eval("RETURN "
                         "datetime('1976-06-13T12:34:56.789012345+01:30')")
     assert isinstance(value, DateTime)
-    assert value == DateTime(1976, 6, 13, 12, 34, 56.789012345,
+    assert value == DateTime(1976, 6, 13, 12, 34, 56, 789012345,
                              tzinfo=FixedOffset(90))
 
 
@@ -303,7 +303,7 @@ def test_datetime_with_named_time_zone_output(cypher_eval):
     value = cypher_eval("RETURN datetime('1976-06-13T12:34:56.789012345"
                         "[Europe/London]')")
     assert isinstance(value, DateTime)
-    dt = DateTime(1976, 6, 13, 12, 34, 56.789012345)
+    dt = DateTime(1976, 6, 13, 12, 34, 56, 789012345)
     assert value == timezone("Europe/London").localize(dt)
 
 
@@ -317,21 +317,21 @@ def test_nanosecond_resolution_localdatetime_output(cypher_eval):
     value = cypher_eval("RETURN "
                         "localdatetime('1976-06-13T12:34:56.789012345')")
     assert isinstance(value, DateTime)
-    assert value == DateTime(1976, 6, 13, 12, 34, 56.789012345)
+    assert value == DateTime(1976, 6, 13, 12, 34, 56, 789012345)
 
 
 def test_duration_output(cypher_eval):
     value = cypher_eval("RETURN duration('P1Y2M3DT4H5M6.789S')")
     assert isinstance(value, Duration)
     assert value == Duration(years=1, months=2, days=3, hours=4,
-                             minutes=5, seconds=6.789)
+                             minutes=5, seconds=6, milliseconds=789)
 
 
 def test_nanosecond_resolution_duration_output(cypher_eval):
     value = cypher_eval("RETURN duration('P1Y2M3DT4H5M6.789123456S')")
     assert isinstance(value, Duration)
     assert value == Duration(years=1, months=2, days=3, hours=4,
-                             minutes=5, seconds=6.789123456)
+                             minutes=5, seconds=6, nanoseconds=789123456)
 
 
 def test_datetime_parameter_case1(session):

--- a/tests/stub/conftest.py
+++ b/tests/stub/conftest.py
@@ -21,7 +21,6 @@
 
 import subprocess
 import os
-import time
 
 from platform import system
 from threading import Thread
@@ -65,12 +64,14 @@ class StubServer:
                     pass
                 log.debug(line)
 
+        self._process.__exit__(None, None, None)
         return True
 
     def kill(self):
         # Kill process if not already dead
         if self._process.poll() is None:
             self._process.kill()
+        self._process.__exit__(None, None, None)
 
 
 class StubCluster:

--- a/tests/stub/test_directdriver.py
+++ b/tests/stub/test_directdriver.py
@@ -21,6 +21,7 @@
 
 import pytest
 
+import neo4j
 from neo4j.exceptions import (
     ServiceUnavailable,
     ConfigurationError,
@@ -80,7 +81,9 @@ def test_direct_driver_with_wrong_port(driver_info):
     uri = "bolt://127.0.0.1:9002"
     with pytest.raises(ServiceUnavailable):
         driver = GraphDatabase.driver(uri, auth=driver_info["auth_token"], **driver_config)
-        driver.verify_connectivity()
+        with pytest.warns(neo4j.ExperimentalWarning,
+                          match="The configuration may change in the future."):
+            driver.verify_connectivity()
 
 
 @pytest.mark.parametrize(
@@ -96,7 +99,13 @@ def test_direct_verify_connectivity(driver_info, test_script, test_expected):
         uri = "bolt://localhost:9001"
         with GraphDatabase.driver(uri, auth=driver_info["auth_token"], **driver_config) as driver:
             assert isinstance(driver, BoltDriver)
-            assert driver.verify_connectivity(default_access_mode=READ_ACCESS) == test_expected
+            with pytest.warns(
+                    neo4j.ExperimentalWarning,
+                    match="The configuration may change in the future."
+            ):
+                assert driver.verify_connectivity(
+                    default_access_mode=READ_ACCESS
+                ) == test_expected
 
 
 @pytest.mark.parametrize(
@@ -112,4 +121,8 @@ def test_direct_verify_connectivity_disconnect_on_run(driver_info, test_script):
         uri = "bolt://127.0.0.1:9001"
         with GraphDatabase.driver(uri, auth=driver_info["auth_token"], **driver_config) as driver:
             with pytest.raises(ServiceUnavailable):
-                driver.verify_connectivity(default_access_mode=READ_ACCESS)
+                with pytest.warns(
+                        neo4j.ExperimentalWarning,
+                        match="The configuration may change in the future."
+                ):
+                    driver.verify_connectivity(default_access_mode=READ_ACCESS)

--- a/tests/stub/test_routingdriver.py
+++ b/tests/stub/test_routingdriver.py
@@ -22,6 +22,7 @@
 import pytest
 
 from neo4j import (
+    ExperimentalWarning,
     GraphDatabase,
     Neo4jDriver,
     TRUST_ALL_CERTIFICATES,
@@ -58,7 +59,11 @@ def test_neo4j_driver_verify_connectivity(driver_info, test_script):
     with StubCluster(test_script):
         with GraphDatabase.driver(driver_info["uri_neo4j"], auth=driver_info["auth_token"], user_agent="test") as driver:
             assert isinstance(driver, Neo4jDriver)
-            assert driver.verify_connectivity() is not None
+            with pytest.warns(
+                    ExperimentalWarning,
+                    match="The configuration may change in the future."
+            ):
+                assert driver.verify_connectivity() is not None
 
 
 # @pytest.mark.skip(reason="Flaky")
@@ -75,4 +80,8 @@ def test_neo4j_driver_verify_connectivity_server_down(driver_info, test_script):
         assert isinstance(driver, Neo4jDriver)
 
         with pytest.raises(ServiceUnavailable):
-            driver.verify_connectivity()
+            with pytest.warns(
+                    ExperimentalWarning,
+                    match="The configuration may change in the future."
+            ):
+                driver.verify_connectivity()

--- a/tests/unit/io/test_direct.py
+++ b/tests/unit/io/test_direct.py
@@ -116,6 +116,7 @@ class BoltTestCase(TestCase):
             connection = Bolt.open(("localhost", 9999), auth=("test", "test"))
 
     def test_open_timeout(self):
+        conf = PoolConfig()
         with pytest.raises(ServiceUnavailable):
             connection = Bolt.open(("localhost", 9999), auth=("test", "test"), timeout=1)
 

--- a/tests/unit/spatial/test_cartesian_point.py
+++ b/tests/unit/spatial/test_cartesian_point.py
@@ -32,11 +32,11 @@ class CartesianPointTestCase(TestCase):
     def test_alias(self):
         x, y, z = 3.2, 4.0, -1.2
         p = CartesianPoint((x, y, z))
-        self.assert_(hasattr(p, "x"))
+        self.assertTrue(hasattr(p, "x"))
         self.assertEqual(p.x, x)
-        self.assert_(hasattr(p, "y"))
+        self.assertTrue(hasattr(p, "y"))
         self.assertEqual(p.y, y)
-        self.assert_(hasattr(p, "z"))
+        self.assertTrue(hasattr(p, "z"))
         self.assertEqual(p.z, z)
 
     def test_dehydration_3d(self):

--- a/tests/unit/spatial/test_wgs84_point.py
+++ b/tests/unit/spatial/test_wgs84_point.py
@@ -32,11 +32,11 @@ class WGS84PointTestCase(TestCase):
     def test_alias(self):
         x, y, z = 3.2, 4.0, -1.2
         p = WGS84Point((x, y, z))
-        self.assert_(hasattr(p, "longitude"))
+        self.assertTrue(hasattr(p, "longitude"))
         self.assertEqual(p.longitude, x)
-        self.assert_(hasattr(p, "latitude"))
+        self.assertTrue(hasattr(p, "latitude"))
         self.assertEqual(p.latitude, y)
-        self.assert_(hasattr(p, "height"))
+        self.assertTrue(hasattr(p, "height"))
         self.assertEqual(p.height, z)
 
     def test_dehydration_3d(self):

--- a/tests/unit/time/test_clock.py
+++ b/tests/unit/time/test_clock.py
@@ -57,7 +57,7 @@ class TestClock(TestCase):
     def test_local_time(self):
         _ = Clock()
         for impl in Clock._Clock__implementations:
-            self.assert_(issubclass(impl, Clock))
+            self.assertTrue(issubclass(impl, Clock))
             clock = object.__new__(impl)
             time = clock.local_time()
             self.assertIsInstance(time, ClockTime)
@@ -65,7 +65,7 @@ class TestClock(TestCase):
     def test_utc_time(self):
         _ = Clock()
         for impl in Clock._Clock__implementations:
-            self.assert_(issubclass(impl, Clock))
+            self.assertTrue(issubclass(impl, Clock))
             clock = object.__new__(impl)
             time = clock.utc_time()
             self.assertIsInstance(time, ClockTime)

--- a/tests/unit/time/test_duration.py
+++ b/tests/unit/time/test_duration.py
@@ -26,7 +26,71 @@ import copy
 import pytest
 
 from neo4j import time
-from neo4j.time import Duration
+from neo4j.time import Duration as _Duration
+
+
+class Duration(_Duration):
+    def __new__(cls, *args, **kwargs):
+        # seconds = kwargs.get("seconds", args[6] if len(args) > 6 else None)
+        subseconds = kwargs.get("subseconds",
+                                args[7] if len(args) > 7 else None)
+        # if (
+        #     isinstance(seconds, float) and not seconds.is_integer()
+        #     or isinstance(seconds, Decimal) and not seconds % 1 != 0
+        # ):
+        #     with pytest.warns(DeprecationWarning,
+        #                       match="Float support second will be removed in "
+        #                             "5.0. Use `nanosecond` instead."):
+        #         return super().__new__(cls, *args, **kwargs)
+        if subseconds is not None:
+            with pytest.warns(
+                    DeprecationWarning,
+                    match="`subseconds` will be removed in 5.0. "
+                          "Use `nanoseconds` instead."
+            ):
+                return super().__new__(cls, *args, **kwargs)
+        return super().__new__(cls, *args, **kwargs)
+
+    @property
+    def hours_minutes_seconds(self):
+        with pytest.warns(
+                DeprecationWarning,
+                match="Will be removed in 5.0. "
+                      "Use `hours_minutes_seconds_nanoseconds` instead."
+        ):
+            return super().hours_minutes_seconds
+
+    @property
+    def subseconds(self):
+        with pytest.warns(
+                DeprecationWarning,
+                match="Will be removed in 5.0. Use `nanoseconds` instead."
+        ):
+            return super().subseconds
+
+    def __mul__(self, other):
+        if isinstance(other, float):
+            with pytest.warns(DeprecationWarning,
+                              match="Multiplication with float will be "
+                                    "removed in 5.0."):
+                return super().__mul__(other)
+        return super().__mul__(other)
+
+    def __floordiv__(self, other):
+        with pytest.warns(DeprecationWarning, match="Will be removed in 5.0."):
+            return super().__floordiv__(other)
+
+    def __mod__(self, other):
+        with pytest.warns(DeprecationWarning, match="Will be removed in 5.0."):
+            return super().__mod__(other)
+
+    def __divmod__(self, other):
+        with pytest.warns(DeprecationWarning, match="Will be removed in 5.0."):
+            return super().__divmod__(other)
+
+    def __truediv__(self, other):
+        with pytest.warns(DeprecationWarning, match="Will be removed in 5.0."):
+            return super().__truediv__(other)
 
 
 def seconds_options(seconds, nanoseconds):

--- a/tox-unit.ini
+++ b/tox-unit.ini
@@ -7,6 +7,6 @@ deps =
     -r tests/requirements.txt
 commands =
     coverage erase
-    coverage run -m pytest -v {posargs} \
+    coverage run -m pytest -W error -v {posargs} \
         tests/unit
     coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     -r tests/requirements.txt
 commands =
     coverage erase
-    coverage run -m pytest -v {posargs} \
+    coverage run -m pytest -W error -v {posargs} \
         tests/unit \
         tests/stub \
         tests/integration


### PR DESCRIPTION
* Fix falsely emitted `DeprecationWarning` regarding
  `update_routing_table_timeout`.
* Treat warnings as errors during testing
* Changed tests to expect and catch warnings or to avoid them.