### PR TITLE
Docs improve type hints

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -248,7 +248,7 @@ Closing a driver will immediately shut down all connections in the pool.
         :param query_: cypher query to execute
         :type query_: typing.LiteralString
         :param parameters_: parameters to use in the query
-        :type parameters_: typing.Optional[typing.Dict[str, typing.Any]]
+        :type parameters_: typing.Dict[str, typing.Any] | None
         :param routing_:
             whether to route the query to a reader (follower/read replica) or
             a writer (leader) in the cluster. Default is to route to a writer.
@@ -264,7 +264,7 @@ Closing a driver will immediately shut down all connections in the pool.
                 as it will not have to resolve the default database first.
 
             See also the Session config :ref:`database-ref`.
-        :type database_: typing.Optional[str]
+        :type database_: str | None
         :param impersonated_user_:
             Name of the user to impersonate.
 
@@ -274,7 +274,7 @@ Closing a driver will immediately shut down all connections in the pool.
             permissions.
 
             See also the Session config :ref:`impersonated-user-ref`.
-        :type impersonated_user_: typing.Optional[str]
+        :type impersonated_user_: str | None
         :param auth_:
             Authentication information to use for this query.
 
@@ -287,7 +287,7 @@ Closing a driver will immediately shut down all connections in the pool.
 
             See also the Session config :ref:`session-auth-ref`.
         :type auth_:
-            typing.Union[typing.Tuple[typing.Any, typing.Any], neo4j.Auth, None]
+            typing.Tuple[typing.Any, typing.Any] | neo4j.Auth | None
         :param result_transformer_:
             A function that gets passed the :class:`neo4j.Result` object
             resulting from the query and converts it to a different type. The
@@ -349,7 +349,7 @@ Closing a driver will immediately shut down all connections in the pool.
                     )
 
         :type result_transformer_:
-            typing.Callable[[neo4j.Result], typing.Union[T]]
+            typing.Callable[[neo4j.Result], T]
         :param bookmark_manager_:
             Specify a bookmark manager to use.
 
@@ -360,7 +360,7 @@ Closing a driver will immediately shut down all connections in the pool.
 
             Pass :data:`None` to disable causal consistency.
         :type bookmark_manager_:
-            typing.Union[BookmarkManager, BookmarkManager, None]
+            BookmarkManager | None
         :param kwargs: additional keyword parameters. None of these can end
             with a single underscore. This is to avoid collisions with the
             keyword configuration parameters of this method. If you need to

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -252,7 +252,7 @@ Closing a driver will immediately shut down all connections in the pool.
         :param routing_:
             whether to route the query to a reader (follower/read replica) or
             a writer (leader) in the cluster. Default is to route to a writer.
-        :type routing_: neo4j.RoutingControl
+        :type routing_: RoutingControl
         :param database_:
             database to execute the query against.
 
@@ -286,8 +286,7 @@ Closing a driver will immediately shut down all connections in the pool.
             https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
 
             See also the Session config :ref:`session-auth-ref`.
-        :type auth_:
-            typing.Tuple[typing.Any, typing.Any] | neo4j.Auth | None
+        :type auth_: typing.Tuple[typing.Any, typing.Any] | Auth | None
         :param result_transformer_:
             A function that gets passed the :class:`neo4j.Result` object
             resulting from the query and converts it to a different type. The
@@ -349,7 +348,7 @@ Closing a driver will immediately shut down all connections in the pool.
                     )
 
         :type result_transformer_:
-            typing.Callable[[neo4j.Result], T]
+            typing.Callable[[Result], T]
         :param bookmark_manager_:
             Specify a bookmark manager to use.
 
@@ -359,8 +358,7 @@ Closing a driver will immediately shut down all connections in the pool.
             Defaults to the driver's :attr:`.execute_query_bookmark_manager`.
 
             Pass :data:`None` to disable causal consistency.
