### PR TITLE
ADR 019: revamp auth managers

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1838,9 +1838,6 @@ Server-side errors
 .. autoexception:: neo4j.exceptions.TokenExpired()
     :show-inheritance:
 
-.. autoexception:: neo4j.exceptions.TokenExpiredRetryable()
-    :show-inheritance:
-
 .. autoexception:: neo4j.exceptions.Forbidden()
     :show-inheritance:
 

--- a/src/neo4j/_async/auth_management.py
+++ b/src/neo4j/_async/auth_management.py
@@ -61,7 +61,7 @@ class AsyncStaticAuthManager(AsyncAuthManager):
         return False
 
 
-class Neo4jAuthTokenManager(AsyncAuthManager):
+class AsyncNeo4jAuthTokenManager(AsyncAuthManager):
     _current_auth: t.Optional[ExpiringAuth]
     _provider: t.Callable[[], t.Awaitable[ExpiringAuth]]
     _handled_codes: t.FrozenSet[str]
@@ -217,7 +217,7 @@ class AsyncAuthManagers:
                                         category=PreviewWarning)
                 return ExpiringAuth(await provider())
 
-        return Neo4jAuthTokenManager(wrapped_provider, handled_codes)
+        return AsyncNeo4jAuthTokenManager(wrapped_provider, handled_codes)
 
     @staticmethod
     @preview("Auth managers are a preview feature.")
@@ -282,4 +282,4 @@ class AsyncAuthManagers:
             "Neo.ClientError.Security.TokenExpired",
             "Neo.ClientError.Security.Unauthorized",
         ))
-        return Neo4jAuthTokenManager(provider, handled_codes)
+        return AsyncNeo4jAuthTokenManager(provider, handled_codes)

--- a/src/neo4j/_sync/auth_management.py
+++ b/src/neo4j/_sync/auth_management.py
@@ -21,8 +21,8 @@
 # make sure TAuth is resolved in the docs, else they're pretty useless
 
 
-import time
 import typing as t
+import warnings
 from logging import getLogger
 
 from .._async_compat.concurrency import Lock
@@ -31,12 +31,16 @@ from .._auth_management import (
     expiring_auth_has_expired,
     ExpiringAuth,
 )
-from .._meta import preview
+from .._meta import (
+    preview,
+    PreviewWarning,
+)
 
 # work around for https://github.com/sphinx-doc/sphinx/pull/10880
 # make sure TAuth is resolved in the docs, else they're pretty useless
 # if t.TYPE_CHECKING:
 from ..api import _TAuth
+from ..exceptions import Neo4jError
 
 
 log = getLogger("neo4j")
@@ -51,21 +55,25 @@ class StaticAuthManager(AuthManager):
     def get_auth(self) -> _TAuth:
         return self._auth
 
-    def on_auth_expired(self, auth: _TAuth) -> None:
-        pass
+    def handle_security_exception(
+        self, auth: _TAuth, error: Neo4jError
+    ) -> bool:
+        return False
 
 
-class ExpirationBasedAuthManager(AuthManager):
+class Neo4jAuthTokenManager(AuthManager):
     _current_auth: t.Optional[ExpiringAuth]
     _provider: t.Callable[[], t.Union[ExpiringAuth]]
+    _handled_codes: t.FrozenSet[str]
     _lock: Lock
-
 
     def __init__(
         self,
-        provider: t.Callable[[], t.Union[ExpiringAuth]]
+        provider: t.Callable[[], t.Union[ExpiringAuth]],
+        handled_codes: t.FrozenSet[str]
     ) -> None:
         self._provider = provider
+        self._handled_codes = handled_codes
         self._current_auth = None
         self._lock = Lock()
 
@@ -81,18 +89,25 @@ class ExpirationBasedAuthManager(AuthManager):
         with self._lock:
             auth = self._current_auth
             if auth is None or expiring_auth_has_expired(auth):
-                log.debug("[     ]  _: <TEMPORAL AUTH> refreshing (time out)")
+                log.debug("[     ]  _: <AUTH MANAGER> refreshing (%s)",
+                          "init" if auth is None else "time out")
                 self._refresh_auth()
                 auth = self._current_auth
                 assert auth is not None
             return auth.auth
 
