### PR TITLE
ADR 015: home db caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
 
 ## NEXT RELEASE
+- To improve the performance of the driver, home database caching has been
+  introduced. Other than a speed-up, this shouldn't have an effect on most
+  use-cases.
+  *However*, if your application changes users' home databases frequently and
+  relies on the driver to pick up those changes in the next session, this will
+  be a breaking change. You can either disable home database caching by setting
+  `max_home_database_delay` to `0` to get back the old but poorly performing
+  behavior, or you can force the driver to re-resolve all home databases by
+  calling `driver.force_home_database_resolution` after changing a user's home
+  database.
 - `neo4j.auth_management.ExpiringAuth`'s `expires_in` (in preview) was replaced
   by `expires_at`, which is a unix timestamp.  
   You can use `ExpiringAuth(some_auth).expires_in(123)` instead.

--- a/docs/source/async_api.rst
+++ b/docs/source/async_api.rst
@@ -243,7 +243,11 @@ Closing a driver will immediately shut down all connections in the pool.
         :param database_:
             database to execute the query against.
 
-            None (default) uses the database configured on the server side.
+            :data:`None` (default) uses the database configured on the server
+            side.
+            Depending on the :ref:`max-home-database-delay-ref` configuration,
+            propagation of changes to the server side default might not be
+            immediate.
 
             .. Note::
                 It is recommended to always specify the database explicitly

--- a/src/neo4j/_async/driver.py
+++ b/src/neo4j/_async/driver.py
@@ -152,6 +152,7 @@ class AsyncGraphDatabase:
             notifications_disabled_categories: t.Optional[
                 t.Iterable[T_NotificationDisabledCategory]
             ] = ...,
+            max_home_database_delay: float = ...,
 
             # undocumented/unsupported options
             # they may be change or removed any time without prior notice
@@ -704,7 +705,11 @@ class AsyncDriver:
         :param database_:
             database to execute the query against.
 
-            None (default) uses the database configured on the server side.
+            :data:`None` (default) uses the database configured on the server
+            side.
+            Depending on the :ref:`max-home-database-delay-ref` configuration,
+            propagation of changes to the server side default might not be
+            immediate.
 
             .. Note::
                 It is recommended to always specify the database explicitly
@@ -1175,6 +1180,28 @@ class AsyncDriver:
     async def _get_server_info(self, **config) -> ServerInfo:
         async with self.session(**config) as session:
             return await session._get_server_info()
