### PR TITLE
Support serializing datetimes with datetime.timezone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ Homepage = "https://github.com/neo4j/neo4j-python-driver"
 [project.optional-dependencies]
 numpy = ["numpy >= 1.7.0, < 2.0.0"]
 pandas = [
-    "pandas >= 1.1.0, < 2.0.0",
+    "pandas >= 1.1.0, < 3.0.0",
     "numpy >= 1.7.0, < 2.0.0",
 ]
 

--- a/src/neo4j/_codec/hydration/v1/temporal.py
+++ b/src/neo4j/_codec/hydration/v1/temporal.py
@@ -20,7 +20,10 @@ from datetime import (
     datetime,
     time,
     timedelta,
+    timezone,
 )
+
+import pytz
 
 from ...._optional_deps import (
     np,
@@ -172,10 +175,15 @@ def dehydrate_datetime(value):
         seconds, nanoseconds = seconds_and_nanoseconds(value)
         return Structure(b"f", seconds, nanoseconds, tz.key)
     else:
+        if isinstance(tz, timezone):
+            # offset of the timezone is constant, so any date will do
+            offset = tz.utcoffset(datetime(1970, 1, 1))
+        else:
+            offset = tz.utcoffset(value)
         # with time offset
         seconds, nanoseconds = seconds_and_nanoseconds(value)
         return Structure(b"F", seconds, nanoseconds,
-                         int(tz.utcoffset(value).total_seconds()))
+                         int(offset.total_seconds()))
 
 
 if np is not None:

--- a/src/neo4j/_codec/hydration/v1/temporal.py
+++ b/src/neo4j/_codec/hydration/v1/temporal.py
@@ -23,8 +23,6 @@ from datetime import (
     timezone,
 )
 
