### PR TITLE
Fix handling of sub-ms transaction timeouts

### DIFF
--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -947,3 +947,32 @@ class AsyncBolt:
 
 
 AsyncBoltSocket.Bolt = AsyncBolt  # type: ignore
+
+
+def tx_timeout_as_ms(timeout: float) -> int:
+    """Round transaction timeout to milliseconds.
+
+    Values in (0, 1], else values are rounded using the built-in round()
+    function (round n.5 values to nearest even).
+
+    :param timeout: timeout in seconds (must be >= 0)
+
+    :returns: timeout in milliseconds (rounded)
+
+    :raise ValueError: if timeout is negative
+    """
+    try:
+        timeout = float(timeout)
+    except (TypeError, ValueError) as e:
+        err_type = type(e)
+        msg = "Timeout must be specified as a number of seconds"
+        raise err_type(msg) from None
+    if timeout < 0:
+        raise ValueError("Timeout must be a positive number or 0.")
+    ms = int(round(1000 * timeout))
+    if ms == 0 and timeout > 0:
+        # Special case for 0 < timeout < 0.5 ms.
+        # This would be rounded to 0 ms, but the server interprets this as
+        # infinite timeout. So we round to the smallest possible timeout: 1 ms.
+        ms = 1
+    return ms

--- a/src/neo4j/_async/io/_bolt3.py
+++ b/src/neo4j/_async/io/_bolt3.py
@@ -39,6 +39,7 @@ from ...exceptions import (
 from ._bolt import (
     AsyncBolt,
     ServerStateManagerBase,
+    tx_timeout_as_ms,
 )
 from ._common import (
     check_supported_server_product,
@@ -262,12 +263,7 @@ class AsyncBolt3(AsyncBolt):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be specified as a number of seconds")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a positive number or 0.")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port, " ".join(map(repr, fields)))
         self._append(b"\x10", fields,
@@ -327,12 +323,7 @@ class AsyncBolt3(AsyncBolt):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be specified as a number of seconds")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a positive number or 0.")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,),
                      Response(self, "begin", hydration_hooks, **handlers),

--- a/src/neo4j/_async/io/_bolt4.py
+++ b/src/neo4j/_async/io/_bolt4.py
@@ -36,6 +36,7 @@ from ...exceptions import (
 from ._bolt import (
     AsyncBolt,
     ServerStateManagerBase,
+    tx_timeout_as_ms,
 )
 from ._bolt3 import (
     ServerStateManager,
@@ -212,12 +213,7 @@ class AsyncBolt4x0(AsyncBolt):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be specified as a number of seconds")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a positive number or 0.")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port, " ".join(map(repr, fields)))
         self._append(b"\x10", fields,
@@ -276,12 +272,7 @@ class AsyncBolt4x0(AsyncBolt):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be specified as a number of seconds")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a positive number or 0.")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,),
                      Response(self, "begin", hydration_hooks, **handlers),
@@ -555,12 +546,7 @@ class AsyncBolt4x4(AsyncBolt4x3):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be specified as a number of seconds")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a positive number or 0.")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port,
                   " ".join(map(repr, fields)))
@@ -596,12 +582,7 @@ class AsyncBolt4x4(AsyncBolt4x3):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be specified as a number of seconds")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a positive number or 0.")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,),
                      Response(self, "begin", hydration_hooks, **handlers),

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -38,6 +38,7 @@ from ...exceptions import (
 from ._bolt import (
     AsyncBolt,
     ServerStateManagerBase,
+    tx_timeout_as_ms,
 )
 from ._bolt3 import (
     ServerStateManager,
@@ -209,12 +210,7 @@ class AsyncBolt5x0(AsyncBolt):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be a number (in seconds)")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a number >= 0")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port,
                   " ".join(map(repr, fields)))
@@ -270,12 +266,7 @@ class AsyncBolt5x0(AsyncBolt):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be a number (in seconds)")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a number >= 0")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,),
                      Response(self, "begin", hydration_hooks, **handlers),