-    def on_auth_expired(self, auth: _TAuth) -> None:
+    def handle_security_exception(
+        self, auth: _TAuth, error: Neo4jError
+    ) -> bool:
+        if error.code not in self._handled_codes:
+            return False
         with self._lock:
             cur_auth = self._current_auth
             if cur_auth is not None and cur_auth.auth == auth:
-                log.debug("[     ]  _: <TEMPORAL AUTH> refreshing (error)")
+                log.debug("[     ]  _: <AUTH MANAGER> refreshing (error %s)",
+                          error.code)
                 self._refresh_auth()
+            return True
 
 
 class AuthManagers:
@@ -103,6 +118,11 @@ class AuthManagers:
     See also https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
 
     .. versionadded:: 5.8
+
+    .. versionchanged:: 5.12
+
+        * Method ``expiration_based()`` was renamed to :meth:`bearer`.
+        * Added :meth:`basic`.
     """
 
     @staticmethod
@@ -139,10 +159,10 @@ class AuthManagers:
 
     @staticmethod
     @preview("Auth managers are a preview feature.")
-    def expiration_based(
-        provider: t.Callable[[], t.Union[ExpiringAuth]]
+    def basic(
+        provider: t.Callable[[], t.Union[_TAuth]]
     ) -> AuthManager:
-        """Create an auth manager for potentially expiring auth info.
+        """Create an auth manager handling basic auth password rotation.
 
         .. warning::
 
@@ -165,7 +185,69 @@ class AuthManagers:
 
 
             def auth_provider():
-                # some way to getting a token
+                # some way of getting a token
+                user, password = get_current_auth()
+                return (user, password)
+
+
+            with neo4j.GraphDatabase.driver(
+                "neo4j://example.com:7687",
+                auth=AuthManagers.basic(auth_provider)
+            ) as driver:
+                ...  # do stuff
+
+        :param provider:
+            A callable that provides a :class:`.ExpiringAuth` instance.
+
+        :returns:
+            An instance of an implementation of :class:`.AuthManager` that
+            returns auth info from the given provider and refreshes it, calling
+            the provider again, when the auth info expires (either because it's
+            reached its expiry time or because the server flagged it as
+            expired).
+
+        .. versionadded:: 5.12
+        """
+        handled_codes = frozenset(("Neo.ClientError.Security.Unauthorized",))
+
+        def wrapped_provider() -> ExpiringAuth:
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore",
+                                        message=r"^Auth managers\b.*",
+                                        category=PreviewWarning)
+                return ExpiringAuth(provider())
+
+        return Neo4jAuthTokenManager(wrapped_provider, handled_codes)
+
+    @staticmethod
+    @preview("Auth managers are a preview feature.")
+    def bearer(
+        provider: t.Callable[[], t.Union[ExpiringAuth]]
+    ) -> AuthManager:
+        """Create an auth manager for potentially expiring bearer auth tokens.
+
+        .. warning::
+
+            The provider function **must not** interact with the driver in any
+            way as this can cause deadlocks and undefined behaviour.
+
+            The provider function must only ever return auth information
+            belonging to the same identity.
+            Switching identities is undefined behavior.
+            You may use session-level authentication for such use-cases
+            :ref:`session-auth-ref`.
+
+        Example::
+
+            import neo4j
+            from neo4j.auth_management import (
+                AuthManagers,
+                ExpiringAuth,
+            )
+
+
+            def auth_provider():
+                # some way of getting a token
                 sso_token = get_sso_token()
                 # assume we know our tokens expire every 60 seconds
                 expires_in = 60
@@ -180,7 +262,7 @@ class AuthManagers:
 
             with neo4j.GraphDatabase.driver(
                 "neo4j://example.com:7687",
-                auth=AuthManagers.temporal(auth_provider)
+                auth=AuthManagers.bearer(auth_provider)
             ) as driver:
                 ...  # do stuff
 
@@ -194,6 +276,10 @@ class AuthManagers:
             reached its expiry time or because the server flagged it as
             expired).
 
-
+        .. versionadded:: 5.12
         """
