### PR TITLE
Improve Neo4jError representation

### DIFF
--- a/neo4j/exceptions.py
+++ b/neo4j/exceptions.py
@@ -247,15 +247,17 @@ class Neo4jError(Exception):
         return False
 
     def __str__(self):
-        return "{{code: {code}}} {{message: {message}}}".format(code=self.code, message=self.message)
+        if self.code and self.message:
+            return "{{code: {code}}} {{message: {message}}}".format(
+                code=self.code, message=self.message
+            )
+        return super().__str__()
 
 
 # Neo4jError > ClientError
 class ClientError(Neo4jError):
     """ The Client sent a bad request - changing the request might yield a successful outcome.
     """
-    def __str__(self) -> str:
-        return super().__str__()
 
 
 # Neo4jError > ClientError > CypherSyntaxError

--- a/neo4j/exceptions.py
+++ b/neo4j/exceptions.py
@@ -247,7 +247,7 @@ class Neo4jError(Exception):
         return False
 
     def __str__(self):
-        if self.code and self.message:
+        if self.code or self.message:
             return "{{code: {code}}} {{message: {message}}}".format(
                 code=self.code, message=self.message
             )

--- a/tests/unit/common/test_exceptions.py
+++ b/tests/unit/common/test_exceptions.py
@@ -257,3 +257,20 @@ def test_error_rewrite(code, expected_cls, expected_code):
     assert error.is_retryable() is expected_retryable
     with pytest.warns(DeprecationWarning, match=".*is_retryable.*"):
         assert error.is_retriable() is expected_retryable
+
+
+def test_neo4j_error_from_server_as_str():
+    error = Neo4jError.hydrate(message="Test error message",
+                               code="Neo.ClientError.General.UnknownError")
+
+    assert isinstance(error, ClientError)
+    assert str(error) == ("{code: Neo.ClientError.General.UnknownError} "
+                          "{message: Test error message}")
+
+
+@pytest.mark.parametrize("cls", (Neo4jError, ClientError))
+def test_neo4j_error_from_code_as_str(cls):
+    error = cls("Generated somewhere in the driver")
+
+    assert isinstance(error, cls)
+    assert str(error) == "Generated somewhere in the driver"


### PR DESCRIPTION
When the error is not received from the DBMS, but instead originates from somewhere in the driver, it might not have a code and a message. In that case, we fall back to the default Exception representation.

Related:
 * https://github.com/neo4j/neo4j-python-driver/issues/796