### PR TITLE
Fix docstring example: session.begin_transaction() needs to be awaited

### DIFF
--- a/neo4j/_async/work/transaction.py
+++ b/neo4j/_async/work/transaction.py
@@ -256,7 +256,7 @@ class AsyncTransaction(AsyncTransactionBase):
     managers (:py:const:`async with` block) where the transaction is committed
     or rolled back on based on whether an exception is raised::
 
-        async with session.begin_transaction() as tx:
+        async with await session.begin_transaction() as tx:
             ...
 
     """


### PR DESCRIPTION
Found this error in the docstring while working with the async module of the driver. When the `session` is an instance of `AsyncSession` the method begin_transaction() is async and needs to be awaited. The example in the docstring was missing the `await` keyword and running it as that returns `AttributeError: __aenter__`