### PR TITLE
Improve logging helper `neo4j.debug.watch()`

### DIFF
--- a/src/neo4j/debug.py
+++ b/src/neo4j/debug.py
@@ -166,12 +166,14 @@ class Watcher:
         self.stop()
         handler = StreamHandler(out)
         handler.setFormatter(self.formatter)
+        handler.setLevel(level)
         if self._task_info:
             handler.addFilter(TaskIdFilter())
         for logger in self. _loggers:
             self._handlers[logger.name] = handler
             logger.addHandler(handler)
-            logger.setLevel(level)
+            if logger.getEffectiveLevel() > level:
+                logger.setLevel(level)
 
     def stop(self) -> None:
         """Disable logging for all loggers."""


### PR DESCRIPTION
The helper did not handle logging level correctly. For example

```
neo4j.debug.watch("neo4j", out=sys.stdout)
neo4j.debug.watch("neo4j", out=sys.stderr, level=logging.WARNING)
```

would've caused the logging level of the "neo4j" logger to end up being `WARNING` even though the first call (implicitly) requested `DEBUG`.

The fix will make sure to set the logger's level to the most verbose requested level and use a level filter on the Handlers registered for each call to filter on the level accordingly.