### PR TITLE
Improve sync TestKit backend performance

### DIFF
--- a/testkitbackend/_async/backend.py
+++ b/testkitbackend/_async/backend.py
@@ -201,11 +201,11 @@ class AsyncBackend:
         self._wr.write(log_output.encode("utf-8"))
         response = {"name": name, "data": data}
         response = dumps(response)
-        log.info(">>> " + name + dumps(data))
         self._wr.write(b"#response begin\n")
-        self._wr.write(bytes(response+"\n", "utf-8"))
+        self._wr.write(bytes(response + "\n", "utf-8"))
         self._wr.write(b"#response end\n")
         if isinstance(self._wr, asyncio.StreamWriter):
             await self._wr.drain()
         else:
             self._wr.flush()
+        log.info(">>> " + name + dumps(data))

--- a/testkitbackend/_sync/backend.py
+++ b/testkitbackend/_sync/backend.py
@@ -201,11 +201,11 @@ class Backend:
         self._wr.write(log_output.encode("utf-8"))
         response = {"name": name, "data": data}
         response = dumps(response)
-        log.info(">>> " + name + dumps(data))
         self._wr.write(b"#response begin\n")
-        self._wr.write(bytes(response+"\n", "utf-8"))
+        self._wr.write(bytes(response + "\n", "utf-8"))
         self._wr.write(b"#response end\n")
         if isinstance(self._wr, asyncio.StreamWriter):
             self._wr.drain()
         else:
             self._wr.flush()
+        log.info(">>> " + name + dumps(data))

--- a/testkitbackend/server.py
+++ b/testkitbackend/server.py
@@ -31,6 +31,9 @@ class Server(TCPServer):
 
     def __init__(self, address):
         class Handler(StreamRequestHandler):
+            # undocumented config but unbearably slow without
+            wbufsize = 2 ** 16  # 64 KiB
+
             def handle(self):
                 backend = Backend(self.rfile, self.wfile)
                 try:


### PR DESCRIPTION
The sync version of the TestKit backend was over 4 times as slow as its async counterpart. The reason is that the TCPServer shipped with Python hands out an unbuffered writer by default.

I don't quite understand why this wasn't a problem earlier. The sync backend code did not change, neither did the TCPServer implementation in the standard library. It shall remain a mystery *insert mystical sound effect*.