### PR TITLE
Fix exception handling in `Session.close()`

### DIFF
--- a/neo4j/_async/work/session.py
+++ b/neo4j/_async/work/session.py
@@ -176,7 +176,7 @@ class AsyncSession(AsyncWorkspace):
         try:
             try:
                 # consume outstanding auto-commit result
-                if self._auto_result:
+                if not self._state_failed and self._auto_result:
                     await self._auto_result.consume()
             finally:
                 # close any outstanding transaction
@@ -185,7 +185,7 @@ class AsyncSession(AsyncWorkspace):
                         await self._transaction._close()
                     except ignored_exceptions:
                         pass
-            # flush connection just in case
+            # flush connection
             if self._connection:
                 try:
                     await self._connection.send_all()

--- a/neo4j/_sync/work/session.py
+++ b/neo4j/_sync/work/session.py
@@ -176,7 +176,7 @@ class Session(Workspace):
         try:
             try:
                 # consume outstanding auto-commit result
-                if self._auto_result:
+                if not self._state_failed and self._auto_result:
                     self._auto_result.consume()
             finally:
                 # close any outstanding transaction
@@ -185,7 +185,7 @@ class Session(Workspace):
                         self._transaction._close()
                     except ignored_exceptions:
                         pass
-            # flush connection just in case
+            # flush connection
             if self._connection:
                 try:
                     self._connection.send_all()

