### PR TITLE
Don't publish test packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ entry_points = {
     "console_scripts": [
     ],
 }
-packages = find_packages(exclude=["tests"])
+packages = find_packages(exclude=["test*"])
 
 readme_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "README.rst"))
 with open(readme_path, mode="r", encoding="utf-8") as fr:


### PR DESCRIPTION
Previously, the testkit backend was included in the published packed.

Backport of https://github.com/neo4j/neo4j-python-driver/pull/855