### PR TITLE
Fix dev dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # the driver itself
--e .
+-e .[pandas,numpy]
 
 # auto-generate sync driver from async code
 unasync>=0.5.0
@@ -18,8 +18,6 @@ tomlkit~=0.11.6
 # needed for running tests
 coverage[toml]>=5.5
 mock>=4.0.3
-numpy>=1.7.0
-pandas>=1.0.0
 pyarrow>=1.0.0
 pytest>=6.2.5
 pytest-asyncio>=0.16.0


### PR DESCRIPTION
The driver has support for pandas >=1.1, <2, but as optional dependencies. If not specified (`pip install neo4j[pandas]`), but installed directly (`pip install pandas`), the version bounds of the driver will not be respected.