### PR TITLE
API docs: replace deprecated Cypher procedures

### DIFF
--- a/neo4j/_async/work/session.py
+++ b/neo4j/_async/work/session.py
@@ -416,9 +416,14 @@ class AsyncSession(AsyncWorkspace):
 
         :param metadata:
             a dictionary with metadata.
-            Specified metadata will be attached to the executing transaction and visible in the output of ``dbms.listQueries`` and ``dbms.listTransactions`` procedures.
+            Specified metadata will be attached to the executing transaction
+            and visible in the output of ``SHOW TRANSACTIONS YIELD *``
             It will also get logged to the ``query.log``.
-            This functionality makes it easier to tag transactions and is equivalent to ``dbms.setTXMetaData`` procedure, see https://neo4j.com/docs/operations-manual/current/reference/procedures/ for procedure reference.
+            This functionality makes it easier to tag transactions and is
+            equivalent to the ``dbms.setTXMetaData`` procedure, see
+            https://neo4j.com/docs/cypher-manual/current/clauses/transaction-clauses/#query-listing-transactions
+            and https://neo4j.com/docs/operations-manual/current/reference/procedures/
+            for reference.
 
         :param timeout:
             the transaction timeout in seconds.

--- a/neo4j/_sync/work/session.py
+++ b/neo4j/_sync/work/session.py
@@ -416,9 +416,14 @@ class Session(Workspace):
 
         :param metadata:
             a dictionary with metadata.
-            Specified metadata will be attached to the executing transaction and visible in the output of ``dbms.listQueries`` and ``dbms.listTransactions`` procedures.
+            Specified metadata will be attached to the executing transaction
+            and visible in the output of ``SHOW TRANSACTIONS YIELD *``
             It will also get logged to the ``query.log``.
-            This functionality makes it easier to tag transactions and is equivalent to ``dbms.setTXMetaData`` procedure, see https://neo4j.com/docs/operations-manual/current/reference/procedures/ for procedure reference.
+            This functionality makes it easier to tag transactions and is
+            equivalent to the ``dbms.setTXMetaData`` procedure, see
+            https://neo4j.com/docs/cypher-manual/current/clauses/transaction-clauses/#query-listing-transactions
+            and https://neo4j.com/docs/operations-manual/current/reference/procedures/
+            for reference.
 
         :param timeout:
             the transaction timeout in seconds.

--- a/neo4j/work/query.py
+++ b/neo4j/work/query.py
@@ -67,14 +67,14 @@ def unit_of_work(
 
     :param metadata:
         a dictionary with metadata.
-        Specified metadata will be attached to the executing transaction and
-        visible in the output of ``dbms.listQueries`` and
-        ``dbms.listTransactions`` procedures.
+        Specified metadata will be attached to the executing transaction
+        and visible in the output of ``SHOW TRANSACTIONS YIELD *``
         It will also get logged to the ``query.log``.
         This functionality makes it easier to tag transactions and is
-        equivalent to ``dbms.setTXMetaData`` procedure, see
-        https://neo4j.com/docs/operations-manual/current/reference/procedures/
-        for procedure reference.
+        equivalent to the ``dbms.setTXMetaData`` procedure, see
+        https://neo4j.com/docs/cypher-manual/current/clauses/transaction-clauses/#query-listing-transactions
+        and https://neo4j.com/docs/operations-manual/current/reference/procedures/
+        for reference.
 
     :param timeout:
         the transaction timeout in seconds.


### PR DESCRIPTION
`dbms.listQueries` and `dbms.listTransactions` have been deprecated in favor of `SHOW TRANSACTIONS YIELD *`