@@ -567,12 +558,7 @@ class AsyncBolt5x2(AsyncBolt5x1):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be a number (in seconds)")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a number >= 0")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port,
                   " ".join(map(repr, fields)))
@@ -603,12 +589,7 @@ class AsyncBolt5x2(AsyncBolt5x1):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be a number (in seconds)")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a number >= 0")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         if notifications_min_severity is not None:
             extra["notifications_minimum_severity"] = \
                 notifications_min_severity

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -947,3 +947,32 @@ class Bolt:
 
 
 BoltSocket.Bolt = Bolt  # type: ignore
+
+
+def tx_timeout_as_ms(timeout: float) -> int:
+    """Round transaction timeout to milliseconds.
+
+    Values in (0, 1], else values are rounded using the built-in round()
+    function (round n.5 values to nearest even).
+
+    :param timeout: timeout in seconds (must be >= 0)
+
+    :returns: timeout in milliseconds (rounded)
+
+    :raise ValueError: if timeout is negative
+    """
+    try:
+        timeout = float(timeout)
+    except (TypeError, ValueError) as e:
+        err_type = type(e)
+        msg = "Timeout must be specified as a number of seconds"
+        raise err_type(msg) from None
+    if timeout < 0:
+        raise ValueError("Timeout must be a positive number or 0.")
+    ms = int(round(1000 * timeout))
+    if ms == 0 and timeout > 0:
+        # Special case for 0 < timeout < 0.5 ms.
+        # This would be rounded to 0 ms, but the server interprets this as
+        # infinite timeout. So we round to the smallest possible timeout: 1 ms.
+        ms = 1
+    return ms

--- a/src/neo4j/_sync/io/_bolt3.py
+++ b/src/neo4j/_sync/io/_bolt3.py
@@ -39,6 +39,7 @@ from ...exceptions import (
 from ._bolt import (
     Bolt,
     ServerStateManagerBase,
+    tx_timeout_as_ms,
 )
 from ._common import (
     check_supported_server_product,
@@ -262,12 +263,7 @@ class Bolt3(Bolt):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be specified as a number of seconds")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a positive number or 0.")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port, " ".join(map(repr, fields)))
         self._append(b"\x10", fields,
@@ -327,12 +323,7 @@ class Bolt3(Bolt):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be specified as a number of seconds")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a positive number or 0.")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,),
                      Response(self, "begin", hydration_hooks, **handlers),

--- a/src/neo4j/_sync/io/_bolt4.py
+++ b/src/neo4j/_sync/io/_bolt4.py
@@ -36,6 +36,7 @@ from ...exceptions import (
 from ._bolt import (
     Bolt,
     ServerStateManagerBase,
+    tx_timeout_as_ms,
 )
 from ._bolt3 import (
     ServerStateManager,
@@ -212,12 +213,7 @@ class Bolt4x0(Bolt):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be specified as a number of seconds")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a positive number or 0.")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port, " ".join(map(repr, fields)))
         self._append(b"\x10", fields,
@@ -276,12 +272,7 @@ class Bolt4x0(Bolt):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be specified as a number of seconds")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a positive number or 0.")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,),
                      Response(self, "begin", hydration_hooks, **handlers),
@@ -555,12 +546,7 @@ class Bolt4x4(Bolt4x3):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be specified as a number of seconds")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a positive number or 0.")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port,
                   " ".join(map(repr, fields)))
@@ -596,12 +582,7 @@ class Bolt4x4(Bolt4x3):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be specified as a number of seconds")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a positive number or 0.")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,),
                      Response(self, "begin", hydration_hooks, **handlers),

