### PR TITLE
Fix bolt handshake not having a timeout

### DIFF
--- a/src/neo4j/_async/io/_pool.py
+++ b/src/neo4j/_async/io/_pool.py
@@ -135,9 +135,7 @@ class AsyncIOPool(abc.ABC):
             released_reservation = False
             try:
                 try:
-                    connection = await self.opener(
-                        address, deadline.to_timeout()
-                    )
+                    connection = await self.opener(address, deadline)
                 except ServiceUnavailable:
                     await self.deactivate(address)
                     raise
@@ -382,9 +380,9 @@ class AsyncBoltPool(AsyncIOPool):
         :returns: BoltPool
         """
 
-        async def opener(addr, timeout):
+        async def opener(addr, deadline):
             return await AsyncBolt.open(
-                addr, auth=auth, timeout=timeout, routing_context=None,
+                addr, auth=auth, deadline=deadline, routing_context=None,
                 pool_config=pool_config
             )
 
@@ -437,9 +435,9 @@ class AsyncNeo4jPool(AsyncIOPool):
             raise ConfigurationError("The key 'address' is reserved for routing context.")
         routing_context["address"] = str(address)
 
-        async def opener(addr, timeout):
+        async def opener(addr, deadline):
             return await AsyncBolt.open(
-                addr, auth=auth, timeout=timeout,
+                addr, auth=auth, deadline=deadline,
                 routing_context=routing_context, pool_config=pool_config
             )
 

--- a/src/neo4j/_deadline.py
+++ b/src/neo4j/_deadline.py
@@ -72,6 +72,9 @@ class Deadline:
             return timeout
         return cls(timeout)
 
+    def __str__(self):
+        return f"Deadline(timeout={self._original_timeout})"
+
 
 merge_deadlines = min
 

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -28,6 +28,7 @@ from ..._async_compat.network import BoltSocket
 from ..._codec.hydration import v1 as hydration_v1
 from ..._codec.packstream import v1 as packstream_v1
 from ..._conf import PoolConfig
+from ..._deadline import Deadline
 from ..._exceptions import (
     BoltError,
     BoltHandshakeError,
@@ -289,17 +290,21 @@ class Bolt:
         return b"".join(version.to_bytes() for version in offered_versions).ljust(16, b"\x00")
 
     @classmethod
-    def ping(cls, address, *, timeout=None, pool_config=None):
+    def ping(cls, address, *, deadline=None, pool_config=None):
         """ Attempt to establish a Bolt connection, returning the
         agreed Bolt protocol version if successful.
         """
         if pool_config is None:
             pool_config = PoolConfig()
+        if deadline is None:
+            deadline = Deadline(None)
+
         try:
             s, protocol_version, handshake, data = \
                 BoltSocket.connect(
                     address,
-                    timeout=timeout,
+                    tcp_timeout=pool_config.connection_timeout,
+                    deadline=deadline,
                     custom_resolver=pool_config.resolver,
                     ssl_context=pool_config.get_ssl_context(),
                     keep_alive=pool_config.keep_alive,
@@ -313,14 +318,14 @@ class Bolt:
     # [bolt-version-bump] search tag when changing bolt version support
     @classmethod
     def open(
-        cls, address, *, auth=None, timeout=None, routing_context=None,
+        cls, address, *, auth=None, deadline=None, routing_context=None,
         pool_config=None
     ):
         """Open a new Bolt connection to a given server address.
 
         :param address:
         :param auth:
-        :param timeout: the connection timeout in seconds
+        :param deadline: how long to wait for the connection to be established
         :param routing_context: dict containing routing context
         :param pool_config:
 
@@ -330,26 +335,17 @@ class Bolt:
             raised if the Bolt Protocol can not negotiate a protocol version.
         :raise ServiceUnavailable: raised if there was a connection issue.
         """
-        def time_remaining():
-            if timeout is None:
-                return None
-            t = timeout - (perf_counter() - t0)
-            return t if t > 0 else 0
 
-        t0 = perf_counter()
         if pool_config is None:
             pool_config = PoolConfig()
+        if deadline is None:
+            deadline = Deadline(None)
 
-        socket_connection_timeout = pool_config.connection_timeout
-        if socket_connection_timeout is None:
-            socket_connection_timeout = time_remaining()
-        elif timeout is not None:
-            socket_connection_timeout = min(pool_config.connection_timeout,
-                                            time_remaining())
         s, protocol_version, handshake, data = \
             BoltSocket.connect(
                 address,
-                timeout=socket_connection_timeout,
+                tcp_timeout=pool_config.connection_timeout,
+                deadline=deadline,
                 custom_resolver=pool_config.resolver,
                 ssl_context=pool_config.get_ssl_context(),
                 keep_alive=pool_config.keep_alive,
@@ -410,7 +406,7 @@ class Bolt:
         )
 
         try:
-            connection.socket.set_deadline(time_remaining())
+            connection.socket.set_deadline(deadline)
             try:
                 connection.hello()
             finally:

--- a/src/neo4j/_sync/io/_pool.py
+++ b/src/neo4j/_sync/io/_pool.py
@@ -135,9 +135,7 @@ class IOPool(abc.ABC):
             released_reservation = False
             try:
                 try:
-                    connection = self.opener(
-                        address, deadline.to_timeout()
-                    )
+                    connection = self.opener(address, deadline)
                 except ServiceUnavailable:
                     self.deactivate(address)
                     raise
@@ -382,9 +380,9 @@ class BoltPool(IOPool):
         :returns: BoltPool
         """
 
