### PR TITLE
AsyncRLock: don't swallow Lock.acquire errors

### DIFF
--- a/src/neo4j/_async_compat/concurrency.py
+++ b/src/neo4j/_async_compat/concurrency.py
@@ -100,10 +100,14 @@ class AsyncRLock(asyncio.Lock):
             # Hence, we flag this task as cancelled again, so that the next
             # `await` will raise the CancelledError.
             asyncio.current_task().cancel()
-        if task.done() and task.exception() is None:
-            self._owner = me
-            self._count = 1
-            return True
+        if task.done():
+            exception = task.exception()
+            if exception is None:
+                self._owner = me
+                self._count = 1
+                return True
+            else:
+                raise exception
         task.cancel()
         return False
 


### PR DESCRIPTION
This PR addresses point 2 ("Missing error handling in `_acquire_non_blocking`") raised in https://github.com/neo4j/neo4j-python-driver/issues/937.

It's not clear if or when `asyncio.Lock.acquire()` would raise an exception. But should it, our wrapping AsyncRLock should not silently swallow it and worse pretend the lock was successfully acquired.