-        :type bookmark_manager_:
-            BookmarkManager | None
+        :type bookmark_manager_: BookmarkManager | None
         :param kwargs: additional keyword parameters. None of these can end
             with a single underscore. This is to avoid collisions with the
             keyword configuration parameters of this method. If you need to
@@ -369,7 +367,7 @@ Closing a driver will immediately shut down all connections in the pool.
             ``parameters_``.
         :type kwargs: typing.Any
 
-        :returns: the result of the ``result_transformer``
+        :returns: the result of the ``result_transformer_``
         :rtype: T
 
         .. versionadded:: 5.5

--- a/docs/source/async_api.rst
+++ b/docs/source/async_api.rst
@@ -235,7 +235,7 @@ Closing a driver will immediately shut down all connections in the pool.
         :param query_: cypher query to execute
         :type query_: typing.LiteralString
         :param parameters_: parameters to use in the query
-        :type parameters_: typing.Optional[typing.Dict[str, typing.Any]]
+        :type parameters_: typing.Dict[str, typing.Any] | None
         :param routing_:
             whether to route the query to a reader (follower/read replica) or
             a writer (leader) in the cluster. Default is to route to a writer.
@@ -251,7 +251,7 @@ Closing a driver will immediately shut down all connections in the pool.
                 as it will not have to resolve the default database first.
 
             See also the Session config :ref:`database-ref`.
-        :type database_: typing.Optional[str]
+        :type database_: str | None
         :param impersonated_user_:
             Name of the user to impersonate.
 
@@ -261,7 +261,7 @@ Closing a driver will immediately shut down all connections in the pool.
             permissions.
 
             See also the Session config :ref:`impersonated-user-ref`.
-        :type impersonated_user_: typing.Optional[str]
+        :type impersonated_user_: str | None
         :param auth_:
             Authentication information to use for this query.
 
@@ -274,7 +274,7 @@ Closing a driver will immediately shut down all connections in the pool.
 
             See also the Session config :ref:`session-auth-ref`.
         :type auth_:
-            typing.Union[typing.Tuple[typing.Any, typing.Any], neo4j.Auth, None]
+            typing.Tuple[typing.Any, typing.Any] | neo4j.Auth | None
         :param result_transformer_:
             A function that gets passed the :class:`neo4j.AsyncResult` object
             resulting from the query and converts it to a different type. The
@@ -347,7 +347,7 @@ Closing a driver will immediately shut down all connections in the pool.
 
             Pass :data:`None` to disable causal consistency.
         :type bookmark_manager_:
-            typing.Union[AsyncBookmarkManager, BookmarkManager, None]
+            AsyncBookmarkManager | BookmarkManager | None
         :param kwargs: additional keyword parameters. None of these can end
             with a single underscore. This is to avoid collisions with the
             keyword configuration parameters of this method. If you need to

--- a/docs/source/async_api.rst
+++ b/docs/source/async_api.rst
@@ -239,7 +239,7 @@ Closing a driver will immediately shut down all connections in the pool.
         :param routing_:
             whether to route the query to a reader (follower/read replica) or
             a writer (leader) in the cluster. Default is to route to a writer.
-        :type routing_: neo4j.RoutingControl
+        :type routing_: RoutingControl
         :param database_:
             database to execute the query against.
 
@@ -273,8 +273,7 @@ Closing a driver will immediately shut down all connections in the pool.
             https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
 
             See also the Session config :ref:`session-auth-ref`.
-        :type auth_:
-            typing.Tuple[typing.Any, typing.Any] | neo4j.Auth | None
+        :type auth_: typing.Tuple[typing.Any, typing.Any] | Auth | None
         :param result_transformer_:
             A function that gets passed the :class:`neo4j.AsyncResult` object
             resulting from the query and converts it to a different type. The
@@ -336,7 +335,7 @@ Closing a driver will immediately shut down all connections in the pool.
                     )
 
         :type result_transformer_:
-            typing.Callable[[neo4j.AsyncResult], typing.Awaitable[T]]
+            typing.Callable[[AsyncResult], typing.Awaitable[T]]
         :param bookmark_manager_:
             Specify a bookmark manager to use.
 
@@ -346,8 +345,7 @@ Closing a driver will immediately shut down all connections in the pool.
             Defaults to the driver's :attr:`.execute_query_bookmark_manager`.
 
             Pass :data:`None` to disable causal consistency.
-        :type bookmark_manager_:
-            AsyncBookmarkManager | BookmarkManager | None
+        :type bookmark_manager_: AsyncBookmarkManager | BookmarkManager | None
         :param kwargs: additional keyword parameters. None of these can end
             with a single underscore. This is to avoid collisions with the
             keyword configuration parameters of this method. If you need to
@@ -356,7 +354,7 @@ Closing a driver will immediately shut down all connections in the pool.
             ``parameters_``.
         :type kwargs: typing.Any
 
-        :returns: the result of the ``result_transformer``
+        :returns: the result of the ``result_transformer_``
         :rtype: T
 
         .. versionadded:: 5.5

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,7 @@
 
 import os
 import sys
+import typing
 
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -118,6 +119,17 @@ todo_include_todos = True
 # Don't include type hints in function signatures
 autodoc_typehints = "description"
 
+autodoc_type_aliases = {
+    # The code-base uses `import typing_extensions as te`.
+    # Re-write these to use `typing` instead, as Sphinx always resolves against
+    # the latest version of the `typing` module.
+    # This is a work-around to make Sphinx resolve type hints correctly, even
+    # though we're using `from __future__ import annotations`.
+    "te": typing,
+    # Type alias that's only defined and imported if `typing.TYPE_CHECKING`
+    # is `True`.
+    "_TAuth": "typing.Tuple[typing.Any, typing.Any] | Auth | None",
+}
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/src/neo4j/_async/auth_management.py
+++ b/src/neo4j/_async/auth_management.py
@@ -16,10 +16,7 @@
 # limitations under the License.
 
 
-# from __future__ import annotations
-# work around for https://github.com/sphinx-doc/sphinx/pull/10880
-# make sure TAuth is resolved in the docs, else they're pretty useless
-
+from __future__ import annotations
 
 import typing as t
 from logging import getLogger
@@ -32,11 +29,10 @@ from .._auth_management import (
 )
 from .._meta import preview
 
-# work around for https://github.com/sphinx-doc/sphinx/pull/10880
-# make sure TAuth is resolved in the docs, else they're pretty useless
-# if t.TYPE_CHECKING:
-from ..api import _TAuth
-from ..exceptions import Neo4jError
+
+if t.TYPE_CHECKING:
+    from ..api import _TAuth
+    from ..exceptions import Neo4jError
 
 
 log = getLogger("neo4j")

--- a/src/neo4j/_async/driver.py
+++ b/src/neo4j/_async/driver.py
@@ -710,7 +710,7 @@ class AsyncDriver:
         :param routing_:
             whether to route the query to a reader (follower/read replica) or
             a writer (leader) in the cluster. Default is to route to a writer.
-        :type routing_: neo4j.RoutingControl
+        :type routing_: RoutingControl
         :param database_:
             database to execute the query against.
 
@@ -744,9 +744,7 @@ class AsyncDriver:
             https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
 
             See also the Session config :ref:`session-auth-ref`.
-        :type auth_: typing.Union[
-            typing.Tuple[typing.Any, typing.Any], neo4j.Auth, None
-        ]
+        :type auth_: typing.Tuple[typing.Any, typing.Any] | Auth | None
         :param result_transformer_:
             A function that gets passed the :class:`neo4j.AsyncResult` object
             resulting from the query and converts it to a different type. The
@@ -808,7 +806,7 @@ class AsyncDriver:
                     )
 
         :type result_transformer_:
-            typing.Callable[[neo4j.AsyncResult], typing.Awaitable[T]]
+            typing.Callable[[AsyncResult], typing.Awaitable[T]]
         :param bookmark_manager_:
             Specify a bookmark manager to use.
 
@@ -818,8 +816,7 @@ class AsyncDriver:
             Defaults to the driver's :attr:`.execute_query_bookmark_manager`.
 
             Pass :data:`None` to disable causal consistency.
-        :type bookmark_manager_:
-            typing.Union[AsyncBookmarkManager, BookmarkManager, None]
+        :type bookmark_manager_: AsyncBookmarkManager | BookmarkManager | None
         :param kwargs: additional keyword parameters. None of these can end
             with a single underscore. This is to avoid collisions with the
             keyword configuration parameters of this method. If you need to
@@ -828,7 +825,7 @@ class AsyncDriver:
             ``parameters_``.
         :type kwargs: typing.Any
 
-        :returns: the result of the ``result_transformer``
+        :returns: the result of the ``result_transformer_``
         :rtype: T
 
         .. versionadded:: 5.5

--- a/src/neo4j/_async/driver.py
+++ b/src/neo4j/_async/driver.py
@@ -122,10 +122,7 @@ class AsyncGraphDatabase:
             uri: str,
             *,
             auth: t.Union[
-                # work around https://github.com/sphinx-doc/sphinx/pull/10880
-                # make sure TAuth is resolved in the docs
-                # TAuth,
-                t.Union[t.Tuple[t.Any, t.Any], Auth, None],
+                _TAuth,
                 AsyncAuthManager,
             ] = ...,
             max_connection_lifetime: float = ...,
