### PR TITLE
[4.4] Reduce scope of pip warnings as errors

### DIFF
--- a/testkit/_common.py
+++ b/testkit/_common.py
@@ -13,5 +13,9 @@ def run(args, env=None):
     )
 
 
-def run_python(args, env=None):
-    run([TEST_BACKEND_VERSION, "-u", "-W", "error", *args], env=env)
+def run_python(args, env=None, warning_as_error=True):
+    cmd = [TEST_BACKEND_VERSION, "-u"]
+    if warning_as_error:
+        cmd += ["-W", "error"]
+    cmd += list(args)
+    run(cmd, env=env)

--- a/testkit/build.py
+++ b/testkit/build.py
@@ -9,6 +9,8 @@ from _common import run_python
 
 if __name__ == "__main__":
     run_python(["setup.py", "build"])
-    run_python(["-m", "pip", "install", "-U", "pip"])
-    run_python(["-m", "pip", "install", "-Ur",
-                "testkitbackend/requirements.txt"])
+    run_python(["-m", "pip", "install", "-U", "pip"], warning_as_error=False)
+    run_python(
+        ["-m", "pip", "install", "-Ur", "testkitbackend/requirements.txt"],
+        warning_as_error=False
+    )


### PR DESCRIPTION
The CI has been failing too often recently because of changes in pip and
dependencies. Those failures were mostly irrelevant warning that we turned into
errors for better visibility. However, so far there was never any action we
needed to take other than muting that warning on or the other way.

Therefore, this commit changes it so that all pip installation calls are run
without treating warnings as error.

Backport of https://github.com/neo4j/neo4j-python-driver/pull/947