+
+    def force_home_database_resolution(self) -> None:
+        """Force the driver to resolve all home databases (again).
+
+        The resolution is lazy and will only happen when the driver needs to
+        know the home database.
+        In practice, this means that the driver will flush the cache
+        configured by `max_home_database_delay`.
+
+        This method is for instance useful when an application has changed a
+        user's home database, and the same application wants to pick up the
+        change in the next session while wanting to avoid setting
+        `max_home_database_delay` to `0` because of the performance penalty.
+
+        .. versionadded:: 5.x
+
+        .. seealso::
+            Driver config :ref:`max-home-database-delay-ref`
+        """
+        home_db_cache = self._pool.home_db_cache
+        if home_db_cache.enabled:
+            home_db_cache.clear()
 
 
 async def _work(

--- a/src/neo4j/_async/home_db_cache.py
+++ b/src/neo4j/_async/home_db_cache.py
@@ -1,0 +1,97 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import typing as t
+from time import monotonic
+
+from .._async_compat.concurrency import AsyncCooperativeLock
+
+
+# TAuthKey = t.Tuple[t.Tuple[]]
+TKey = t.Union[str, t.Tuple[t.Tuple[str, t.Hashable], ...], None]
+TVal = t.Tuple[float, str]
+
+
+class AsyncHomeDbCache:
+    def __init__(self, ttl: float) -> None:
+        if ttl < 0:
+            raise ValueError("max_home_database_delay cannot be negative")
+        self._enabled = ttl > 0
+        self._ttl = ttl
+        self._cache: t.Dict[TKey, TVal] = {}
+        self._lock = AsyncCooperativeLock()
+        self._last_clean = monotonic()
+
+    def compute_key(
+        self,
+        imp_user: t.Optional[str],
+        auth: t.Optional[dict],
+    ) -> TKey:
+        if not self._enabled:
+            return None
+        if imp_user is not None:
+            return imp_user
+        if auth is not None:
+            return _hashable_dict(auth)
+        return None
+
+    def get(self, key: TKey) -> t.Optional[str]:
+        with self._lock:
+            val = self._cache.get(key)
+            if val is None:
+                return None
+            now = monotonic()
+            if now - val[0] > self._ttl:
+                del self._cache[key]
+                return None
+            # Saved some time with a cache hit,
+            # so we can waste some with cleaning the cache ;)
+            self._clean(now)
+            return val[1]
+
+    def set(self, key: TKey, value: t.Optional[str]) -> None:
+        with self._lock:
+            if value is None:
+                self._cache.pop(key, None)
+            else:
+                self._cache[key] = (monotonic(), value)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._cache = {}
+            self._last_clean = monotonic()
+
+    def _clean(self, now: float) -> None:
+        if now - self._last_clean > self._ttl:
+            self._cache = {
+                k: v for
+                k, v in self._cache.items()
+                if now - v[0] < self._ttl
+            }
+            self._last_clean = now
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+
+def _hashable_dict(d: dict) -> tuple:
+    return tuple(
+        (k, _hashable_dict(v) if isinstance(v, dict) else v)
+        for k, v in sorted(d.items())
+    )

--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -26,6 +26,7 @@ from time import perf_counter
 
 from ..._async_compat.network import AsyncBoltSocket
 from ..._async_compat.util import AsyncUtil
+from ..._auth_management import to_auth_dict
 from ..._codec.hydration import v1 as hydration_v1
 from ..._codec.packstream import v1 as packstream_v1
 from ..._conf import PoolConfig
@@ -41,7 +42,6 @@ from ...api import (
     Version,
 )
 from ...exceptions import (
-    AuthError,
     ConfigurationError,
     DriverError,
     IncompleteCommit,
@@ -157,7 +157,7 @@ class AsyncBolt:
             self.user_agent = USER_AGENT
 
         self.auth = auth
-        self.auth_dict = self._to_auth_dict(auth)
+        self.auth_dict = to_auth_dict(auth)
         self.auth_manager = auth_manager
 
         self.notifications_min_severity = notifications_min_severity
@@ -171,20 +171,6 @@ class AsyncBolt:
     @abc.abstractmethod
     def _get_server_state_manager(self) -> ServerStateManagerBase:
         ...
-
-    @classmethod
-    def _to_auth_dict(cls, auth):
-        # Determine auth details
-        if not auth:
-            return {}
-        elif isinstance(auth, tuple) and 2 <= len(auth) <= 3:
-            from ...api import Auth
-            return vars(Auth("basic", *auth))
-        else:
-            try:
-                return vars(auth)
-            except (KeyError, TypeError):
-                raise AuthError("Cannot determine auth details from %r" % auth)
 
     @property
     def connection_id(self):
@@ -525,7 +511,7 @@ class AsyncBolt:
 
         :returns: whether the auth was changed
         """
-        new_auth_dict = self._to_auth_dict(auth)
+        new_auth_dict = to_auth_dict(auth)
         if not force and new_auth_dict == self.auth_dict:
             self.auth_manager = auth_manager
             self.auth = auth

--- a/src/neo4j/_async/work/workspace.py
+++ b/src/neo4j/_async/work/workspace.py
@@ -20,19 +20,29 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import typing as t
 
 from ..._async_compat.util import AsyncUtil
+from ..._auth_management import to_auth_dict
 from ..._conf import WorkspaceConfig
 from ..._meta import (
     deprecation_warn,
     unclosed_resource_warn,
 )
-from ...api import Bookmarks
+from ...api import (
+    _TAuth,
+    Bookmarks,
+)
+from ...auth_management import (
+    AsyncAuthManager,
+    AuthManager,
+)
 from ...exceptions import (
     ServiceUnavailable,
     SessionError,
     SessionExpired,
 )
+from ..home_db_cache import AsyncHomeDbCache
 from ..io import (
     AcquireAuth,
     AsyncNeo4jPool,
@@ -83,6 +93,23 @@ class AsyncWorkspace:
 
     async def __aexit__(self, exc_type, exc_value, traceback):
         await self.close()
+
+    def _make_database_callback(
+        self,
+        auth: t.Union[AsyncAuthManager, AuthManager, None]
+    ) -> t.Callable[[str], t.Awaitable[None]]:
+        async def _database_callback(database) -> None:
+            nonlocal auth
+            db_cache: AsyncHomeDbCache = self._pool.home_db_cache
+            if db_cache.enabled:
+                cache_key = db_cache.compute_key(
+                    self._config.impersonated_user,
+                    await self._resolve_session_auth(auth)
+                )
+                db_cache.set(cache_key, database)
+            self._set_cached_database(database)
+
+        return _database_callback
 
     def _set_cached_database(self, database):
         self._cached_database = True
@@ -135,10 +162,8 @@ class AsyncWorkspace:
 
     async def _connect(self, access_mode, auth=None, **acquire_kwargs):
         acquisition_timeout = self._config.connection_acquisition_timeout
-        auth = AcquireAuth(
-            auth,
-            force_auth=acquire_kwargs.pop("force_auth", False),
-        )
+        force_auth=acquire_kwargs.pop("force_auth", False)
+        acquire_auth = AcquireAuth(auth, force_auth=force_auth)
 
         if self._connection:
             # TODO: Investigate this
@@ -146,9 +171,25 @@ class AsyncWorkspace:
             await self._connection.send_all()
             await self._connection.fetch_all()
             await self._disconnect()
+        await self._fill_cached_database(acquire_auth)
+        acquire_kwargs_ = {
+            "access_mode": access_mode,
+            "timeout": acquisition_timeout,
+            "database": self._config.database,
+            "bookmarks": await self._get_bookmarks(),
+            "auth": acquire_auth,
+            "liveness_check_timeout": None,
+        }
+        acquire_kwargs_.update(acquire_kwargs)
+        self._connection = await self._pool.acquire(**acquire_kwargs_)
+        self._connection_access_mode = access_mode
+
+    async def _fill_cached_database(self, acquire_auth: AcquireAuth) -> None:
+        auth = acquire_auth.auth
+        acquisition_timeout = self._config.connection_acquisition_timeout
         if not self._cached_database:
             if (self._config.database is not None
-                    or not isinstance(self._pool, AsyncNeo4jPool)):
+                or not isinstance(self._pool, AsyncNeo4jPool)):
                 self._set_cached_database(self._config.database)
             else:
                 # This is the first time we open a connection to a server in a
@@ -157,26 +198,47 @@ class AsyncWorkspace:
                 # to try to fetch the home database. If provided by the server,
                 # we shall use this database explicitly for all subsequent
                 # actions within this session.
+                # Unless we have the resolved home db in out cache:
+
+                db_cache: AsyncHomeDbCache = self._pool.home_db_cache
+                cached_db = None
+                if db_cache.enabled:
+                    cache_key = db_cache.compute_key(
+                        self._config.impersonated_user,
+                        await self._resolve_session_auth(auth)
+                    )
+                    cached_db = db_cache.get(cache_key)
+                if cached_db is not None:
+                    log.debug("[#0000]  _: <WORKSPACE> resolved home database "
+                              f"from cache: {cached_db}")
+                    self._set_cached_database(cached_db)
+                    return
                 log.debug("[#0000]  _: <WORKSPACE> resolve home database")
                 await self._pool.update_routing_table(
                     database=self._config.database,
                     imp_user=self._config.impersonated_user,
                     bookmarks=await self._get_bookmarks(),
-                    auth=auth,
+                    auth=acquire_auth,
                     acquisition_timeout=acquisition_timeout,
-                    database_callback=self._set_cached_database
+                    database_callback=self._make_database_callback(auth),
                 )
-        acquire_kwargs_ = {
-            "access_mode": access_mode,
-            "timeout": acquisition_timeout,
-            "database": self._config.database,
-            "bookmarks": await self._get_bookmarks(),
-            "auth": auth,
-            "liveness_check_timeout": None,
-        }
-        acquire_kwargs_.update(acquire_kwargs)
-        self._connection = await self._pool.acquire(**acquire_kwargs_)
-        self._connection_access_mode = access_mode
+
+    @staticmethod
+    async def _resolve_session_auth(
+        auth: t.Union[AsyncAuthManager, AuthManager, None]
+    ) -> t.Optional[dict]:
+        if auth is None:
+            return None
+        # resolved_auth = await AsyncUtil.callback(auth.get_auth)
+        # The above line breaks mypy
+        # https://github.com/python/mypy/issues/15295
+        auth_getter: t.Callable[[], t.Union[_TAuth, t.Awaitable[_TAuth]]] = \
+            auth.get_auth
+        # so we enforce the right type here
+        # (explicit type annotation above added as it's a necessary assumption
+        #  for this cast to be correct)
+        resolved_auth = t.cast(_TAuth, await AsyncUtil.callback(auth_getter))
+        return to_auth_dict(resolved_auth)
 
     async def _disconnect(self, sync=False):
         if self._connection:

--- a/src/neo4j/_async_compat/util.py
+++ b/src/neo4j/_async_compat/util.py
@@ -59,11 +59,7 @@ class AsyncUtil:
     @staticmethod
     @t.overload
     async def callback(
-        cb: t.Union[
-            t.Callable[_P, t.Union[_T, t.Awaitable[_T]]],
-            t.Callable[_P, t.Awaitable[_T]],
-            t.Callable[_P, _T],
-        ],
+        cb: t.Callable[_P, t.Union[t.Awaitable[_T], _T]],
         *args: _P.args, **kwargs: _P.kwargs
     ) -> _T:
         ...

--- a/src/neo4j/_auth_management.py
+++ b/src/neo4j/_auth_management.py
@@ -31,7 +31,11 @@ from ._meta import (
     preview,
     PreviewWarning,
 )
-from .api import _TAuth
+from .api import (
+    _TAuth,
+    Auth,
+)
+from .exceptions import AuthError
 
 
 @preview("Auth managers are a preview feature.")
@@ -176,3 +180,20 @@ class AsyncAuthManager(metaclass=abc.ABCMeta):
         .. seealso:: :meth:`.AuthManager.on_auth_expired`
         """
         ...
+
+
+def to_auth_dict(auth: _TAuth) -> dict:
+    # Determine auth details
+    if not auth:
+        return {}
+    elif isinstance(auth, tuple) and 2 <= len(auth) <= 3:
+        return vars(Auth("basic", *auth))
+    else:
+        try:
+            return vars(auth)
+        except (KeyError, TypeError):
+            # TODO: 6.0 - this should not raise an AuthError
+            #     AuthError is reserved for the server
+            #     (inherits from Neo4jError).
+            #     Consider ValueError, TypeError or similar.
+            raise AuthError(f"Cannot determine auth details from {auth!r}")

--- a/src/neo4j/_conf.py
+++ b/src/neo4j/_conf.py
@@ -415,6 +415,9 @@ class PoolConfig(Config):
     #: List of notification categories for the server to ignore
     notifications_disabled_categories = None
 
+    #: TTL for the home database result cache in seconds
+    max_home_database_delay = 5
+
     def get_ssl_context(self):
         if self.ssl_context is not None:
             return self.ssl_context

--- a/src/neo4j/_sync/home_db_cache.py
+++ b/src/neo4j/_sync/home_db_cache.py
@@ -1,0 +1,97 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import typing as t
+from time import monotonic
+
+from .._async_compat.concurrency import CooperativeLock
+
+
+# TAuthKey = t.Tuple[t.Tuple[]]
+TKey = t.Union[str, t.Tuple[t.Tuple[str, t.Hashable], ...], None]
+TVal = t.Tuple[float, str]
+
+
+class HomeDbCache:
+    def __init__(self, ttl: float) -> None:
+        if ttl < 0:
+            raise ValueError("max_home_database_delay cannot be negative")
+        self._enabled = ttl > 0
+        self._ttl = ttl
+        self._cache: t.Dict[TKey, TVal] = {}
+        self._lock = CooperativeLock()
+        self._last_clean = monotonic()
+
+    def compute_key(
+        self,
+        imp_user: t.Optional[str],
+        auth: t.Optional[dict],
+    ) -> TKey:
+        if not self._enabled:
+            return None
+        if imp_user is not None:
+            return imp_user
+        if auth is not None:
+            return _hashable_dict(auth)
+        return None
+
+    def get(self, key: TKey) -> t.Optional[str]:
+        with self._lock:
+            val = self._cache.get(key)
+            if val is None:
+                return None
+            now = monotonic()
+            if now - val[0] > self._ttl:
+                del self._cache[key]
+                return None
+            # Saved some time with a cache hit,
+            # so we can waste some with cleaning the cache ;)
+            self._clean(now)
+            return val[1]
+
+    def set(self, key: TKey, value: t.Optional[str]) -> None:
+        with self._lock:
+            if value is None:
+                self._cache.pop(key, None)
+            else:
+                self._cache[key] = (monotonic(), value)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._cache = {}
+            self._last_clean = monotonic()
+
+    def _clean(self, now: float) -> None:
+        if now - self._last_clean > self._ttl:
+            self._cache = {
+                k: v for
+                k, v in self._cache.items()
+                if now - v[0] < self._ttl
+            }
+            self._last_clean = now
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+
+def _hashable_dict(d: dict) -> tuple:
+    return tuple(
+        (k, _hashable_dict(v) if isinstance(v, dict) else v)
+        for k, v in sorted(d.items())
+    )

--- a/src/neo4j/_sync/work/workspace.py
+++ b/src/neo4j/_sync/work/workspace.py
@@ -20,19 +20,26 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import typing as t
 
 from ..._async_compat.util import Util
+from ..._auth_management import to_auth_dict
 from ..._conf import WorkspaceConfig
 from ..._meta import (
     deprecation_warn,
     unclosed_resource_warn,
 )
-from ...api import Bookmarks
+from ...api import (
+    _TAuth,
+    Bookmarks,
+)
+from ...auth_management import AuthManager
 from ...exceptions import (
     ServiceUnavailable,
     SessionError,
     SessionExpired,
 )
+from ..home_db_cache import HomeDbCache
 from ..io import (
     AcquireAuth,
     Neo4jPool,
@@ -83,6 +90,23 @@ class Workspace:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
+
+    def _make_database_callback(
+        self,
+        auth: t.Union[AuthManager, AuthManager, None]
+    ) -> t.Callable[[str], t.Union[None]]:
+        def _database_callback(database) -> None:
+            nonlocal auth
+            db_cache: HomeDbCache = self._pool.home_db_cache
+            if db_cache.enabled:
+                cache_key = db_cache.compute_key(
+                    self._config.impersonated_user,
+                    self._resolve_session_auth(auth)
+                )
+                db_cache.set(cache_key, database)
+            self._set_cached_database(database)
+
+        return _database_callback
 
     def _set_cached_database(self, database):
         self._cached_database = True
@@ -135,10 +159,8 @@ class Workspace:
 
     def _connect(self, access_mode, auth=None, **acquire_kwargs):
         acquisition_timeout = self._config.connection_acquisition_timeout
-        auth = AcquireAuth(
-            auth,
-            force_auth=acquire_kwargs.pop("force_auth", False),
-        )
+        force_auth=acquire_kwargs.pop("force_auth", False)
+        acquire_auth = AcquireAuth(auth, force_auth=force_auth)
 
         if self._connection:
             # TODO: Investigate this
@@ -146,9 +168,25 @@ class Workspace:
             self._connection.send_all()
             self._connection.fetch_all()
             self._disconnect()
+        self._fill_cached_database(acquire_auth)
+        acquire_kwargs_ = {
+            "access_mode": access_mode,
+            "timeout": acquisition_timeout,
+            "database": self._config.database,
+            "bookmarks": self._get_bookmarks(),
+            "auth": acquire_auth,
+            "liveness_check_timeout": None,
+        }
+        acquire_kwargs_.update(acquire_kwargs)
+        self._connection = self._pool.acquire(**acquire_kwargs_)
+        self._connection_access_mode = access_mode
+
+    def _fill_cached_database(self, acquire_auth: AcquireAuth) -> None:
+        auth = acquire_auth.auth
+        acquisition_timeout = self._config.connection_acquisition_timeout
         if not self._cached_database:
             if (self._config.database is not None
-                    or not isinstance(self._pool, Neo4jPool)):
+                or not isinstance(self._pool, Neo4jPool)):
                 self._set_cached_database(self._config.database)
             else:
                 # This is the first time we open a connection to a server in a
@@ -157,26 +195,47 @@ class Workspace:
                 # to try to fetch the home database. If provided by the server,
                 # we shall use this database explicitly for all subsequent
                 # actions within this session.
+                # Unless we have the resolved home db in out cache:
+
+                db_cache: HomeDbCache = self._pool.home_db_cache
+                cached_db = None
+                if db_cache.enabled:
+                    cache_key = db_cache.compute_key(
+                        self._config.impersonated_user,
+                        self._resolve_session_auth(auth)
+                    )
+                    cached_db = db_cache.get(cache_key)
+                if cached_db is not None:
+                    log.debug("[#0000]  _: <WORKSPACE> resolved home database "
+                              f"from cache: {cached_db}")
+                    self._set_cached_database(cached_db)
+                    return
                 log.debug("[#0000]  _: <WORKSPACE> resolve home database")
                 self._pool.update_routing_table(
                     database=self._config.database,
                     imp_user=self._config.impersonated_user,
                     bookmarks=self._get_bookmarks(),
-                    auth=auth,
+                    auth=acquire_auth,
                     acquisition_timeout=acquisition_timeout,
-                    database_callback=self._set_cached_database
+                    database_callback=self._make_database_callback(auth),
                 )
-        acquire_kwargs_ = {
-            "access_mode": access_mode,
-            "timeout": acquisition_timeout,
-            "database": self._config.database,
-            "bookmarks": self._get_bookmarks(),
-            "auth": auth,
-            "liveness_check_timeout": None,
-        }
-        acquire_kwargs_.update(acquire_kwargs)
-        self._connection = self._pool.acquire(**acquire_kwargs_)
-        self._connection_access_mode = access_mode
+
+    @staticmethod
+    def _resolve_session_auth(
+        auth: t.Union[AuthManager, AuthManager, None]
+    ) -> t.Optional[dict]:
+        if auth is None:
+            return None
+        # resolved_auth = await AsyncUtil.callback(auth.get_auth)
+        # The above line breaks mypy
+        # https://github.com/python/mypy/issues/15295
+        auth_getter: t.Callable[[], t.Union[_TAuth, t.Union[_TAuth]]] = \
+            auth.get_auth
+        # so we enforce the right type here
+        # (explicit type annotation above added as it's a necessary assumption
+        #  for this cast to be correct)
+        resolved_auth = t.cast(_TAuth, Util.callback(auth_getter))
+        return to_auth_dict(resolved_auth)
 
     def _disconnect(self, sync=False):
         if self._connection:

--- a/testkitbackend/_async/requests.py
+++ b/testkitbackend/_async/requests.py
@@ -125,6 +125,7 @@ async def NewDriver(backend, data):
         ("connectionTimeoutMs", "connection_timeout"),
         ("maxTxRetryTimeMs", "max_transaction_retry_time"),
         ("connectionAcquisitionTimeoutMs", "connection_acquisition_timeout"),
+        ("maxHomeDatabaseDelayMs", "max_home_database_delay"),
     ):
         if data.get(timeout_testkit) is not None:
             kwargs[timeout_driver] = data[timeout_testkit] / 1000
@@ -327,6 +328,13 @@ async def CheckSessionAuthSupport(backend, data):
     await backend.send_response("SessionAuthSupport", {
         "id": backend.next_key(), "available": available
     })
+
+
+async def ForceHomeDatabaseResolution(backend, data):
+    driver_id = data["driverId"]
+    driver = backend.drivers[driver_id]
+    driver.force_home_database_resolution()
+    await backend.send_response("Driver", {"id": driver_id})
 
 
 async def ExecuteQuery(backend, data):

--- a/testkitbackend/_sync/requests.py
+++ b/testkitbackend/_sync/requests.py
@@ -125,6 +125,7 @@ def NewDriver(backend, data):
         ("connectionTimeoutMs", "connection_timeout"),
         ("maxTxRetryTimeMs", "max_transaction_retry_time"),
         ("connectionAcquisitionTimeoutMs", "connection_acquisition_timeout"),
+        ("maxHomeDatabaseDelayMs", "max_home_database_delay"),
     ):
         if data.get(timeout_testkit) is not None:
             kwargs[timeout_driver] = data[timeout_testkit] / 1000