@@ -172,10 +169,7 @@ class AsyncGraphDatabase:
         def driver(
             cls, uri: str, *,
             auth: t.Union[
-                # work around https://github.com/sphinx-doc/sphinx/pull/10880
-                # make sure TAuth is resolved in the docs
-                # TAuth,
-                t.Union[t.Tuple[t.Any, t.Any], Auth, None],
+                _TAuth,
                 AsyncAuthManager,
             ] = None,
             **config

--- a/src/neo4j/_async/work/result.py
+++ b/src/neo4j/_async/work/result.py
@@ -430,6 +430,7 @@ class AsyncResult:
             instead of returning None if there is more than one record or
             warning if there are more than 1 record.
             :const:`False` by default.
+        :type strict: bool
 
         :returns: the next :class:`neo4j.Record` or :data:`None` if none remain
 

--- a/src/neo4j/_async/work/session.py
+++ b/src/neo4j/_async/work/session.py
@@ -274,9 +274,12 @@ class AsyncSession(AsyncWorkspace):
         For more usage details, see :meth:`.AsyncTransaction.run`.
 
         :param query: cypher query
+        :type query: typing.LiteralString | Query
         :param parameters: dictionary of parameters
+        :type parameters: typing.Dict[str, typing.Any] | None
         :param kwargs: additional keyword parameters.
             These take precedence over parameters passed as ``parameters``.
+        :type kwargs: typing.Any
 
         :returns: a new :class:`neo4j.AsyncResult` object
 
@@ -608,10 +611,15 @@ class AsyncSession(AsyncWorkspace):
             argument and does work with the transaction.
             ``transaction_function(tx, *args, **kwargs)`` where ``tx`` is a
             :class:`.AsyncManagedTransaction`.
+        :type transaction_function:
+            typing.Callable[[AsyncManagedTransaction, P], typing.Awaitable[R]]
         :param args: additional arguments for the `transaction_function`
+        :type args: P
         :param kwargs: key word arguments for the `transaction_function`
+        :type kwargs: P
 
         :returns: whatever the given `transaction_function` returns
+        :rtype: R
 
         :raises SessionError: if the session has been closed.
 
@@ -640,10 +648,15 @@ class AsyncSession(AsyncWorkspace):
             argument and does work with the transaction.
             ``transaction_function(tx, *args, **kwargs)`` where ``tx`` is a
             :class:`.AsyncManagedTransaction`.
+        :type transaction_function:
+            typing.Callable[[AsyncManagedTransaction, P], typing.Awaitable[R]]
         :param args: additional arguments for the `transaction_function`
+        :type args: P
         :param kwargs: key word arguments for the `transaction_function`
+        :type kwargs: P
 
         :returns: a result as returned by the given unit of work
+        :rtype: R
 
         :raises SessionError: if the session has been closed.
 
@@ -690,10 +703,15 @@ class AsyncSession(AsyncWorkspace):
             argument and does work with the transaction.
             ``transaction_function(tx, *args, **kwargs)`` where ``tx`` is a
             :class:`.AsyncManagedTransaction`.
+        :type transaction_function:
+            typing.Callable[[AsyncManagedTransaction, P], typing.Awaitable[R]]
         :param args: additional arguments for the `transaction_function`
+        :type args: P
         :param kwargs: key word arguments for the `transaction_function`
+        :type kwargs: P
 
         :returns: a result as returned by the given unit of work
+        :rtype: R
 
         :raises SessionError: if the session has been closed.
 
@@ -722,10 +740,15 @@ class AsyncSession(AsyncWorkspace):
             argument and does work with the transaction.
             ``transaction_function(tx, *args, **kwargs)`` where ``tx`` is a
             :class:`.AsyncManagedTransaction`.
+        :type transaction_function:
+            typing.Callable[[AsyncManagedTransaction, P], typing.Awaitable[R]]
         :param args: additional arguments for the `transaction_function`
+        :type args: P
         :param kwargs: key word arguments for the `transaction_function`
+        :type kwargs: P
 
         :returns: a result as returned by the given unit of work
+        :rtype: R
 
         :raises SessionError: if the session has been closed.
 

--- a/src/neo4j/_async/work/transaction.py
+++ b/src/neo4j/_async/work/transaction.py
@@ -127,9 +127,12 @@ class AsyncTransactionBase:
         :class:`list` properties must be homogenous.
 
         :param query: cypher query
+        :type query: typing.LiteralString
         :param parameters: dictionary of parameters
+        :type parameters: typing.Dict[str, typing.Any] | None
         :param kwparameters: additional keyword parameters.
             These take precedence over parameters passed as ``parameters``.
+        :type kwparameters: typing.Any
 
         :raise TransactionError: if the transaction is already closed
 
@@ -255,7 +258,7 @@ class AsyncTransactionBase:
         """Indicate whether the transaction has been closed or cancelled.
 
         :returns:
-            :const:`True` if closed or cancelled, :const:`False` otherwise.
+            :data:`True` if closed or cancelled, :data:`False` otherwise.
         :rtype: bool
         """
         return self._closed_flag

--- a/src/neo4j/_auth_management.py
+++ b/src/neo4j/_auth_management.py
@@ -16,10 +16,7 @@
 # limitations under the License.
 
 
-# from __future__ import annotations
-# work around for https://github.com/sphinx-doc/sphinx/pull/10880
-# make sure TAuth is resolved in the docs, else they're pretty useless
-
+from __future__ import annotations
 
 import abc
 import time
@@ -27,8 +24,11 @@ import typing as t
 from dataclasses import dataclass
 
 from ._meta import preview
-from .api import _TAuth
 from .exceptions import Neo4jError
+
+
+if t.TYPE_CHECKING:
+    from .api import _TAuth
 
 
 @preview("Auth managers are a preview feature.")
@@ -62,10 +62,10 @@ class ExpiringAuth:
         :meth:`.expires_in` can be used to create an :class:`.ExpiringAuth`
         with a relative expiration time.
     """
-    auth: "_TAuth"
+    auth: _TAuth
     expires_at: t.Optional[float] = None
 
-    def expires_in(self, seconds: float) -> "ExpiringAuth":
+    def expires_in(self, seconds: float) -> ExpiringAuth:
         """Return a (flat) copy of this object with a new expiration time.
 
         This is a convenience method for creating an :class:`.ExpiringAuth`

--- a/src/neo4j/_sync/auth_management.py
+++ b/src/neo4j/_sync/auth_management.py
@@ -16,10 +16,7 @@
 # limitations under the License.
 
 
-# from __future__ import annotations
-# work around for https://github.com/sphinx-doc/sphinx/pull/10880
-# make sure TAuth is resolved in the docs, else they're pretty useless
-
+from __future__ import annotations
 
 import typing as t
 from logging import getLogger
@@ -32,11 +29,10 @@ from .._auth_management import (
 )
 from .._meta import preview
 
-# work around for https://github.com/sphinx-doc/sphinx/pull/10880
-# make sure TAuth is resolved in the docs, else they're pretty useless
-# if t.TYPE_CHECKING:
-from ..api import _TAuth
-from ..exceptions import Neo4jError
+
+if t.TYPE_CHECKING:
+    from ..api import _TAuth
+    from ..exceptions import Neo4jError
 
 
 log = getLogger("neo4j")

--- a/src/neo4j/_sync/driver.py
+++ b/src/neo4j/_sync/driver.py
@@ -709,7 +709,7 @@ class Driver:
         :param routing_:
             whether to route the query to a reader (follower/read replica) or
             a writer (leader) in the cluster. Default is to route to a writer.
-        :type routing_: neo4j.RoutingControl
+        :type routing_: RoutingControl
         :param database_:
             database to execute the query against.
 
@@ -743,9 +743,7 @@ class Driver:
             https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
 
             See also the Session config :ref:`session-auth-ref`.
-        :type auth_: typing.Union[
-            typing.Tuple[typing.Any, typing.Any], neo4j.Auth, None
-        ]
+        :type auth_: typing.Tuple[typing.Any, typing.Any] | Auth | None
         :param result_transformer_:
             A function that gets passed the :class:`neo4j.Result` object
             resulting from the query and converts it to a different type. The
@@ -807,7 +805,7 @@ class Driver:
                     )
 
         :type result_transformer_:
-            typing.Callable[[neo4j.Result], typing.Union[T]]
+            typing.Callable[[Result], typing.Union[T]]
         :param bookmark_manager_:
             Specify a bookmark manager to use.
 
@@ -817,8 +815,7 @@ class Driver:
             Defaults to the driver's :attr:`.execute_query_bookmark_manager`.
 
             Pass :data:`None` to disable causal consistency.
-        :type bookmark_manager_:
-            typing.Union[BookmarkManager, BookmarkManager, None]
+        :type bookmark_manager_: BookmarkManager | BookmarkManager | None
         :param kwargs: additional keyword parameters. None of these can end
             with a single underscore. This is to avoid collisions with the
             keyword configuration parameters of this method. If you need to
@@ -827,7 +824,7 @@ class Driver:
             ``parameters_``.
         :type kwargs: typing.Any
 
-        :returns: the result of the ``result_transformer``
+        :returns: the result of the ``result_transformer_``
         :rtype: T
 
         .. versionadded:: 5.5

--- a/src/neo4j/_sync/driver.py
+++ b/src/neo4j/_sync/driver.py
@@ -121,10 +121,7 @@ class GraphDatabase:
             uri: str,
             *,
             auth: t.Union[
-                # work around https://github.com/sphinx-doc/sphinx/pull/10880
-                # make sure TAuth is resolved in the docs
-                # TAuth,
-                t.Union[t.Tuple[t.Any, t.Any], Auth, None],
+                _TAuth,
                 AuthManager,
             ] = ...,
             max_connection_lifetime: float = ...,