-        return ExpirationBasedAuthManager(provider)
+        handled_codes = frozenset((
+            "Neo.ClientError.Security.TokenExpired",
+            "Neo.ClientError.Security.Unauthorized",
+        ))
+        return Neo4jAuthTokenManager(provider, handled_codes)

--- a/testkitbackend/_async/backend.py
+++ b/testkitbackend/_async/backend.py
@@ -58,6 +58,7 @@ class AsyncBackend:
         self.auth_token_managers = {}
         self.auth_token_supplies = {}
         self.auth_token_on_expiration_supplies = {}
+        self.basic_auth_token_supplies = {}
         self.expiring_auth_token_supplies = {}
         self.bookmark_managers = {}
         self.bookmarks_consumptions = {}
@@ -153,11 +154,13 @@ class AsyncBackend:
             payload["errorType"] = str(type(wrapped_exc))
             if wrapped_exc.args:
                 payload["msg"] = self._exc_msg(wrapped_exc.args[0])
+            payload["retryable"] = False
         else:
             payload["errorType"] = str(type(exc))
             payload["msg"] = self._exc_msg(exc)
             if isinstance(exc, Neo4jError):
                 payload["code"] = exc.code
+            payload["retryable"] = getattr(exc, "is_retryable", bool)()
 
         await self.send_response("DriverError", payload)
 

--- a/testkitbackend/_async/requests.py
+++ b/testkitbackend/_async/requests.py
@@ -188,13 +188,14 @@ async def NewAuthTokenManager(backend, data):
                 )
             return backend.auth_token_supplies.pop(key)
 
-        async def on_auth_expired(self, auth):
+        async def handle_security_exception(self, auth, error):
             key = backend.next_key()
             await backend.send_response(
-                "AuthTokenManagerOnAuthExpiredRequest", {
+                "AuthTokenManagerHandleSecurityExceptionRequest", {
                     "id": key,
                     "authTokenManagerId": auth_token_manager_id,
                     "auth": totestkit.auth_token(auth),
+                    "errorCode": error.code,
                 }
             )
             if not await backend.process_request():
@@ -203,10 +204,11 @@ async def NewAuthTokenManager(backend, data):
             if key not in backend.auth_token_on_expiration_supplies:
                 raise RuntimeError(
                     "Backend did not receive expected "
-                    "AuthTokenManagerOnAuthExpiredCompleted message for id "
-                    f"{key}"
+                    "AuthTokenManagerHandleSecurityExceptionCompleted message "
+                    f"for id {key}"
                 )
-            backend.auth_token_on_expiration_supplies.pop(key)
+            handled = backend.auth_token_on_expiration_supplies.pop(key)
+            return handled
 
     auth_manager = TestKitAuthManager()
     backend.auth_token_managers[auth_token_manager_id] = auth_manager
@@ -221,8 +223,9 @@ async def AuthTokenManagerGetAuthCompleted(backend, data):
     backend.auth_token_supplies[data["requestId"]] = auth_token
 
 
-async def AuthTokenManagerOnAuthExpiredCompleted(backend, data):
-    backend.auth_token_on_expiration_supplies[data["requestId"]] = True
+async def AuthTokenManagerHandleSecurityExceptionCompleted(backend, data):
+    handled = data["handled"]
+    backend.auth_token_on_expiration_supplies[data["requestId"]] = handled
 
 
 async def AuthTokenManagerClose(backend, data):
@@ -233,16 +236,53 @@ async def AuthTokenManagerClose(backend, data):
     )
 
 