--- a/src/neo4j/_sync/io/_bolt5.py
+++ b/src/neo4j/_sync/io/_bolt5.py
@@ -38,6 +38,7 @@ from ...exceptions import (
 from ._bolt import (
     Bolt,
     ServerStateManagerBase,
+    tx_timeout_as_ms,
 )
 from ._bolt3 import (
     ServerStateManager,
@@ -209,12 +210,7 @@ class Bolt5x0(Bolt):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be a number (in seconds)")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a number >= 0")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port,
                   " ".join(map(repr, fields)))
@@ -270,12 +266,7 @@ class Bolt5x0(Bolt):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be a number (in seconds)")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a number >= 0")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         log.debug("[#%04X]  C: BEGIN %r", self.local_port, extra)
         self._append(b"\x11", (extra,),
                      Response(self, "begin", hydration_hooks, **handlers),
@@ -567,12 +558,7 @@ class Bolt5x2(Bolt5x1):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be a number (in seconds)")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a number >= 0")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         fields = (query, parameters, extra)
         log.debug("[#%04X]  C: RUN %s", self.local_port,
                   " ".join(map(repr, fields)))
@@ -603,12 +589,7 @@ class Bolt5x2(Bolt5x1):
             except TypeError:
                 raise TypeError("Metadata must be coercible to a dict")
         if timeout is not None:
-            try:
-                extra["tx_timeout"] = int(1000 * float(timeout))
-            except TypeError:
-                raise TypeError("Timeout must be a number (in seconds)")
-            if extra["tx_timeout"] < 0:
-                raise ValueError("Timeout must be a number >= 0")
+            extra["tx_timeout"] = tx_timeout_as_ms(timeout)
         if notifications_min_severity is not None:
             extra["notifications_minimum_severity"] = \
                 notifications_min_severity

