### PR TITLE
Improve docstring for `timeout` param in `unit_of_work` decorator.

### DIFF
--- a/neo4j/work/query.py
+++ b/neo4j/work/query.py
@@ -73,6 +73,7 @@ def unit_of_work(
         Transactions that execute longer than the configured timeout will be terminated by the database.
         This functionality allows to limit query/transaction execution time.
         Specified timeout overrides the default timeout configured in the database using ``dbms.transaction.timeout`` setting.
+        Values higher than ``dbms.transaction.timeout`` will be ignored and will fallback to default (unless using Neo4j < 4.2).
         Value should not represent a negative duration.
         A zero duration will make the transaction execute indefinitely.
         None will use the default timeout configured in the database.

--- a/neo4j/work/query.py
+++ b/neo4j/work/query.py
@@ -50,7 +50,10 @@ class Query:
 def unit_of_work(
     metadata: t.Dict[str, t.Any] = None, timeout: float = None
 ) -> t.Callable[[_T], _T]:
-    """This function is a decorator for transaction functions that allows extra control over how the transaction is carried out.
+    """Decorator giving extra control over transaction function configuration.
+
+    This function is a decorator for transaction functions that allows extra
+    control over how the transaction is carried out.
 
     For example, a timeout may be applied::
 
@@ -64,16 +67,24 @@ def unit_of_work(
 
     :param metadata:
         a dictionary with metadata.
-        Specified metadata will be attached to the executing transaction and visible in the output of ``dbms.listQueries`` and ``dbms.listTransactions`` procedures.
+        Specified metadata will be attached to the executing transaction and
+        visible in the output of ``dbms.listQueries`` and
+        ``dbms.listTransactions`` procedures.
         It will also get logged to the ``query.log``.
-        This functionality makes it easier to tag transactions and is equivalent to ``dbms.setTXMetaData`` procedure, see https://neo4j.com/docs/operations-manual/current/reference/procedures/ for procedure reference.
+        This functionality makes it easier to tag transactions and is
+        equivalent to ``dbms.setTXMetaData`` procedure, see
+        https://neo4j.com/docs/operations-manual/current/reference/procedures/
+        for procedure reference.
 
     :param timeout:
         the transaction timeout in seconds.
-        Transactions that execute longer than the configured timeout will be terminated by the database.
+        Transactions that execute longer than the configured timeout will be
+        terminated by the database.
         This functionality allows to limit query/transaction execution time.
-        Specified timeout overrides the default timeout configured in the database using ``dbms.transaction.timeout`` setting.
-        Values higher than ``dbms.transaction.timeout`` will be ignored and will fallback to default (unless using Neo4j < 4.2).
+        Specified timeout overrides the default timeout configured in the
+        database using ``dbms.transaction.timeout`` setting.
+        Values higher than ``dbms.transaction.timeout`` will be ignored and
+        will fall back to default (unless using Neo4j < 4.2).
         Value should not represent a negative duration.
         A zero duration will make the transaction execute indefinitely.
         None will use the default timeout configured in the database.


### PR DESCRIPTION
Quoting from https://neo4j.com/docs/python-manual/current/session-api/#_transaction_timeout

> Note: Using with Neo4j 4.1 and earlier it is possible for the driver to override any value set with dbms.transaction.timeout. **In 4.2 and later, dbms.transaction.timeout also acts as a maximum which the driver cannot override**. For example, with a server setting of dbms.transaction.timeout=10s the driver can specify a shorter timeout (e.g. 5 seconds) but not a value greater than 10 seconds. If a greater value is supplied the transaction will still timeout after 10 seconds.

so I added a note in the related docstring accordingly.