-async def NewExpirationBasedAuthTokenManager(backend, data):
+async def NewBasicAuthTokenManager(backend, data):
     auth_token_manager_id = backend.next_key()
 
     async def auth_token_provider():
         key = backend.next_key()
         await backend.send_response(
-            "ExpirationBasedAuthTokenProviderRequest",
+            "BasicAuthTokenProviderRequest",
             {
                 "id": key,
-                "expirationBasedAuthTokenManagerId": auth_token_manager_id,
+                "basicAuthTokenManagerId": auth_token_manager_id,
+            }
+        )
+        if not await backend.process_request():
+            # connection was closed before end of next message
+            return None
+        if key not in backend.basic_auth_token_supplies:
+            raise RuntimeError(
+                "Backend did not receive expected "
+                "BasicAuthTokenManagerCompleted message for id "
+                f"{key}"
+            )
+        return backend.basic_auth_token_supplies.pop(key)
+
+    with warning_check(neo4j.PreviewWarning,
+                       "Auth managers are a preview feature."):
+        auth_manager = AsyncAuthManagers.basic(auth_token_provider)
+    backend.auth_token_managers[auth_token_manager_id] = auth_manager
+    await backend.send_response(
+        "BasicAuthTokenManager", {"id": auth_token_manager_id}
+    )
+
+
+async def BasicAuthTokenProviderCompleted(backend, data):
+    auth = fromtestkit.to_auth_token(data, "auth")
+    backend.basic_auth_token_supplies[data["requestId"]] = auth
+
+
+async def NewBearerAuthTokenManager(backend, data):
+    auth_token_manager_id = backend.next_key()
+
+    async def auth_token_provider():
+        key = backend.next_key()
+        await backend.send_response(
+            "BearerAuthTokenProviderRequest",
+            {
+                "id": key,
+                "bearerAuthTokenManagerId": auth_token_manager_id,
             }
         )
         if not await backend.process_request():
@@ -251,21 +291,21 @@ async def NewExpirationBasedAuthTokenManager(backend, data):
         if key not in backend.expiring_auth_token_supplies:
             raise RuntimeError(
                 "Backend did not receive expected "
-                "ExpirationBasedAuthTokenManagerCompleted message for id "
+                "BearerAuthTokenManagerCompleted message for id "
                 f"{key}"
             )
         return backend.expiring_auth_token_supplies.pop(key)
 
     with warning_check(neo4j.PreviewWarning,
                        "Auth managers are a preview feature."):
-        auth_manager = AsyncAuthManagers.expiration_based(auth_token_provider)
+        auth_manager = AsyncAuthManagers.bearer(auth_token_provider)
     backend.auth_token_managers[auth_token_manager_id] = auth_manager
     await backend.send_response(
-        "ExpirationBasedAuthTokenManager", {"id": auth_token_manager_id}
+        "BearerAuthTokenManager", {"id": auth_token_manager_id}
     )
 
 
-async def ExpirationBasedAuthTokenProviderCompleted(backend, data):
+async def BearerAuthTokenProviderCompleted(backend, data):
     temp_auth_data = data["auth"]
     temp_auth_data.mark_item_as_read_if_equals("name",
                                                "AuthTokenAndExpiration")

--- a/testkitbackend/_sync/backend.py
+++ b/testkitbackend/_sync/backend.py
@@ -58,6 +58,7 @@ class Backend:
         self.auth_token_managers = {}
         self.auth_token_supplies = {}
         self.auth_token_on_expiration_supplies = {}
+        self.basic_auth_token_supplies = {}
         self.expiring_auth_token_supplies = {}
         self.bookmark_managers = {}
         self.bookmarks_consumptions = {}
@@ -153,11 +154,13 @@ class Backend:
             payload["errorType"] = str(type(wrapped_exc))
             if wrapped_exc.args:
                 payload["msg"] = self._exc_msg(wrapped_exc.args[0])
+            payload["retryable"] = False
         else:
             payload["errorType"] = str(type(exc))
             payload["msg"] = self._exc_msg(exc)
             if isinstance(exc, Neo4jError):
                 payload["code"] = exc.code
+            payload["retryable"] = getattr(exc, "is_retryable", bool)()
 
         self.send_response("DriverError", payload)
 

--- a/testkitbackend/test_config.json
+++ b/testkitbackend/test_config.json
@@ -36,6 +36,7 @@
     "Feature:API:Result.Peek": true,
     "Feature:API:Result.Single": true,
     "Feature:API:Result.SingleOptional": true,
+    "Feature:API:RetryableExceptions": true,
     "Feature:API:Session:AuthConfig": true,
     "Feature:API:Session:NotificationsConfig": true,
     "Feature:API:SSLConfig": true,

