### PR TITLE
Fix suppression of warnings for internal API usage

### DIFF
--- a/src/neo4j/_async/auth_management.py
+++ b/src/neo4j/_async/auth_management.py
@@ -22,7 +22,6 @@
 
 
 import typing as t
-import warnings
 from logging import getLogger
 
 from .._async_compat.concurrency import AsyncLock
@@ -31,10 +30,7 @@ from .._auth_management import (
     expiring_auth_has_expired,
     ExpiringAuth,
 )
-from .._meta import (
-    preview,
-    PreviewWarning,
-)
+from .._meta import preview
 
 # work around for https://github.com/sphinx-doc/sphinx/pull/10880
 # make sure TAuth is resolved in the docs, else they're pretty useless
@@ -215,11 +211,9 @@ class AsyncAuthManagers:
         handled_codes = frozenset(("Neo.ClientError.Security.Unauthorized",))
 
         async def wrapped_provider() -> ExpiringAuth:
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore",
-                                        message=r"^Auth managers\b.*",
-                                        category=PreviewWarning)
-                return ExpiringAuth(await provider())
+            return ExpiringAuth._without_warning(  # type: ignore
+                await provider()
+            )
 
         return AsyncNeo4jAuthTokenManager(wrapped_provider, handled_codes)
 

--- a/src/neo4j/_async/work/session.py
+++ b/src/neo4j/_async/work/session.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import asyncio
 import typing as t
-import warnings
 from logging import getLogger
 from random import random
 from time import perf_counter
@@ -28,10 +27,7 @@ from time import perf_counter
 from ..._async_compat import async_sleep
 from ..._async_compat.util import AsyncUtil
 from ..._conf import SessionConfig
-from ..._meta import (
-    deprecated,
-    PreviewWarning,
-)
+from ..._meta import deprecated
 from ..._util import ContextBool
 from ..._work import Query
 from ...api import (
@@ -108,14 +104,9 @@ class AsyncSession(AsyncWorkspace):
     def __init__(self, pool, session_config):
         assert isinstance(session_config, SessionConfig)
         if session_config.auth is not None:
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore", message=r".*\bAuth managers\b.*",
-                    category=PreviewWarning
-                )
-                session_config.auth = AsyncAuthManagers.static(
-                    session_config.auth
-                )
+            session_config.auth = AsyncAuthManagers.static._without_warning(
+                session_config.auth
+            )
         super().__init__(pool, session_config)
         self._config = session_config
         self._initialize_bookmarks(session_config.bookmarks)

--- a/src/neo4j/_auth_management.py
+++ b/src/neo4j/_auth_management.py
@@ -24,13 +24,9 @@
 import abc
 import time
 import typing as t
-import warnings
 from dataclasses import dataclass
 
-from ._meta import (
-    preview,
-    PreviewWarning,
-)
+from ._meta import preview
 from .api import _TAuth
 from .exceptions import Neo4jError
 
@@ -89,11 +85,9 @@ class ExpiringAuth:
 
         .. versionadded:: 5.9
         """
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message=r"^Auth managers\b.*",
-                                    category=PreviewWarning)
-            return ExpiringAuth(self.auth, time.time() + seconds)
+        return ExpiringAuth._without_warning(  # type: ignore
+            self.auth, time.time() + seconds
+        )
 
 
 def expiring_auth_has_expired(auth: ExpiringAuth) -> bool:

--- a/src/neo4j/_sync/auth_management.py
+++ b/src/neo4j/_sync/auth_management.py
@@ -22,7 +22,6 @@
 
 
 import typing as t
-import warnings
 from logging import getLogger
 
 from .._async_compat.concurrency import Lock
@@ -31,10 +30,7 @@ from .._auth_management import (
     expiring_auth_has_expired,
     ExpiringAuth,
 )
-from .._meta import (
-    preview,
-    PreviewWarning,
-)
+from .._meta import preview
 
 # work around for https://github.com/sphinx-doc/sphinx/pull/10880
 # make sure TAuth is resolved in the docs, else they're pretty useless
@@ -215,11 +211,9 @@ class AuthManagers:
         handled_codes = frozenset(("Neo.ClientError.Security.Unauthorized",))
 
         def wrapped_provider() -> ExpiringAuth:
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore",
-                                        message=r"^Auth managers\b.*",
-                                        category=PreviewWarning)
-                return ExpiringAuth(provider())
+            return ExpiringAuth._without_warning(  # type: ignore
+                provider()
+            )
 
         return Neo4jAuthTokenManager(wrapped_provider, handled_codes)
 

--- a/src/neo4j/_sync/work/session.py
+++ b/src/neo4j/_sync/work/session.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import asyncio
 import typing as t
-import warnings
 from logging import getLogger
 from random import random
 from time import perf_counter
@@ -28,10 +27,7 @@ from time import perf_counter
 from ..._async_compat import sleep
 from ..._async_compat.util import Util
 from ..._conf import SessionConfig
-from ..._meta import (
-    deprecated,
-    PreviewWarning,
-)
+from ..._meta import deprecated
 from ..._util import ContextBool
 from ..._work import Query
 from ...api import (
@@ -108,14 +104,9 @@ class Session(Workspace):
     def __init__(self, pool, session_config):
         assert isinstance(session_config, SessionConfig)
         if session_config.auth is not None:
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore", message=r".*\bAuth managers\b.*",
-                    category=PreviewWarning
-                )
-                session_config.auth = AuthManagers.static(
-                    session_config.auth
-                )
+            session_config.auth = AuthManagers.static._without_warning(
+                session_config.auth
+            )
         super().__init__(pool, session_config)
         self._config = session_config
         self._initialize_bookmarks(session_config.bookmarks)

--- a/src/neo4j/api.py
+++ b/src/neo4j/api.py
@@ -189,6 +189,7 @@ def custom_auth(
 
 
 # TODO: 6.0 - remove this class
+@deprecated("Use the `Bookmarks` class instead.")
 class Bookmark:
     """A Bookmark object contains an immutable list of bookmark string values.
 
@@ -198,8 +199,6 @@ class Bookmark:
         `Bookmark` will be removed in version 6.0.
         Use :class:`Bookmarks` instead.
     """
-
-    @deprecated("Use the `Bookmarks`` class instead.")
     def __init__(self, *values: str) -> None:
         if values:
             bookmarks = []


### PR DESCRIPTION
Using `warnings.catch_warning` for suppressing warnings when using APIs internally that are preview/experimental/deprecated is a bad idea because the `warnings` module stores the configuration globally per module. This is not thread-safe. Therefore, the code was restructured to not rely of the `warnings` module to suppress those warnings. Instead, warning-free internal APIs are being used.