-import pytz
-
 from ...._optional_deps import (
     np,
     pd,

--- a/src/neo4j/_codec/hydration/v1/temporal.py
+++ b/src/neo4j/_codec/hydration/v1/temporal.py
@@ -39,6 +39,9 @@ from ....time import (
 from ...packstream import Structure
 
 
+ANY_BUILTIN_DATETIME = datetime(1970, 1, 1)
+
+
 def get_date_unix_epoch():
     return Date(1970, 1, 1)
 
@@ -175,7 +178,7 @@ def dehydrate_datetime(value):
     else:
         if isinstance(tz, timezone):
             # offset of the timezone is constant, so any date will do
-            offset = tz.utcoffset(datetime(1970, 1, 1))
+            offset = tz.utcoffset(ANY_BUILTIN_DATETIME)
         else:
             offset = tz.utcoffset(value)
         # with time offset

--- a/src/neo4j/_codec/hydration/v2/temporal.py
+++ b/src/neo4j/_codec/hydration/v2/temporal.py
@@ -83,8 +83,12 @@ def dehydrate_datetime(value):  # type: ignore[no-redef]
         return Structure(b"i", seconds, nanoseconds, tz.key)
     else:
         # with time offset
+        if isinstance(tz, timezone):
+            # offset of the timezone is constant, so any date will do
+            offset = tz.utcoffset(datetime(1970, 1, 1))
+        else:
+            offset = tz.utcoffset(value)
         seconds, nanoseconds = seconds_and_nanoseconds(value)
-        offset = tz.utcoffset(value)
         if offset.microseconds:
             raise ValueError("Bolt protocol does not support sub-second "
                              "UTC offsets.")

--- a/tests/unit/common/codec/hydration/v1/test_temporal_dehydration.py
+++ b/tests/unit/common/codec/hydration/v1/test_temporal_dehydration.py
@@ -129,6 +129,18 @@ class TestTimeDehydration(HydrationHandlerTestBase):
                                pytz.FixedOffset(60))
         assert_transforms(dt, Structure(b"F", 1539344261, 474716000, 3600))
 
+    def test_date_time_fixed_native_offset(self, assert_transforms):
+        dt = DateTime(2018, 10, 12, 11, 37, 41, 474716862,
+                      datetime.timezone(datetime.timedelta(minutes=60)))
+        assert_transforms(dt, Structure(b"F", 1539344261, 474716862, 3600))
+
+    def test_native_date_time_fixed_native_offset(self, assert_transforms):
+        dt = datetime.datetime(
+            2018, 10, 12, 11, 37, 41, 474716,
+            datetime.timezone(datetime.timedelta(minutes=60))
+        )
+        assert_transforms(dt, Structure(b"F", 1539344261, 474716000, 3600))
+
     def test_pandas_date_time_fixed_offset(self, assert_transforms):
         dt = pd.Timestamp("2018-10-12T11:37:41.474716862+0100")
         assert_transforms(dt, Structure(b"F", 1539344261, 474716862, 3600))
@@ -141,6 +153,19 @@ class TestTimeDehydration(HydrationHandlerTestBase):
     def test_native_date_time_fixed_negative_offset(self, assert_transforms):
         dt = datetime.datetime(2018, 10, 12, 11, 37, 41, 474716,
                                pytz.FixedOffset(-60))
+        assert_transforms(dt, Structure(b"F", 1539344261, 474716000, -3600))
+
+    def test_date_time_fixed_negative_native_offset(self, assert_transforms):
+        dt = DateTime(2018, 10, 12, 11, 37, 41, 474716862,
+                      datetime.timezone(datetime.timedelta(minutes=-60)))
+        assert_transforms(dt, Structure(b"F", 1539344261, 474716862, -3600))
+
+    def test_native_date_time_fixed_negative_native_offset(self,
+                                                           assert_transforms):
+        dt = datetime.datetime(
+            2018, 10, 12, 11, 37, 41, 474716,
+            datetime.timezone(datetime.timedelta(minutes=-60))
+        )
         assert_transforms(dt, Structure(b"F", 1539344261, 474716000, -3600))
 
     def test_pandas_date_time_fixed_negative_offset(self, assert_transforms):

--- a/tests/unit/common/codec/hydration/v1/test_temporal_dehydration_utc_patch.py
+++ b/tests/unit/common/codec/hydration/v1/test_temporal_dehydration_utc_patch.py
@@ -34,9 +34,13 @@ class UTCPatchedTimeDehydrationMeta(type):
         for test_func in (
             "test_date_time_fixed_offset",
             "test_native_date_time_fixed_offset",
+            "test_date_time_fixed_native_offset",
+            "test_native_date_time_fixed_native_offset",
             "test_pandas_date_time_fixed_offset",
             "test_date_time_fixed_negative_offset",
             "test_native_date_time_fixed_negative_offset",
+            "test_date_time_fixed_negative_native_offset",
+            "test_native_date_time_fixed_negative_native_offset",
             "test_pandas_date_time_fixed_negative_offset",
             "test_date_time_zone_id",
             "test_native_date_time_zone_id",

--- a/tests/unit/common/codec/hydration/v2/test_temporal_dehydration.py
+++ b/tests/unit/common/codec/hydration/v2/test_temporal_dehydration.py
@@ -52,6 +52,24 @@ class TestTimeDehydration(_TestTemporalDehydrationV1):
             Structure(b"I", 1539340661, 474716000, 3600)
         )
 
+    def test_date_time_fixed_native_offset(self, assert_transforms):
+        dt = DateTime(2018, 10, 12, 11, 37, 41, 474716862,
+                      datetime.timezone(datetime.timedelta(minutes=60)))
+        assert_transforms(
+            dt,
+            Structure(b"I", 1539340661, 474716862, 3600)
+        )
+
+    def test_native_date_time_fixed_native_offset(self, assert_transforms):
+        dt = datetime.datetime(
+            2018, 10, 12, 11, 37, 41, 474716,
+            datetime.timezone(datetime.timedelta(minutes=60))
+        )
+        assert_transforms(
+            dt,
+            Structure(b"I", 1539340661, 474716000, 3600)
+        )
+
     def test_pandas_date_time_fixed_offset(self, assert_transforms):
         dt = pd.Timestamp("2018-10-12T11:37:41.474716862+0100")
         assert_transforms(dt, Structure(b"I", 1539340661, 474716862, 3600))
@@ -67,6 +85,25 @@ class TestTimeDehydration(_TestTemporalDehydrationV1):
     def test_native_date_time_fixed_negative_offset(self, assert_transforms):
         dt = datetime.datetime(2018, 10, 12, 11, 37, 41, 474716,
                                pytz.FixedOffset(-60))
+        assert_transforms(
+            dt,
+            Structure(b"I", 1539347861, 474716000, -3600)
+        )
+
+    def test_date_time_fixed_negative_native_offset(self, assert_transforms):
+        dt = DateTime(2018, 10, 12, 11, 37, 41, 474716862,
+                      datetime.timezone(datetime.timedelta(minutes=-60)))
+        assert_transforms(
+            dt,
+            Structure(b"I", 1539347861, 474716862, -3600)
+        )
+
+    def test_native_date_time_fixed_negative_native_offset(self,
+                                                           assert_transforms):
+        dt = datetime.datetime(
+            2018, 10, 12, 11, 37, 41, 474716,
+            datetime.timezone(datetime.timedelta(minutes=-60))
+        )
         assert_transforms(
             dt,
             Structure(b"I", 1539347861, 474716000, -3600)


### PR DESCRIPTION
This enables users to use python's standard `datetime.timezone` for constant utc-offset timezones (only for serialization, data coming back from the server will continue to use `pytz`).

This change also enables pandas 2 as pandas switched over to `datetime.timezone` for constant offset timezones
https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#utc-and-fixed-offset-timezones-default-to-standard-library-tzinfo-objects