@@ -327,6 +328,13 @@ def CheckSessionAuthSupport(backend, data):
     backend.send_response("SessionAuthSupport", {
         "id": backend.next_key(), "available": available
     })
+
+
+def ForceHomeDatabaseResolution(backend, data):
+    driver_id = data["driverId"]
+    driver = backend.drivers[driver_id]
+    driver.force_home_database_resolution()
+    backend.send_response("Driver", {"id": driver_id})
 
 
 def ExecuteQuery(backend, data):

--- a/testkitbackend/test_config.json
+++ b/testkitbackend/test_config.json
@@ -51,6 +51,7 @@
     "Feature:Bolt:5.3": true,
     "Feature:Bolt:Patch:UTC": true,
     "Feature:Impersonation": true,
+    "Feature:HomeDbCache": true,
     "Feature:TLS:1.1": "Driver blocks TLS 1.1 for security reasons.",
     "Feature:TLS:1.2": true,
     "Feature:TLS:1.3": "Depends on the machine (will be calculated dynamically).",


### PR DESCRIPTION
Add `max_home_database_delay` config option to the driver. Defines an upper bound for how long (in seconds) a resolved home database can be cached. It defaults to `5.0` seconds.

This should improve performance by reducing the extra round trips needed for resolving the home database. However, this also means that home database changes might become visible later in the driver than they used to. There are different options how to tackle this, should this be a problem.

1. Reduce the value of `max_home_database_delay`. This can go as far to to set it to `0` effectively restoring the driver's behavior before this change. However, extrem values are likely to incur a significant performance penalty (driver and server side).
2. Call the new `driver.force_home_database_resolution()` to make the driver forget any cached home dbs. This is especially useful after a home database change has been issued and needs to be readable from the same application directly afterwards.

Depends on
 * https://github.com/neo4j-drivers/testkit/pull/569

Should be ported back to 4.4