-        def opener(addr, timeout):
+        def opener(addr, deadline):
             return Bolt.open(
-                addr, auth=auth, timeout=timeout, routing_context=None,
+                addr, auth=auth, deadline=deadline, routing_context=None,
                 pool_config=pool_config
             )
 
@@ -437,9 +435,9 @@ class Neo4jPool(IOPool):
             raise ConfigurationError("The key 'address' is reserved for routing context.")
         routing_context["address"] = str(address)
 
-        def opener(addr, timeout):
+        def opener(addr, deadline):
             return Bolt.open(
-                addr, auth=auth, timeout=timeout,
+                addr, auth=auth, deadline=deadline,
                 routing_context=routing_context, pool_config=pool_config
             )
 

--- a/tests/unit/async_/io/test_direct.py
+++ b/tests/unit/async_/io/test_direct.py
@@ -109,7 +109,7 @@ async def test_bolt_connection_open():
 async def test_bolt_connection_open_timeout():
     with pytest.raises(ServiceUnavailable):
         await AsyncBolt.open(("localhost", 9999), auth=("test", "test"),
-                             timeout=1)
+                             deadline=Deadline(1))
 
 
 @mark_async_test
@@ -120,7 +120,8 @@ async def test_bolt_connection_ping():
 
 @mark_async_test
 async def test_bolt_connection_ping_timeout():
-    protocol_version = await AsyncBolt.ping(("localhost", 9999), timeout=1)
+    protocol_version = await AsyncBolt.ping(("localhost", 9999),
+                                            deadline=Deadline(1))
     assert protocol_version is None
 
 

--- a/tests/unit/async_/io/test_direct.py
+++ b/tests/unit/async_/io/test_direct.py
@@ -102,14 +102,17 @@ class AsyncFakeBoltPool(AsyncIOPool):
 @mark_async_test
 async def test_bolt_connection_open():
     with pytest.raises(ServiceUnavailable):
-        await AsyncBolt.open(("localhost", 9999), auth=("test", "test"))
+        await AsyncBolt.open(
+            ("localhost", 9999), auth=("test", "test")
+        )
 
 
 @mark_async_test
 async def test_bolt_connection_open_timeout():
     with pytest.raises(ServiceUnavailable):
-        await AsyncBolt.open(("localhost", 9999), auth=("test", "test"),
-                             deadline=Deadline(1))
+        await AsyncBolt.open(
+            ("localhost", 9999), auth=("test", "test"), deadline=Deadline(1)
+        )
 
 
 @mark_async_test
@@ -120,8 +123,9 @@ async def test_bolt_connection_ping():
 
 @mark_async_test
 async def test_bolt_connection_ping_timeout():
-    protocol_version = await AsyncBolt.ping(("localhost", 9999),
-                                            deadline=Deadline(1))
+    protocol_version = await AsyncBolt.ping(
+        ("localhost", 9999), deadline=Deadline(1)
+    )
     assert protocol_version is None
 
 

--- a/tests/unit/sync/io/test_direct.py
+++ b/tests/unit/sync/io/test_direct.py
@@ -102,14 +102,17 @@ class FakeBoltPool(IOPool):
 @mark_sync_test
 def test_bolt_connection_open():
     with pytest.raises(ServiceUnavailable):
-        Bolt.open(("localhost", 9999), auth=("test", "test"))
+        Bolt.open(
+            ("localhost", 9999), auth=("test", "test")
+        )
 
 
 @mark_sync_test
 def test_bolt_connection_open_timeout():
     with pytest.raises(ServiceUnavailable):
-        Bolt.open(("localhost", 9999), auth=("test", "test"),
-                             deadline=Deadline(1))
+        Bolt.open(
+            ("localhost", 9999), auth=("test", "test"), deadline=Deadline(1)
+        )
 
 
 @mark_sync_test
@@ -120,8 +123,9 @@ def test_bolt_connection_ping():
 
 @mark_sync_test
 def test_bolt_connection_ping_timeout():
-    protocol_version = Bolt.ping(("localhost", 9999),
-                                            deadline=Deadline(1))
+    protocol_version = Bolt.ping(
+        ("localhost", 9999), deadline=Deadline(1)
+    )
     assert protocol_version is None
 
 

--- a/tests/unit/sync/io/test_direct.py
+++ b/tests/unit/sync/io/test_direct.py
@@ -109,7 +109,7 @@ def test_bolt_connection_open():
 def test_bolt_connection_open_timeout():
     with pytest.raises(ServiceUnavailable):
         Bolt.open(("localhost", 9999), auth=("test", "test"),
-                             timeout=1)
+                             deadline=Deadline(1))
 
 
 @mark_sync_test
@@ -120,7 +120,8 @@ def test_bolt_connection_ping():
 
 @mark_sync_test
 def test_bolt_connection_ping_timeout():
-    protocol_version = Bolt.ping(("localhost", 9999), timeout=1)
+    protocol_version = Bolt.ping(("localhost", 9999),
+                                            deadline=Deadline(1))
     assert protocol_version is None
 
 


### PR DESCRIPTION
During the bolt version negotiation the socket was not constrained by any timeout. This could, in rare occasions, cause the driver to get stuck until some other mechanism (e.g., socket keep alive) would free it.

The handshake is now limited by the `connection_acquisition_timeout`.

Introducing tests in https://github.com/neo4j-drivers/testkit/pull/546