### PR TITLE
Package `py.typed` marker file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ entry_points = {
     ],
 }
 packages = find_packages(exclude=["tests"])
+package_data = {
+    "neo4j": ["py.typed"],
+}
 
 readme_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                            "README.rst"))
@@ -73,6 +76,7 @@ setup_args = {
     "extras_require": extras_require,
     "classifiers": classifiers,
     "packages": packages,
+    "package_data": package_data,
     "entry_points": entry_points,
     "python_requires": ">=3.7",
 }

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ entry_points = {
 }
 packages = find_packages(exclude=["tests"])
 package_data = {
-    "neo4j": ["py.typed"],
+    package: ["py.typed"] for package in packages
 }
 
 readme_path = os.path.abspath(os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
https://peps.python.org/pep-0561/#packaging-type-information for a little bit of context.

I just missed to bundle the marker file with the source distribution, effectively leaving the driver without typing...