### PR TITLE
TestKit backend: run python with unbuffered stdout/err

### DIFF
--- a/testkit/_common.py
+++ b/testkit/_common.py
@@ -14,4 +14,4 @@ def run(args, env=None):
 
 
 def run_python(args, env=None):
-    run([TEST_BACKEND_VERSION, "-W", "error", *args], env=env)
+    run([TEST_BACKEND_VERSION, "-u", "-W", "error", *args], env=env)


### PR DESCRIPTION
Test TestKit backend gets killed forcefully (`SIGKILL`) by TestKit/docker. Therefore, buffered stdout/stderr (default Python interpreter behavior) can lead to the last bits of output missing in the log files.