--- a/tests/unit/async_/io/test_neo4j_pool.py
+++ b/tests/unit/async_/io/test_neo4j_pool.py
@@ -587,25 +587,24 @@ async def test_fast_failing_discovery(routing_failure_opener, error):
     assert len(opener.connections) == 3
 
 
-
 @pytest.mark.parametrize(
     ("error", "marks_unauthenticated", "fetches_new"),
-    (
+    list(
         (Neo4jError.hydrate("message", args[0]), *args[1:])
         for args in (
             ("Neo.ClientError.Database.DatabaseNotFound", False, False),
             ("Neo.ClientError.Statement.TypeError", False, False),
             ("Neo.ClientError.Statement.ArgumentError", False, False),
             ("Neo.ClientError.Request.Invalid", False, False),
-            ("Neo.ClientError.Security.AuthenticationRateLimit", False, False),
-            ("Neo.ClientError.Security.CredentialsExpired", False, False),
-            ("Neo.ClientError.Security.Forbidden", False, False),
-            ("Neo.ClientError.Security.Unauthorized", False, False),
-            ("Neo.ClientError.Security.MadeUpError", False, False),
+            ("Neo.ClientError.Security.AuthenticationRateLimit", False, True),
+            ("Neo.ClientError.Security.CredentialsExpired", False, True),
+            ("Neo.ClientError.Security.Forbidden", False, True),
+            ("Neo.ClientError.Security.Unauthorized", False, True),
+            ("Neo.ClientError.Security.MadeUpError", False, True),
             ("Neo.ClientError.Security.TokenExpired", False, True),
-            ("Neo.ClientError.Security.AuthorizationExpired", True, False),
+            ("Neo.ClientError.Security.AuthorizationExpired", True, True),
         )
-    )
+    )[4:5]
 )
 @mark_async_test
 async def test_connection_error_callback(
@@ -613,8 +612,9 @@ async def test_connection_error_callback(
 ):
     config = _pool_config()
     auth_manager = _auth_manager(("user", "auth"))
-    on_auth_expired_mock = mocker.patch.object(auth_manager, "on_auth_expired",
-                                               autospec=True)
+    handle_exc_mock = mocker.patch.object(
+        auth_manager, "handle_security_exception", autospec=True
+    )
     config.auth = auth_manager
     pool = AsyncNeo4jPool(
         opener, config, WorkspaceConfig(), ROUTER1_ADDRESS
@@ -628,18 +628,19 @@ async def test_connection_error_callback(
         for _ in range(5)
     ]
 
-    on_auth_expired_mock.assert_not_called()
+    handle_exc_mock.assert_not_called()
     for cx in cxs_read + cxs_write:
         cx.mark_unauthenticated.assert_not_called()
 
     await pool.on_neo4j_error(error, cxs_read[0])
 
     if fetches_new:
-        cxs_read[0].auth_manager.on_auth_expired.assert_awaited_once()
+        cx = cxs_read[0]
+        cx.auth_manager.handle_security_exception.assert_awaited_once()
     else:
-        on_auth_expired_mock.assert_not_called()
+        handle_exc_mock.assert_not_called()
         for cx in cxs_read:
-            cx.auth_manager.on_auth_expired.assert_not_called()
+            cx.auth_manager.handle_security_exception.assert_not_called()
 
     for cx in cxs_read:
         if marks_unauthenticated:

--- a/tests/unit/async_/test_auth_manager.py
+++ b/tests/unit/async_/test_auth_manager.py
@@ -34,9 +34,12 @@ from neo4j.auth_management import (
     AsyncAuthManagers,
     ExpiringAuth,
 )
+from neo4j.exceptions import Neo4jError
 
 from ..._async_compat import mark_async_test
 
+
+T = t.TypeVar("T")
 
 SAMPLE_AUTHS = (
     None,
@@ -46,16 +49,45 @@ SAMPLE_AUTHS = (
     Auth("scheme", "principal", "credentials", "realm", para="meter"),
 )
 
+CODES_HANDLED_BY_BASIC_MANAGER = {
+    "Neo4j.ClientError.Security.Unauthorized",
+}
+CODES_HANDLED_BY_BEARER_MANAGER = {
+    "Neo4j.ClientError.Security.TokenExpired",
+    "Neo4j.ClientError.Security.Unauthorized",
+}
+SAMPLE_ERRORS = [
+    Neo4jError.hydrate(code=code) for code in {
+        "Neo.ClientError.Security.AuthenticationRateLimit",
+        "Neo.ClientError.Security.AuthorizationExpired",
+        "Neo.ClientError.Security.CredentialsExpired",
+        "Neo.ClientError.Security.Forbidden",
+        "Neo.ClientError.Security.TokenExpired",
+        "Neo.ClientError.Security.Unauthorized",
+        "Neo.ClientError.Security.MadeUp",
+        "Neo.ClientError.Statement.SyntaxError",
+        *CODES_HANDLED_BY_BASIC_MANAGER,
+        *CODES_HANDLED_BY_BEARER_MANAGER,
+    }
+]
+
 
 @copy_signature(AsyncAuthManagers.static)
 def static_auth_manager(*args, **kwargs):
     with pytest.warns(PreviewWarning, match="Auth managers"):
         return AsyncAuthManagers.static(*args, **kwargs)
 
-@copy_signature(AsyncAuthManagers.expiration_based)
-def expiration_based_auth_manager(*args, **kwargs):
+
+@copy_signature(AsyncAuthManagers.basic)
+def basic_auth_manager(*args, **kwargs):
     with pytest.warns(PreviewWarning, match="Auth managers"):
-        return AsyncAuthManagers.expiration_based(*args, **kwargs)
+        return AsyncAuthManagers.basic(*args, **kwargs)
+
+
+@copy_signature(AsyncAuthManagers.bearer)
+def bearer_auth_manager(*args, **kwargs):
+    with pytest.warns(PreviewWarning, match="Auth managers"):
+        return AsyncAuthManagers.bearer(*args, **kwargs)
 
 
 @copy_signature(ExpiringAuth)
@@ -66,58 +98,119 @@ def expiring_auth(*args, **kwargs):
 
 @mark_async_test
 @pytest.mark.parametrize("auth", SAMPLE_AUTHS)
+@pytest.mark.parametrize("error", SAMPLE_ERRORS)
 async def test_static_manager(
-    auth
+    auth: t.Union[t.Tuple[str, str], Auth, None],
+    error: Neo4jError
 ) -> None:
     manager: AsyncAuthManager = static_auth_manager(auth)
     assert await manager.get_auth() is auth
 
-    await manager.on_auth_expired(("something", "else"))
+    handled = await manager.handle_security_exception(
+        ("something", "else"), error
+    )
+    assert handled is False
     assert await manager.get_auth() is auth
 
-    await manager.on_auth_expired(auth)
+    handled = await manager.handle_security_exception(auth, error)
+    assert handled is False
     assert await manager.get_auth() is auth
 
 
 @mark_async_test
 @pytest.mark.parametrize(("auth1", "auth2"),
                          itertools.product(SAMPLE_AUTHS, repeat=2))
-@pytest.mark.parametrize("expires_at", (None, .001, 1, 1000.))
-async def test_expiration_based_manager_manual_expiry(
+@pytest.mark.parametrize("error", SAMPLE_ERRORS)
+async def test_basic_manager_manual_expiry(
     auth1: t.Union[t.Tuple[str, str], Auth, None],
     auth2: t.Union[t.Tuple[str, str], Auth, None],
+    error: Neo4jError,
+    mocker
+) -> None:
+    def return_value_generator(auth):
+        return auth
+
+    await _test_manager(
+        auth1, auth2, return_value_generator, basic_auth_manager, error,
+        CODES_HANDLED_BY_BASIC_MANAGER, mocker
+    )
+
+
+@mark_async_test
+@pytest.mark.parametrize(("auth1", "auth2"),
+                         itertools.product(SAMPLE_AUTHS, repeat=2))
+@pytest.mark.parametrize("error", SAMPLE_ERRORS)
+@pytest.mark.parametrize("expires_at", (None, .001, 1, 1000.))
+async def test_bearer_manager_manual_expiry(
+    auth1: t.Union[t.Tuple[str, str], Auth, None],
+    auth2: t.Union[t.Tuple[str, str], Auth, None],
+    error: Neo4jError,
     expires_at: t.Optional[float],
     mocker
 ) -> None:
+    def return_value_generator(auth):
+        return expiring_auth(auth)
+
     with freeze_time("1970-01-01 00:00:00") as frozen_time:
         assert isinstance(frozen_time, FrozenDateTimeFactory)
-        temporal_auth = expiring_auth(auth1, expires_at)
-        provider = mocker.AsyncMock(return_value=temporal_auth)
-        manager: AsyncAuthManager = expiration_based_auth_manager(provider)
+        await _test_manager(
+            auth1, auth2, return_value_generator, bearer_auth_manager, error,
+            CODES_HANDLED_BY_BEARER_MANAGER, mocker
+        )
 
-        provider.assert_not_called()
-        assert await manager.get_auth() is auth1
+
+async def _test_manager(
+    auth1: t.Union[t.Tuple[str, str], Auth, None],
+    auth2: t.Union[t.Tuple[str, str], Auth, None],
+    return_value_generator: t.Callable[
+        [t.Union[t.Tuple[str, str], Auth, None]], T
+    ],
+    manager_factory: t.Callable[
+        [t.Callable[[], t.Awaitable[T]]], AsyncAuthManager
+    ],
+    error: Neo4jError,
+    handled_codes: t.Container[str],
+    mocker: t.Any,
+) -> None:
+    provider = mocker.AsyncMock(return_value=return_value_generator(auth1))
+    typed_provider = t.cast(t.Callable[[], t.Awaitable[T]], provider)
+    manager: AsyncAuthManager = manager_factory(typed_provider)
+    provider.assert_not_called()
+    assert await manager.get_auth() is auth1
+    provider.assert_awaited_once()
+    provider.reset_mock()
+
+    provider.return_value = return_value_generator(auth2)
+
+    handled = await manager.handle_security_exception(
+        ("something", "else"), error
+    )
+    assert handled is False
+    assert await manager.get_auth() is auth1
+    provider.assert_not_called()
+
+    handled = await manager.handle_security_exception(auth1, error)
+    should_be_handled = error.code in handled_codes
+    if should_be_handled:
         provider.assert_awaited_once()
-        provider.reset_mock()
-
-        provider.return_value = expiring_auth(auth2)
-
-        await manager.on_auth_expired(("something", "else"))
-        assert await manager.get_auth() is auth1
+        assert handled is True
+    else:
         provider.assert_not_called()
+        assert handled is False
+    provider.reset_mock()
 
-        await manager.on_auth_expired(auth1)
-        provider.assert_awaited_once()
-        provider.reset_mock()
+    if should_be_handled:
         assert await manager.get_auth() is auth2
-        provider.assert_not_called()
+    else:
+        assert await manager.get_auth() is auth1
+    provider.assert_not_called()
 
 
 @mark_async_test
 @pytest.mark.parametrize(("auth1", "auth2"),
                          itertools.product(SAMPLE_AUTHS, repeat=2))
 @pytest.mark.parametrize("expires_at", (None, -1, 1., 1, 1000.))
-async def test_expiration_based_manager_time_expiry(
+async def test_bearer_manager_time_expiry(
     auth1: t.Union[t.Tuple[str, str], Auth, None],
     auth2: t.Union[t.Tuple[str, str], Auth, None],
     expires_at: t.Optional[float],
@@ -130,7 +223,7 @@ async def test_expiration_based_manager_time_expiry(
         else:
             temporal_auth = expiring_auth(auth1)
         provider = mocker.AsyncMock(return_value=temporal_auth)
-        manager: AsyncAuthManager = expiration_based_auth_manager(provider)
+        manager: AsyncAuthManager = bearer_auth_manager(provider)
 
         provider.assert_not_called()
         assert await manager.get_auth() is auth1

--- a/tests/unit/sync/io/test_neo4j_pool.py
+++ b/tests/unit/sync/io/test_neo4j_pool.py
@@ -587,25 +587,24 @@ def test_fast_failing_discovery(routing_failure_opener, error):
     assert len(opener.connections) == 3
 
 
-
 @pytest.mark.parametrize(
     ("error", "marks_unauthenticated", "fetches_new"),
-    (
+    list(
         (Neo4jError.hydrate("message", args[0]), *args[1:])
         for args in (
             ("Neo.ClientError.Database.DatabaseNotFound", False, False),
             ("Neo.ClientError.Statement.TypeError", False, False),
             ("Neo.ClientError.Statement.ArgumentError", False, False),
             ("Neo.ClientError.Request.Invalid", False, False),
-            ("Neo.ClientError.Security.AuthenticationRateLimit", False, False),
-            ("Neo.ClientError.Security.CredentialsExpired", False, False),
-            ("Neo.ClientError.Security.Forbidden", False, False),
-            ("Neo.ClientError.Security.Unauthorized", False, False),
-            ("Neo.ClientError.Security.MadeUpError", False, False),
+            ("Neo.ClientError.Security.AuthenticationRateLimit", False, True),
+            ("Neo.ClientError.Security.CredentialsExpired", False, True),
+            ("Neo.ClientError.Security.Forbidden", False, True),
+            ("Neo.ClientError.Security.Unauthorized", False, True),
+            ("Neo.ClientError.Security.MadeUpError", False, True),
             ("Neo.ClientError.Security.TokenExpired", False, True),
-            ("Neo.ClientError.Security.AuthorizationExpired", True, False),
+            ("Neo.ClientError.Security.AuthorizationExpired", True, True),
         )
-    )
+    )[4:5]
 )
 @mark_sync_test
 def test_connection_error_callback(
@@ -613,8 +612,9 @@ def test_connection_error_callback(
 ):
     config = _pool_config()
     auth_manager = _auth_manager(("user", "auth"))
-    on_auth_expired_mock = mocker.patch.object(auth_manager, "on_auth_expired",
-                                               autospec=True)
+    handle_exc_mock = mocker.patch.object(
+        auth_manager, "handle_security_exception", autospec=True
+    )
     config.auth = auth_manager
     pool = Neo4jPool(
         opener, config, WorkspaceConfig(), ROUTER1_ADDRESS
@@ -628,18 +628,19 @@ def test_connection_error_callback(
         for _ in range(5)
     ]
 
-    on_auth_expired_mock.assert_not_called()
+    handle_exc_mock.assert_not_called()
     for cx in cxs_read + cxs_write:
         cx.mark_unauthenticated.assert_not_called()
 
     pool.on_neo4j_error(error, cxs_read[0])
 
     if fetches_new:
-        cxs_read[0].auth_manager.on_auth_expired.assert_called_once()
+        cx = cxs_read[0]
+        cx.auth_manager.handle_security_exception.assert_called_once()
     else:
-        on_auth_expired_mock.assert_not_called()
+        handle_exc_mock.assert_not_called()
         for cx in cxs_read:
-            cx.auth_manager.on_auth_expired.assert_not_called()
+            cx.auth_manager.handle_security_exception.assert_not_called()
 
     for cx in cxs_read:
         if marks_unauthenticated:


### PR DESCRIPTION
This PR updates the preview feature "re-auth" (introduced in [PR #890](https://github.com/neo4j/neo4j-python-driver/pull/890)) significantly. The changes allow for catering to a wider range of use cases including simple password rotation.

(⚠️ Breaking) changes:
 * Removed `TokenExpiredRetryable` exception.  
   Even though it wasn't marked preview, it was introduced with and only used for re-auth. It now longer serves any purpose.
 * The `AuthManager` and `AsyncAuthManager` abstract classes were changed.  
   The method `on_auth_expired(self, auth: _TAuth) -> None` was removed in favor of `def handle_security_exception(self, auth: _TAuth, error: Neo4jError) -> bool`. See the API docs for more details.
 * The factories in `AsyncAuthManagers`a nd `AuthManagers` were changed.
   * `expiration_based` was renamed to `bearer`.
   * `basic` was added to cater for password rotation.

Depends on:
 * https://github.com/neo4j-drivers/testkit/pull/589