### PR TITLE
Fix bookmark manager docs

### DIFF
--- a/neo4j/_async/driver.py
+++ b/neo4j/_async/driver.py
@@ -241,9 +241,11 @@ class AsyncGraphDatabase:
                 async with driver.session(
                     bookmark_manager=bookmark_manager
                 ) as session2:
-                    session1.run("<WRITE_QUERY>")
+                    result1 = await session1.run("<WRITE_QUERY>")
+                    await result1.consume()
                     # READ_QUERY is guaranteed to see what WRITE_QUERY wrote.
-                    session2.run("<READ_QUERY>")
+                    result2 = await session2.run("<READ_QUERY>")
+                    await result2.consume()
 
         This is a very contrived example, and in this particular case, having
         both queries in the same session has the exact same effect and might

--- a/neo4j/_sync/driver.py
+++ b/neo4j/_sync/driver.py
@@ -240,9 +240,11 @@ class GraphDatabase:
                 with driver.session(
                     bookmark_manager=bookmark_manager
                 ) as session2:
-                    session1.run("<WRITE_QUERY>")
+                    result1 = session1.run("<WRITE_QUERY>")
+                    result1.consume()
                     # READ_QUERY is guaranteed to see what WRITE_QUERY wrote.
-                    session2.run("<READ_QUERY>")
+                    result2 = session2.run("<READ_QUERY>")
+                    result2.consume()
 
         This is a very contrived example, and in this particular case, having
         both queries in the same session has the exact same effect and might


### PR DESCRIPTION
Results need to be consumed in order for the BMM to pick up the bookmarks.

Note:
Consumption could also happen through session closure, starting another auto-
commit transaction, or maybe, in future protocol versions, will the server send
bookmarks in the first `SUCCESS` message to an auto-commit `RUN`. But not yet.