### PR TITLE
Silence mypy error

### DIFF
--- a/src/neo4j/_spatial/__init__.py
+++ b/src/neo4j/_spatial/__init__.py
@@ -60,7 +60,10 @@ class Point(t.Tuple[float, ...]):
         def z(self) -> float: ...
 
     def __new__(cls, iterable: t.Iterable[float]) -> Point:
-        return tuple.__new__(cls, map(float, iterable))
+        # mypy issue https://github.com/python/mypy/issues/14890
+        return tuple.__new__(  # type: ignore[type-var]
+            cls, map(float, iterable)
+        )
 
     def __repr__(self) -> str:
         return "POINT(%s)" % " ".join(map(str, self))

--- a/src/neo4j/time/__init__.py
+++ b/src/neo4j/time/__init__.py
@@ -415,7 +415,8 @@ class Duration(t.Tuple[int, int, int, int],  # type: ignore[misc]
         if not MIN_INT64 <= avg_total_seconds <= MAX_INT64:
             raise ValueError("Duration value out of range: %r",
                              tuple.__repr__((mo, d, s, ns)))
-        return tuple.__new__(cls, (mo, d, s, ns))
+        # mypy issue https://github.com/python/mypy/issues/14890
+        return tuple.__new__(cls, (mo, d, s, ns))  # type: ignore[type-var]
 
     def __bool__(self) -> bool:
         """Falsy if all primary instance attributes are."""


### PR DESCRIPTION
Staring with mypy 1.1.1, mypy started complaining about `__new__` of for example `Tuple[float, ...]`, which we are using in spatial and temporal types.