--- a/neo4j/_sync/work/session.py
+++ b/neo4j/_sync/work/session.py
@@ -169,46 +169,38 @@ class Session(Workspace):
         This will release any borrowed resources, such as connections, and will
         roll back any outstanding transactions.
         """
+        ignored_exceptions = (Neo4jError, ServiceUnavailable, SessionExpired)
+
         if self._closed:
             return
-        if self._connection:
+        try:
             if self._auto_result:
-                if self._state_failed is False:
-                    try:
-                        self._auto_result.consume()
-                        self._update_bookmark(
-                            self._auto_result._database,
-                            self._auto_result._bookmark
-                        )
-                    except Exception as error:
-                        # TODO: Investigate potential non graceful close states
-                        self._auto_result = None
-                        self._state_failed = True
-
+                try:
+                    self._auto_result.consume()
+                except ignored_exceptions:
+                    pass
             if self._transaction:
-                if self._transaction._closed() is False:
-                    # roll back the transaction if it is not closed
-                    self._transaction._rollback()
-                self._transaction = None
-
-            try:
-                if self._connection:
+                try:
+                    self._transaction._close()
+                except ignored_exceptions:
+                    pass
+            if self._connection:
+                try:
                     self._connection.send_all()
                     self._connection.fetch_all()
                     # TODO: Investigate potential non graceful close states
-            except Neo4jError:
-                pass
-            except TransactionError:
-                pass
-            except ServiceUnavailable:
-                pass
-            except SessionExpired:
-                pass
-            finally:
+                except ignored_exceptions:
+                    pass
+        except asyncio.CancelledError:
+            self._handle_cancellation(message="close")
+            raise
+        finally:
+            self._auto_result = None
+            self._transaction = None
+            try:
                 self._disconnect()
-
-            self._state_failed = False
-        self._closed = True
+            finally:
+                self._closed = True
 
     if Util.is_async_code:
         def cancel(self) -> None:
@@ -376,6 +368,10 @@ class Session(Workspace):
             self._disconnect()
 
     def _transaction_error_handler(self, error):
+        if isinstance(error, asyncio.CancelledError):
+            return self._handle_cancellation(
+                message="_transaction_error_handler"
+            )
         if self._transaction:
             self._transaction = None
             self._disconnect()

--- a/neo4j/_sync/work/session.py
+++ b/neo4j/_sync/work/session.py
@@ -174,27 +174,29 @@ class Session(Workspace):
         if self._closed:
             return
         try:
-            if self._auto_result:
-                try:
+            try:
+                # consume outstanding auto-commit result
+                if self._auto_result:
                     self._auto_result.consume()
-                except ignored_exceptions:
-                    pass
-            if self._transaction:
-                try:
-                    self._transaction._close()
-                except ignored_exceptions:
-                    pass
+            finally:
+                # close any outstanding transaction
+                if self._transaction:
+                    try:
+                        self._transaction._close()
+                    except ignored_exceptions:
+                        pass
+            # flush connection just in case
             if self._connection:
                 try:
                     self._connection.send_all()
                     self._connection.fetch_all()
-                    # TODO: Investigate potential non graceful close states
                 except ignored_exceptions:
                     pass
         except asyncio.CancelledError:
             self._handle_cancellation(message="close")
             raise
         finally:
+            # disconnect, clean up, and mark as closed
             self._auto_result = None
             self._transaction = None
             try:

--- a/tests/unit/sync/work/test_session.py
+++ b/tests/unit/sync/work/test_session.py
@@ -23,6 +23,7 @@ import pytest
 from neo4j import (
     Bookmarks,
     ManagedTransaction,
+    Result,
     Session,
     Transaction,
     unit_of_work,
@@ -33,6 +34,12 @@ from neo4j._sync.io import (
     Neo4jPool,
 )
 from neo4j.api import BookmarkManager
+from neo4j.exceptions import (
+    DriverError,
+    Neo4jError,
+    ServiceUnavailable,
+    SessionExpired,
+)
 
 from ...._async_compat import mark_sync_test
 
@@ -50,11 +57,101 @@ def assert_warns_tx_func_deprecation(tx_func_name):
 @mark_sync_test
 def test_session_context_calls_close(mocker):
     s = Session(None, SessionConfig())
+    original_close = s.close
+
+    def mock_close(*args, **kwargs):
+        assert not s._state_failed
+        return original_close(*args, **kwargs)
+
     mock_close = mocker.patch.object(s, 'close', autospec=True,
-                                     side_effect=s.close)
+                                     side_effect=mock_close)
     with s:
         pass
     mock_close.assert_called_once_with()
+
+
+@mark_sync_test
+def test_session_context_calls_close_exception_case(mocker):
+    exc = Exception("test")
+
+    s = Session(None, SessionConfig())
+    original_close = s.close
+
+    def mock_close(*args, **kwargs):
+        assert s._state_failed
+        return original_close(*args, **kwargs)
+
+    mock_close = mocker.patch.object(s, 'close', autospec=True,
+                                     side_effect=mock_close)
+
+    with pytest.raises(type(exc)) as exc_info:
+        with s:
+            raise exc
+    assert exc_info.value is exc
+    mock_close.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("pending_tx", "pending_auto_commit"),
+    (
+        (True, False),
+        (False, True),
+        (False, False),
+    )
+)
+@pytest.mark.parametrize(
+    ("cleanup_fail", "silent_fail"),
+    (
+        (None, True),
+        (AttributeError("the dev sucks"), False),
+        (Exception("test"), False),
+        (DriverError("test"), False),
+        (ServiceUnavailable("test"), True),
+        (SessionExpired("test"), True),
+        (Neo4jError("test", "Neo.TransientError.What.Ever"), True),
+    )
+)
+@pytest.mark.parametrize("user_code_raised", (True, False))
+@mark_sync_test
+def test_close_with_failed_state(
+    pending_tx, pending_auto_commit, cleanup_fail, silent_fail,
+    user_code_raised, mocker,
+):
+    s = Session(None, SessionConfig())
+    s._state_failed = user_code_raised
+    tx_mock = mocker.Mock(spec=Transaction)
+    res_mock = mocker.Mock(spec=Result)
+    if pending_tx:
+        s._transaction = tx_mock
+        if cleanup_fail:
+            s._transaction._close.side_effect = cleanup_fail
+    if pending_auto_commit:
+        s._auto_result = res_mock
+        if cleanup_fail:
+            s._auto_result.consume.side_effect = cleanup_fail
+
+    if not pending_tx and not pending_auto_commit:
+        expected_to_fail = False
+    elif pending_auto_commit:
+        expected_to_fail = not user_code_raised and cleanup_fail
+    else:
+        expected_to_fail = not silent_fail
+
+    if expected_to_fail:
+        with pytest.raises(type(cleanup_fail)) as exc_info:
+            s.close()
+        assert exc_info.value is cleanup_fail
+    else:
+        s.close()
+
+    assert s.closed()
+    if pending_tx:
+        tx_mock._close.assert_called_once_with()
+    if pending_auto_commit:
+        if user_code_raised:
+            res_mock.consume.assert_not_called()
+        else:
+            res_mock.consume.assert_called_once_with()
 
 
 @pytest.mark.parametrize("test_run_args", (


### PR DESCRIPTION
Exceptions raised during some cleanup steps in `session.close` could have left the session in an unclean state. In particular, the session wouldn't be marked as closed. Moreover, errors encountered when consuming outstanding auto-commit results during session closure were silently swallowed.