### PR TITLE
Add Python 3.11 support to README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ breaking API changes.
 
 See also: https://neo4j.com/developer/kb/neo4j-supported-versions/
 
++ Python 3.11 supported.
 + Python 3.10 supported.
 + Python 3.9 supported.
 + Python 3.8 supported.


### PR DESCRIPTION
Python 3.11 support was actually introduced in version 5.3.0, but apparently the README was not updated accordingly.