### PR TITLE
[4.4] Fix #796: connection pool clogging up

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -756,9 +756,9 @@ class IOPool:
                          + self.connections_reservations[address])
             can_create_new_connection = (infinite_pool_size
                                          or pool_size < max_pool_size)
-            self.connections_reservations[address] += 1
-        if can_create_new_connection:
-            return connection_creator
+            if can_create_new_connection:
+                self.connections_reservations[address] += 1
+                return connection_creator
 
     def _acquire(self, address, deadline):
 

--- a/tests/unit/io/test_neo4j_pool.py
+++ b/tests/unit/io/test_neo4j_pool.py
@@ -35,6 +35,7 @@ from neo4j.conf import (
     RoutingConfig,
     WorkspaceConfig
 )
+from neo4j._deadline import Deadline
 from neo4j.exceptions import (
     ServiceUnavailable,
     SessionExpired
@@ -271,3 +272,29 @@ def test_failing_opener_leaves_connections_in_use_alone(opener):
         pool.acquire(READ_ACCESS, 30, 60, "test_db", None)
 
     assert not cx1.closed()
+
+
+def test__acquire_new_later_with_room(opener):
+    config = PoolConfig()
+    config.max_connection_pool_size = 1
+    pool = Neo4jPool(
+        opener, config, WorkspaceConfig(), ROUTER_ADDRESS
+    )
+    assert pool.connections_reservations[READER_ADDRESS] == 0
+    creator = pool._acquire_new_later(READER_ADDRESS, Deadline(1))
+    assert pool.connections_reservations[READER_ADDRESS] == 1
+    assert callable(creator)
+
+
+def test__acquire_new_later_without_room(opener):
+    config = PoolConfig()
+    config.max_connection_pool_size = 1
+    pool = Neo4jPool(
+        opener, config, WorkspaceConfig(), ROUTER_ADDRESS
+    )
+    _ = pool.acquire(READ_ACCESS, 30, 60, "test_db", None)
+    # pool is full now
+    assert pool.connections_reservations[READER_ADDRESS] == 0
+    creator = pool._acquire_new_later(READER_ADDRESS, Deadline(1))
+    assert pool.connections_reservations[READER_ADDRESS] == 0
+    assert creator is None


### PR DESCRIPTION
The reservation count was also increased if the pool was full and the reserveration would never be turned into a new connection. This lead to the pool clogging up after a while.