### PR TITLE
Add the ability to Refresh Auth Token Credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ neo4j-enterprise-*
 
 testkit/CAs
 testkit/CustomCAs
+/.vs

--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -49,6 +49,7 @@ from ._common import (
     AsyncInbox,
     AsyncOutbox,
     CommitResponse,
+    auth_to_dict,
 )
 
 
@@ -142,7 +143,7 @@ class AsyncBolt:
             self.auth_dict = vars(Auth("basic", *auth))
         else:
             try:
-                self.auth_dict = vars(auth)
+                self.auth_dict = auth_to_dict(auth)
             except (KeyError, TypeError):
                 raise AuthError("Cannot determine auth details from %r" % auth)
 

--- a/src/neo4j/_async/io/_common.py
+++ b/src/neo4j/_async/io/_common.py
@@ -294,3 +294,12 @@ async def receive_into_buffer(sock, buffer, n_bytes):
             if n == 0:
                 raise OSError("No data")
             buffer.used += n
+
+
+def auth_to_dict(auth):
+    auth_dict = vars(auth).copy()
+    if "credentials_refresher" in auth_dict:
+        if auth_dict["credentials_refresher"] is not None:
+            auth_dict["credentials"] = auth_dict["credentials_refresher"]()
+        auth_dict.pop("credentials_refresher")
+    return auth_dict

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -24,6 +24,7 @@ from collections import deque
 from logging import getLogger
 from time import perf_counter
 
+from ..._async.io._common import auth_to_dict
 from ..._async_compat.network import BoltSocket
 from ..._codec.hydration import v1 as hydration_v1
 from ..._codec.packstream import v1 as packstream_v1
@@ -142,7 +143,7 @@ class Bolt:
             self.auth_dict = vars(Auth("basic", *auth))
         else:
             try:
-                self.auth_dict = vars(auth)
+                self.auth_dict = auth_to_dict(auth)
             except (KeyError, TypeError):
                 raise AuthError("Cannot determine auth details from %r" % auth)
 

--- a/src/neo4j/api.py
+++ b/src/neo4j/api.py
@@ -102,6 +102,10 @@ class Auth:
             self.realm = realm
         if parameters:
             self.parameters = parameters
+        self.credentials_refresher = None
+
+    def add_credentials_refresher(self, credentials_refresher: t.Any):
+        self.credentials_refresher = credentials_refresher
 
 
 # For backwards compatibility


### PR DESCRIPTION
Add the ability to Refresh Auth Token Credentials

Currently when credentials expire, driver will continue trying to connect with the outdated credentials. There is no ability to update or refresh login credentials (See https://github.com/neo4j/neo4j-python-driver/issues/834).

This PR introduces the ability to pass an optional `credentials_refresher` function to an authToken object which will change credentials as they become obsolete.

There are no breaking changes introduced in this PR.

There is a test which uses a simple credentials_refresher to validate that these modifications do not break serialization.

Intended use

```
auth_token = basic_auth("some_login", "ignored")
auth_token.add_credentials_refresher(credentials_refresher)
self.driver = GraphDatabase.driver(uri, auth=auth_token, encrypted=True)
```

I'm a first-time contributor and have just signed the CLA