### PR TITLE
[4.4] Improve Neo4jError representation

### DIFF
--- a/neo4j/exceptions.py
+++ b/neo4j/exceptions.py
@@ -146,7 +146,7 @@ class Neo4jError(Exception):
         return False
 
     def __str__(self):
-        if self.code and self.message:
+        if self.code or self.message:
             return "{{code: {code}}} {{message: {message}}}".format(
                 code=self.code, message=self.message
             )

--- a/neo4j/exceptions.py
+++ b/neo4j/exceptions.py
@@ -146,14 +146,16 @@ class Neo4jError(Exception):
         return False
 
     def __str__(self):
-        return "{{code: {code}}} {{message: {message}}}".format(code=self.code, message=self.message)
+        if self.code and self.message:
+            return "{{code: {code}}} {{message: {message}}}".format(
+                code=self.code, message=self.message
+            )
+        return super().__str__()
 
 
 class ClientError(Neo4jError):
     """ The Client sent a bad request - changing the request might yield a successful outcome.
     """
-    def __str__(self):
-        return super(Neo4jError, self).__str__()
 
 
 class DatabaseError(Neo4jError):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -239,18 +239,57 @@ def test_transient_error_is_retriable_case_3():
     assert error.is_retriable() is True
 
 
-def test_neo4j_error_from_server_as_str():
-    error = Neo4jError.hydrate(message="Test error message",
-                               code="Neo.ClientError.General.UnknownError")
+@pytest.mark.parametrize(
+    ("code", "message", "expected_cls", "expected_str"),
+    (
+        (
+            "Neo.ClientError.General.UnknownError",
+            "Test error message",
+            ClientError,
+            "{code: Neo.ClientError.General.UnknownError} "
+            "{message: Test error message}"
+        ),
+        (
+            None,
+            "Test error message",
+            DatabaseError,
+            "{code: Neo.DatabaseError.General.UnknownError} "
+            "{message: Test error message}"
+        ),
+        (
+            "",
+            "Test error message",
+            DatabaseError,
+            "{code: Neo.DatabaseError.General.UnknownError} "
+            "{message: Test error message}"
+        ),
+        (
+            "Neo.ClientError.General.UnknownError",
+            None,
+            ClientError,
+            "{code: Neo.ClientError.General.UnknownError} "
+            "{message: An unknown error occurred}"
+        ),
+        (
+            "Neo.ClientError.General.UnknownError",
+            "",
+            ClientError,
+            "{code: Neo.ClientError.General.UnknownError} "
+            "{message: An unknown error occurred}"
+        ),
+    )
+)
+def test_neo4j_error_from_server_as_str(code, message, expected_cls,
+                                        expected_str):
+    error = Neo4jError.hydrate(code=code, message=message)
 
-    assert isinstance(error, ClientError)
-    assert str(error) == ("{code: Neo.ClientError.General.UnknownError} "
-                          "{message: Test error message}")
+    assert type(error) == expected_cls
+    assert str(error) == expected_str
 
 
 @pytest.mark.parametrize("cls", (Neo4jError, ClientError))
 def test_neo4j_error_from_code_as_str(cls):
     error = cls("Generated somewhere in the driver")
 
-    assert isinstance(error, cls)
+    assert type(error)== cls
     assert str(error) == "Generated somewhere in the driver"

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -237,3 +237,20 @@ def test_transient_error_is_retriable_case_3():
 
     assert isinstance(error, TransientError)
     assert error.is_retriable() is True
+
+
+def test_neo4j_error_from_server_as_str():
+    error = Neo4jError.hydrate(message="Test error message",
+                               code="Neo.ClientError.General.UnknownError")
+
+    assert isinstance(error, ClientError)
+    assert str(error) == ("{code: Neo.ClientError.General.UnknownError} "
+                          "{message: Test error message}")
+
+
+@pytest.mark.parametrize("cls", (Neo4jError, ClientError))
+def test_neo4j_error_from_code_as_str(cls):
+    error = cls("Generated somewhere in the driver")
+
+    assert isinstance(error, cls)
+    assert str(error) == "Generated somewhere in the driver"


### PR DESCRIPTION
When the error is not received from the DBMS, but instead originates from somewhere in the driver, it might not have a code and a message. In that case, we fall back to the default Exception representation.

Related:
 * https://github.com/neo4j/neo4j-python-driver/issues/796