@@ -171,10 +168,7 @@ class GraphDatabase:
         def driver(
             cls, uri: str, *,
             auth: t.Union[
-                # work around https://github.com/sphinx-doc/sphinx/pull/10880
-                # make sure TAuth is resolved in the docs
-                # TAuth,
-                t.Union[t.Tuple[t.Any, t.Any], Auth, None],
+                _TAuth,
                 AuthManager,
             ] = None,
             **config

--- a/src/neo4j/_sync/work/result.py
+++ b/src/neo4j/_sync/work/result.py
@@ -430,6 +430,7 @@ class Result:
             instead of returning None if there is more than one record or
             warning if there are more than 1 record.
             :const:`False` by default.
+        :type strict: bool
 
         :returns: the next :class:`neo4j.Record` or :data:`None` if none remain
 

--- a/src/neo4j/_sync/work/session.py
+++ b/src/neo4j/_sync/work/session.py
@@ -274,9 +274,12 @@ class Session(Workspace):
         For more usage details, see :meth:`.Transaction.run`.
 
         :param query: cypher query
+        :type query: typing.LiteralString | Query
         :param parameters: dictionary of parameters
+        :type parameters: typing.Dict[str, typing.Any] | None
         :param kwargs: additional keyword parameters.
             These take precedence over parameters passed as ``parameters``.
+        :type kwargs: typing.Any
 
         :returns: a new :class:`neo4j.Result` object
 
@@ -608,10 +611,15 @@ class Session(Workspace):
             argument and does work with the transaction.
             ``transaction_function(tx, *args, **kwargs)`` where ``tx`` is a
             :class:`.ManagedTransaction`.
+        :type transaction_function:
+            typing.Callable[[ManagedTransaction, P], typing.Union[R]]
         :param args: additional arguments for the `transaction_function`
+        :type args: P
         :param kwargs: key word arguments for the `transaction_function`
+        :type kwargs: P
 
         :returns: whatever the given `transaction_function` returns
+        :rtype: R
 
         :raises SessionError: if the session has been closed.
 
@@ -640,10 +648,15 @@ class Session(Workspace):
             argument and does work with the transaction.
             ``transaction_function(tx, *args, **kwargs)`` where ``tx`` is a
             :class:`.ManagedTransaction`.
+        :type transaction_function:
+            typing.Callable[[ManagedTransaction, P], typing.Union[R]]
         :param args: additional arguments for the `transaction_function`
+        :type args: P
         :param kwargs: key word arguments for the `transaction_function`
+        :type kwargs: P
 
         :returns: a result as returned by the given unit of work
+        :rtype: R
 
         :raises SessionError: if the session has been closed.
 
@@ -690,10 +703,15 @@ class Session(Workspace):
             argument and does work with the transaction.
             ``transaction_function(tx, *args, **kwargs)`` where ``tx`` is a
             :class:`.ManagedTransaction`.
+        :type transaction_function:
+            typing.Callable[[ManagedTransaction, P], typing.Union[R]]
         :param args: additional arguments for the `transaction_function`
+        :type args: P
         :param kwargs: key word arguments for the `transaction_function`
+        :type kwargs: P
 
         :returns: a result as returned by the given unit of work
+        :rtype: R
 
         :raises SessionError: if the session has been closed.
 
@@ -722,10 +740,15 @@ class Session(Workspace):
             argument and does work with the transaction.
             ``transaction_function(tx, *args, **kwargs)`` where ``tx`` is a
             :class:`.ManagedTransaction`.
+        :type transaction_function:
+            typing.Callable[[ManagedTransaction, P], typing.Union[R]]
         :param args: additional arguments for the `transaction_function`
+        :type args: P
         :param kwargs: key word arguments for the `transaction_function`
+        :type kwargs: P
 
         :returns: a result as returned by the given unit of work
+        :rtype: R
 
         :raises SessionError: if the session has been closed.
 

--- a/src/neo4j/_sync/work/transaction.py
+++ b/src/neo4j/_sync/work/transaction.py
@@ -127,9 +127,12 @@ class TransactionBase:
         :class:`list` properties must be homogenous.
 
         :param query: cypher query
+        :type query: typing.LiteralString
         :param parameters: dictionary of parameters
+        :type parameters: typing.Dict[str, typing.Any] | None
         :param kwparameters: additional keyword parameters.
             These take precedence over parameters passed as ``parameters``.
+        :type kwparameters: typing.Any
 
         :raise TransactionError: if the transaction is already closed
 
@@ -255,7 +258,7 @@ class TransactionBase:
         """Indicate whether the transaction has been closed or cancelled.
 
         :returns:
-            :const:`True` if closed or cancelled, :const:`False` otherwise.
+            :data:`True` if closed or cancelled, :data:`False` otherwise.
         :rtype: bool
         """
         return self._closed_flag

--- a/src/neo4j/_work/query.py
+++ b/src/neo4j/_work/query.py
@@ -35,8 +35,11 @@ class Query:
     a similar role as :func:`.unit_of_work` for transactions functions.
 
     :param text: The query text.
+    :type text: typing.LiteralString
     :param metadata: metadata attached to the query.
+    :type metadata: typing.Dict[str, typing.Any] | None
     :param timeout: seconds.
+    :type timeout: float | None
     """
     def __init__(
         self,
@@ -83,6 +86,7 @@ def unit_of_work(
         https://neo4j.com/docs/cypher-manual/current/clauses/transaction-clauses/#query-listing-transactions
         and https://neo4j.com/docs/operations-manual/current/reference/procedures/
         for reference.
+    :type metadata: typing.Dict[str, typing.Any] | None
 
     :param timeout:
         the transaction timeout in seconds.
@@ -96,6 +100,9 @@ def unit_of_work(
         Value should not represent a negative duration.
         A zero duration will make the transaction execute indefinitely.
         None will use the default timeout configured in the database.
+    :type timeout: float | None
+
+    :rtype: typing.Callable[[T], T]
     """
 
     def wrapper(f):

--- a/src/neo4j/api.py
+++ b/src/neo4j/api.py
@@ -78,11 +78,16 @@ class Auth:
 
     :param scheme: specifies the type of authentication, examples: "basic",
                    "kerberos"
+    :type scheme: str | None
     :param principal: specifies who is being authenticated
+    :type principal: str | None
     :param credentials: authenticates the principal
+    :type credentials: str | None
     :param realm: specifies the authentication provider
+    :type realm: str | None
     :param parameters: extra key word parameters passed along to the
                        authentication provider
+    :type parameters: typing.Any
     """
 
     def __init__(
@@ -105,7 +110,7 @@ class Auth:
         if parameters:
             self.parameters = parameters
 
-    def __eq__(self, other):
+    def __eq__(self, other: t.Any) -> bool:
         if not isinstance(other, Auth):
             return NotImplemented
         return vars(self) == vars(other)
@@ -114,11 +119,8 @@ class Auth:
 # For backwards compatibility
 AuthToken = Auth
 
-# if t.TYPE_CHECKING:
-# commented out as work around for
-# https://github.com/sphinx-doc/sphinx/pull/10880
-# make sure TAuth is resolved in the docs, else they're pretty useless
-_TAuth = t.Union[t.Tuple[t.Any, t.Any], Auth, None]
+if t.TYPE_CHECKING:
+    _TAuth = t.Union[t.Tuple[t.Any, t.Any], Auth, None]
 
 
 def basic_auth(


### PR DESCRIPTION
With `from __future__ import annotations` in the code, Sphinx gets easily
confused. This applies to several areas like:
 * Type aliases
 * Things defined in `if typing.TYPE_CHECKING` blocks
 * Usage of the `typing_extensions` module

This PR aims to work around as many of those quirks as possible.