### PR TITLE
Don't install tests subpackages either

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ entry_points = {
     "console_scripts": [
     ],
 }
-packages = find_packages(exclude=["tests"])
+packages = find_packages(exclude=["tests", "tests.*"])
 
 readme_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                            "README.rst"))

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ entry_points = {
     "console_scripts": [
     ],
 }
-packages = find_packages(exclude=["tests", "tests.*"])
+packages = find_packages(exclude=["test*"])
 
 readme_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                            "README.rst"))


### PR DESCRIPTION
We already try to avoid installing tests but we need to include a glob to catch subpackages (we do
the same in neo4j's boltkit).