### PR TITLE
[4.4] Fix missing lock acquisition in pool

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -1334,10 +1334,11 @@ class Neo4jPool(IOPool):
         log.debug("[#0000]  C: <ROUTING> Deactivating address %r", address)
         # We use `discard` instead of `remove` here since the former
         # will not fail if the address has already been removed.
-        for database in self.routing_tables.keys():
-            self.routing_tables[database].routers.discard(address)
-            self.routing_tables[database].readers.discard(address)
-            self.routing_tables[database].writers.discard(address)
+        with self.refresh_lock:
+            for database in self.routing_tables.keys():
+                self.routing_tables[database].routers.discard(address)
+                self.routing_tables[database].readers.discard(address)
+                self.routing_tables[database].writers.discard(address)
         log.debug("[#0000]  C: <ROUTING> table=%r", self.routing_tables)
         super(Neo4jPool, self).deactivate(address)
 
@@ -1345,8 +1346,9 @@ class Neo4jPool(IOPool):
         """ Remove a writer address from the routing table, if present.
         """
         log.debug("[#0000]  C: <ROUTING> Removing writer %r", address)
-        for database in self.routing_tables.keys():
-            self.routing_tables[database].writers.discard(address)
+        with self.refresh_lock:
+            for database in self.routing_tables.keys():
+                self.routing_tables[database].writers.discard(address)
         log.debug("[#0000]  C: <ROUTING> table=%r", self.routing_tables)
 
 


### PR DESCRIPTION
Fix some functions in the pool manipulating the routing information without holding the right lock.

Backport of https://github.com/neo4j/neo4j-python-driver/pull/952

Blocked by:
 * https://github.com/neo4j/neo4j-python-driver/pull/954