### PR TITLE
Improve keyword query parameters

### DIFF
--- a/neo4j/work/result.py
+++ b/neo4j/work/result.py
@@ -63,21 +63,19 @@ class Result:
         else:
             return self._raw_qid
 
-    def _tx_ready_run(self, query, parameters, **kwparameters):
+    def _tx_ready_run(self, query, parameters):
         # BEGIN+RUN does not carry any extra on the RUN message.
         # BEGIN {extra}
         # RUN "query" {parameters} {extra}
-        self._run(query, parameters, None, None, None, None, **kwparameters)
+        self._run(query, parameters, None, None, None, None)
 
-    def _run(self, query, parameters, db, imp_user, access_mode, bookmarks,
-             **kwparameters):
+    def _run(self, query, parameters, db, imp_user, access_mode, bookmarks):
         query_text = str(query)  # Query or string object
         query_metadata = getattr(query, "metadata", None)
         query_timeout = getattr(query, "timeout", None)
 
         parameters = DataDehydrator.fix_parameters(
-            dict(parameters or {}, **kwparameters),
-            patch_utc="utc" in self._connection.bolt_patches
+            parameters, patch_utc="utc" in self._connection.bolt_patches
         )
 
         self._metadata = {

--- a/neo4j/work/simple.py
+++ b/neo4j/work/simple.py
@@ -213,7 +213,7 @@ class Session(Workspace):
             cx, hydrant, self._config.fetch_size, self._result_closed,
             self._result_error
         )
-        dict(parameters or {}, **kwparameters),
+        parameters = dict(parameters or {}, **kwparameters),
         self._autoResult._run(
             query, parameters, self._config.database,
             self._config.impersonated_user, self._config.default_access_mode,

--- a/neo4j/work/simple.py
+++ b/neo4j/work/simple.py
@@ -185,7 +185,8 @@ class Session(Workspace):
         :type query: str, neo4j.Query
         :param parameters: dictionary of parameters
         :type parameters: dict
-        :param kwparameters: additional keyword parameters
+        :param kwparameters: additional keyword parameters.
+            These take precedence over parameters passed as ``parameters``.
         :returns: a new :class:`neo4j.Result` object
         :rtype: :class:`neo4j.Result`
         """
@@ -212,10 +213,11 @@ class Session(Workspace):
             cx, hydrant, self._config.fetch_size, self._result_closed,
             self._result_error
         )
+        dict(parameters or {}, **kwparameters),
         self._autoResult._run(
             query, parameters, self._config.database,
             self._config.impersonated_user, self._config.default_access_mode,
-            self._bookmarks, **kwparameters
+            self._bookmarks
         )
 
         return self._autoResult

--- a/neo4j/work/simple.py
+++ b/neo4j/work/simple.py
@@ -213,7 +213,7 @@ class Session(Workspace):
             cx, hydrant, self._config.fetch_size, self._result_closed,
             self._result_error
         )
-        parameters = dict(parameters or {}, **kwparameters),
+        parameters = dict(parameters or {}, **kwparameters)
         self._autoResult._run(
             query, parameters, self._config.database,
             self._config.impersonated_user, self._config.default_access_mode,

--- a/neo4j/work/transaction.py
+++ b/neo4j/work/transaction.py
@@ -105,7 +105,8 @@ class Transaction:
         :type query: str
         :param parameters: dictionary of parameters
         :type parameters: dict
-        :param kwparameters: additional keyword parameters
+        :param kwparameters: additional keyword parameters.
+            These take precedence over parameters passed as ``parameters``.
         :returns: a new :class:`neo4j.Result` object
         :rtype: :class:`neo4j.Result`
         :raise TransactionError: if the transaction is already closed
@@ -138,7 +139,8 @@ class Transaction:
         )
         self._results.append(result)
 
-        result._tx_ready_run(query, parameters, **kwparameters)
+        parameters = dict(parameters or {}, **kwparameters)
+        result._tx_ready_run(query, parameters)
 
         return result
 


### PR DESCRIPTION
 * API docs: clarify precedence between keyword and dict query parameters
 * Fix: parameters of internal functions could clash with keyword parameters. E.g., `db` and `imp_user` could not be used as keyword query parameters causing a not necessarily easy to understand error message. This got fixed by merging keyword and dict parameters at the top-most level.

Backport of https://github.com/neo4j/neo4j-python-driver/pull/835