--- a/tests/unit/async_/io/test_class_bolt3.py
+++ b/tests/unit/async_/io/test_class_bolt3.py
@@ -324,6 +324,10 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/async_/io/test_class_bolt3.py
+++ b/tests/unit/async_/io/test_class_bolt3.py
@@ -297,3 +297,61 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = await sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_async_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+async def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=AsyncBolt3.PACKER_CLS,
+                               unpacker_cls=AsyncBolt3.UNPACKER_CLS)
+    await sockets.server.send_message(b"\x70", {})
+    connection = AsyncBolt3(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        await connection.send_all()
+        tag, fields = await sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/async_/io/test_class_bolt4x0.py
+++ b/tests/unit/async_/io/test_class_bolt4x0.py
@@ -393,3 +393,61 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = await sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_async_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+async def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=AsyncBolt4x0.PACKER_CLS,
+                               unpacker_cls=AsyncBolt4x0.UNPACKER_CLS)
+    await sockets.server.send_message(b"\x70", {})
+    connection = AsyncBolt4x0(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        await connection.send_all()
+        tag, fields = await sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/async_/io/test_class_bolt4x0.py
+++ b/tests/unit/async_/io/test_class_bolt4x0.py
@@ -420,6 +420,10 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/async_/io/test_class_bolt4x1.py
+++ b/tests/unit/async_/io/test_class_bolt4x1.py
@@ -410,3 +410,61 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = await sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_async_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+async def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=AsyncBolt4x1.PACKER_CLS,
+                               unpacker_cls=AsyncBolt4x1.UNPACKER_CLS)
+    await sockets.server.send_message(b"\x70", {})
+    connection = AsyncBolt4x1(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        await connection.send_all()
+        tag, fields = await sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/async_/io/test_class_bolt4x1.py
+++ b/tests/unit/async_/io/test_class_bolt4x1.py
@@ -437,6 +437,10 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/async_/io/test_class_bolt4x2.py
+++ b/tests/unit/async_/io/test_class_bolt4x2.py
@@ -411,3 +411,61 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = await sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_async_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+async def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=AsyncBolt4x2.PACKER_CLS,
+                               unpacker_cls=AsyncBolt4x2.UNPACKER_CLS)
+    await sockets.server.send_message(b"\x70", {})
+    connection = AsyncBolt4x2(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        await connection.send_all()
+        tag, fields = await sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/async_/io/test_class_bolt4x2.py
+++ b/tests/unit/async_/io/test_class_bolt4x2.py
@@ -438,6 +438,10 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/async_/io/test_class_bolt4x3.py
+++ b/tests/unit/async_/io/test_class_bolt4x3.py
@@ -465,6 +465,10 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/async_/io/test_class_bolt4x3.py
+++ b/tests/unit/async_/io/test_class_bolt4x3.py
@@ -438,3 +438,61 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = await sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_async_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+async def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=AsyncBolt4x3.PACKER_CLS,
+                               unpacker_cls=AsyncBolt4x3.UNPACKER_CLS)
+    await sockets.server.send_message(b"\x70", {})
+    connection = AsyncBolt4x3(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        await connection.send_all()
+        tag, fields = await sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/async_/io/test_class_bolt4x4.py
+++ b/tests/unit/async_/io/test_class_bolt4x4.py
@@ -451,3 +451,61 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = await sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_async_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+async def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=AsyncBolt4x4.PACKER_CLS,
+                               unpacker_cls=AsyncBolt4x4.UNPACKER_CLS)
+    await sockets.server.send_message(b"\x70", {})
+    connection = AsyncBolt4x4(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        await connection.send_all()
+        tag, fields = await sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/async_/io/test_class_bolt4x4.py
+++ b/tests/unit/async_/io/test_class_bolt4x4.py
@@ -478,6 +478,10 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/async_/io/test_class_bolt5x0.py
+++ b/tests/unit/async_/io/test_class_bolt5x0.py
@@ -478,6 +478,10 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/async_/io/test_class_bolt5x0.py
+++ b/tests/unit/async_/io/test_class_bolt5x0.py
@@ -451,3 +451,61 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = await sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_async_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+async def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=AsyncBolt5x0.PACKER_CLS,
+                               unpacker_cls=AsyncBolt5x0.UNPACKER_CLS)
+    await sockets.server.send_message(b"\x70", {})
+    connection = AsyncBolt5x0(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        await connection.send_all()
+        tag, fields = await sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/async_/io/test_class_bolt5x1.py
+++ b/tests/unit/async_/io/test_class_bolt5x1.py
@@ -532,6 +532,10 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/async_/io/test_class_bolt5x1.py
+++ b/tests/unit/async_/io/test_class_bolt5x1.py
@@ -505,3 +505,61 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = await sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_async_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+async def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=AsyncBolt5x1.PACKER_CLS,
+                               unpacker_cls=AsyncBolt5x1.UNPACKER_CLS)
+    await sockets.server.send_message(b"\x70", {})
+    connection = AsyncBolt5x1(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        await connection.send_all()
+        tag, fields = await sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/async_/io/test_class_bolt5x2.py
+++ b/tests/unit/async_/io/test_class_bolt5x2.py
@@ -523,3 +523,61 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = await sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_async_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+async def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=AsyncBolt5x2.PACKER_CLS,
+                               unpacker_cls=AsyncBolt5x2.UNPACKER_CLS)
+    await sockets.server.send_message(b"\x70", {})
+    connection = AsyncBolt5x2(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        await connection.send_all()
+        tag, fields = await sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/async_/io/test_class_bolt5x2.py
+++ b/tests/unit/async_/io/test_class_bolt5x2.py
@@ -550,6 +550,10 @@ async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/async_/io/test_class_bolt5x3.py
+++ b/tests/unit/async_/io/test_class_bolt5x3.py
@@ -461,6 +461,10 @@ async def test_sends_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/async_/io/test_class_bolt5x3.py
+++ b/tests/unit/async_/io/test_class_bolt5x3.py
@@ -434,3 +434,61 @@ async def test_sends_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = await sockets.server.pop_message()
     extra = fields[0]
     assert extra["bolt_agent"] == BOLT_AGENT_DICT
+
+
+@mark_async_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+async def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=AsyncBolt5x3.PACKER_CLS,
+                               unpacker_cls=AsyncBolt5x3.UNPACKER_CLS)
+    await sockets.server.send_message(b"\x70", {})
+    connection = AsyncBolt5x3(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        await connection.send_all()
+        tag, fields = await sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/sync/io/test_class_bolt3.py
+++ b/tests/unit/sync/io/test_class_bolt3.py
@@ -324,6 +324,10 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/sync/io/test_class_bolt3.py
+++ b/tests/unit/sync/io/test_class_bolt3.py
@@ -297,3 +297,61 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_sync_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=Bolt3.PACKER_CLS,
+                               unpacker_cls=Bolt3.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt3(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        connection.send_all()
+        tag, fields = sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/sync/io/test_class_bolt4x0.py
+++ b/tests/unit/sync/io/test_class_bolt4x0.py
@@ -420,6 +420,10 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/sync/io/test_class_bolt4x0.py
+++ b/tests/unit/sync/io/test_class_bolt4x0.py
@@ -393,3 +393,61 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_sync_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=Bolt4x0.PACKER_CLS,
+                               unpacker_cls=Bolt4x0.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt4x0(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        connection.send_all()
+        tag, fields = sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/sync/io/test_class_bolt4x1.py
+++ b/tests/unit/sync/io/test_class_bolt4x1.py
@@ -437,6 +437,10 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/sync/io/test_class_bolt4x1.py
+++ b/tests/unit/sync/io/test_class_bolt4x1.py
@@ -410,3 +410,61 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_sync_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=Bolt4x1.PACKER_CLS,
+                               unpacker_cls=Bolt4x1.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt4x1(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        connection.send_all()
+        tag, fields = sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/sync/io/test_class_bolt4x2.py
+++ b/tests/unit/sync/io/test_class_bolt4x2.py
@@ -438,6 +438,10 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/sync/io/test_class_bolt4x2.py
+++ b/tests/unit/sync/io/test_class_bolt4x2.py
@@ -411,3 +411,61 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_sync_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=Bolt4x2.PACKER_CLS,
+                               unpacker_cls=Bolt4x2.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt4x2(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        connection.send_all()
+        tag, fields = sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/sync/io/test_class_bolt4x3.py
+++ b/tests/unit/sync/io/test_class_bolt4x3.py
@@ -438,3 +438,61 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_sync_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=Bolt4x3.PACKER_CLS,
+                               unpacker_cls=Bolt4x3.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt4x3(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        connection.send_all()
+        tag, fields = sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/sync/io/test_class_bolt4x3.py
+++ b/tests/unit/sync/io/test_class_bolt4x3.py
@@ -465,6 +465,10 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/sync/io/test_class_bolt4x4.py
+++ b/tests/unit/sync/io/test_class_bolt4x4.py
@@ -451,3 +451,61 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_sync_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=Bolt4x4.PACKER_CLS,
+                               unpacker_cls=Bolt4x4.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt4x4(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        connection.send_all()
+        tag, fields = sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/sync/io/test_class_bolt4x4.py
+++ b/tests/unit/sync/io/test_class_bolt4x4.py
@@ -478,6 +478,10 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/sync/io/test_class_bolt5x0.py
+++ b/tests/unit/sync/io/test_class_bolt5x0.py
@@ -451,3 +451,61 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_sync_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=Bolt5x0.PACKER_CLS,
+                               unpacker_cls=Bolt5x0.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt5x0(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        connection.send_all()
+        tag, fields = sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/sync/io/test_class_bolt5x0.py
+++ b/tests/unit/sync/io/test_class_bolt5x0.py
@@ -478,6 +478,10 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/sync/io/test_class_bolt5x1.py
+++ b/tests/unit/sync/io/test_class_bolt5x1.py
@@ -532,6 +532,10 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/sync/io/test_class_bolt5x1.py
+++ b/tests/unit/sync/io/test_class_bolt5x1.py
@@ -505,3 +505,61 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_sync_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=Bolt5x1.PACKER_CLS,
+                               unpacker_cls=Bolt5x1.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt5x1(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        connection.send_all()
+        tag, fields = sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/sync/io/test_class_bolt5x2.py
+++ b/tests/unit/sync/io/test_class_bolt5x2.py
@@ -550,6 +550,10 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/sync/io/test_class_bolt5x2.py
+++ b/tests/unit/sync/io/test_class_bolt5x2.py
@@ -523,3 +523,61 @@ def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = sockets.server.pop_message()
     extra = fields[0]
     assert "bolt_agent" not in extra
+
+
+@mark_sync_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=Bolt5x2.PACKER_CLS,
+                               unpacker_cls=Bolt5x2.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt5x2(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        connection.send_all()
+        tag, fields = sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res

--- a/tests/unit/sync/io/test_class_bolt5x3.py
+++ b/tests/unit/sync/io/test_class_bolt5x3.py
@@ -461,6 +461,10 @@ def test_sends_bolt_agent(fake_socket_pair, user_agent):
         (3.456, 3456),
         (1, 1000),
         (
+            -1e-15,
+            ValueError("Timeout must be a positive number or 0")
+        ),
+        (
             "foo",
             ValueError("Timeout must be specified as a number of seconds")
         ),

--- a/tests/unit/sync/io/test_class_bolt5x3.py
+++ b/tests/unit/sync/io/test_class_bolt5x3.py
@@ -434,3 +434,61 @@ def test_sends_bolt_agent(fake_socket_pair, user_agent):
     tag, fields = sockets.server.pop_message()
     extra = fields[0]
     assert extra["bolt_agent"] == BOLT_AGENT_DICT
+
+
+@mark_sync_test
+@pytest.mark.parametrize(
+    ("func", "args", "extra_idx"),
+    (
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
+    )
+)
+@pytest.mark.parametrize(
+    ("timeout", "res"),
+    (
+        (None, None),
+        (0, 0),
+        (0.1, 100),
+        (0.001, 1),
+        (1e-15, 1),
+        (0.0005, 1),
+        (0.0001, 1),
+        (1.0015, 1002),
+        (1.000499, 1000),
+        (1.0025, 1002),
+        (3.0005, 3000),
+        (3.456, 3456),
+        (1, 1000),
+        (
+            "foo",
+            ValueError("Timeout must be specified as a number of seconds")
+        ),
+        (
+            [1, 2],
+            TypeError("Timeout must be specified as a number of seconds")
+        )
+    )
+)
+def test_tx_timeout(
+    fake_socket_pair, func, args, extra_idx, timeout, res
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address,
+                               packer_cls=Bolt5x3.PACKER_CLS,
+                               unpacker_cls=Bolt5x3.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt5x3(address, sockets.client, 0)
+    func = getattr(connection, func)
+    if isinstance(res, Exception):
+        with pytest.raises(type(res), match=str(res)):
+            func(*args, timeout=timeout)
+    else:
+        func(*args, timeout=timeout)
+        connection.send_all()
+        tag, fields = sockets.server.pop_message()
+        extra = fields[extra_idx]
+        if timeout is None:
+            assert "tx_timeout" not in extra
+        else:
+            assert extra["tx_timeout"] == res


### PR DESCRIPTION
Transaction timeouts are specified in seconds as float. However, the server expects it in milliseconds as int. This would lead to
 1) rounding issues: previously, the driver would multiply by 1000 and
    then truncate to int. E.g., 256.4 seconds would be turned into 256399 ms
    because of float imprecision.
    Therefore, the built-in `round` is now used instead.
 2) values below 1 ms (e.g., 0.0001) would be rounded down to 0. However, 0 is
    a special value that instructs the server to not apply any timeout. This
    is likely to surprise the user which specified a non-zero timeout. In this
    special case, the driver now rounds up to 1 ms.