### PR TITLE
[4.4] Fix exception handling in `Session.close()`

### DIFF
--- a/neo4j/work/simple.py
+++ b/neo4j/work/simple.py
@@ -135,7 +135,7 @@ class Session(Workspace):
         try:
             try:
                 # consume outstanding auto-commit result
-                if self._autoResult:
+                if not self._state_failed and self._autoResult:
                     self._autoResult.consume()
             finally:
                 # close any outstanding transaction
@@ -144,7 +144,7 @@ class Session(Workspace):
                         self._transaction.close()
                     except ignored_exceptions:
                         pass
-            # flush connection just in case
+            # flush connection
             if self._connection:
                 try:
                     self._connection.send_all()


### PR DESCRIPTION
Exceptions raised during some cleanup steps in `session.close` could have left the session in an unclean state. In particular, the session wouldn't be marked as closed. Moreover, errors encountered when consuming outstanding auto-commit results during session closure were silently swallowed.

Back port of https://github.com/neo4j/neo4j-python-driver/pull/800