### PR TITLE
Remove session config `ignore_bookmark_manager`

### DIFF
--- a/neo4j/_async/driver.py
+++ b/neo4j/_async/driver.py
@@ -423,7 +423,6 @@ class AsyncDriver:
             fetch_size: int = ...,
             impersonated_user: t.Optional[str] = ...,
             bookmarks: t.Union[t.Iterable[str], Bookmarks, None] = ...,
-            ignore_bookmark_manager: bool = ...,
             default_access_mode: str = ...,
             bookmark_manager: t.Union[AsyncBookmarkManager,
                                       BookmarkManager, None] = ...,

--- a/neo4j/_async/work/session.py
+++ b/neo4j/_async/work/session.py
@@ -100,8 +100,7 @@ class AsyncSession(AsyncWorkspace):
         assert isinstance(session_config, SessionConfig)
         super().__init__(pool, session_config)
         self._initialize_bookmarks(session_config.bookmarks)
-        if not session_config.ignore_bookmark_manager:
-            self._bookmark_manager = session_config.bookmark_manager
+        self._bookmark_manager = session_config.bookmark_manager
 
     async def __aenter__(self) -> AsyncSession:
         return self

--- a/neo4j/_conf.py
+++ b/neo4j/_conf.py
@@ -490,9 +490,6 @@ class SessionConfig(WorkspaceConfig):
     #: Default AccessMode
     default_access_mode = WRITE_ACCESS
 
-    #: Whether to ignore the bookmark manager configured at driver level
-    ignore_bookmark_manager = False
-
 
 class TransactionConfig(Config):
     """ Transaction configuration. This is internal for now.

--- a/neo4j/_sync/driver.py
+++ b/neo4j/_sync/driver.py
@@ -422,7 +422,6 @@ class Driver:
             fetch_size: int = ...,
             impersonated_user: t.Optional[str] = ...,
             bookmarks: t.Union[t.Iterable[str], Bookmarks, None] = ...,
-            ignore_bookmark_manager: bool = ...,
             default_access_mode: str = ...,
             bookmark_manager: t.Union[BookmarkManager,
                                       BookmarkManager, None] = ...,

--- a/neo4j/_sync/work/session.py
+++ b/neo4j/_sync/work/session.py
@@ -100,8 +100,7 @@ class Session(Workspace):
         assert isinstance(session_config, SessionConfig)
         super().__init__(pool, session_config)
         self._initialize_bookmarks(session_config.bookmarks)
-        if not session_config.ignore_bookmark_manager:
-            self._bookmark_manager = session_config.bookmark_manager
+        self._bookmark_manager = session_config.bookmark_manager
 
     def __enter__(self) -> Session:
         return self

--- a/testkitbackend/_async/requests.py
+++ b/testkitbackend/_async/requests.py
@@ -370,7 +370,6 @@ async def NewSession(backend, data):
     for (conf_name, data_name) in (
         ("fetch_size", "fetchSize"),
         ("impersonated_user", "impersonatedUser"),
-        ("ignore_bookmark_manager", "ignoreBookmarkManager"),
     ):
         if data_name in data:
             config[conf_name] = data[data_name]

--- a/testkitbackend/_sync/requests.py
+++ b/testkitbackend/_sync/requests.py
@@ -370,7 +370,6 @@ def NewSession(backend, data):
     for (conf_name, data_name) in (
         ("fetch_size", "fetchSize"),
         ("impersonated_user", "impersonatedUser"),
-        ("ignore_bookmark_manager", "ignoreBookmarkManager"),
     ):
         if data_name in data:
             config[conf_name] = data[data_name]

--- a/tests/unit/async_/work/test_session.py
+++ b/tests/unit/async_/work/test_session.py
@@ -484,16 +484,3 @@ async def test_last_bookmarks_do_not_leak_bookmark_managers_bookmarks(
 
         assert last_bookmarks.raw_values == {"session", "bookmarks"}
     assert last_bookmarks.raw_values == {"session", "bookmarks"}
-
-
-@mark_async_test
-async def test_with_ignored_bookmark_manager(fake_pool, mocker):
-    bmm = mocker.Mock(spec=AsyncBookmarkManager)
-    session_config = SessionConfig()
-    session_config.bookmark_manager = bmm
-    session_config.ignore_bookmark_manager = True
-    async with AsyncSession(fake_pool, session_config) as session:
-        await session.run("RETURN 1")
-
-    bmm.assert_not_called()
-    assert not bmm.method_calls

--- a/tests/unit/common/test_conf.py
+++ b/tests/unit/common/test_conf.py
@@ -68,7 +68,6 @@ test_session_config = {
     "impersonated_user": None,
     "fetch_size": 100,
     "bookmark_manager": object(),
-    "ignore_bookmark_manager": False,
 }
 
 

--- a/tests/unit/sync/work/test_session.py
+++ b/tests/unit/sync/work/test_session.py
@@ -484,16 +484,3 @@ def test_last_bookmarks_do_not_leak_bookmark_managers_bookmarks(
 
         assert last_bookmarks.raw_values == {"session", "bookmarks"}
     assert last_bookmarks.raw_values == {"session", "bookmarks"}
-
-
-@mark_sync_test
-def test_with_ignored_bookmark_manager(fake_pool, mocker):
-    bmm = mocker.Mock(spec=BookmarkManager)
-    session_config = SessionConfig()
-    session_config.bookmark_manager = bmm
-    session_config.ignore_bookmark_manager = True
-    with Session(fake_pool, session_config) as session:
-        session.run("RETURN 1")
-
-    bmm.assert_not_called()
-    assert not bmm.method_calls


### PR DESCRIPTION
It's a leftover from a previous design of the bookmark manager.