### PR TITLE
Docs: mature TCP keep alive

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -454,9 +454,6 @@ Specify whether TCP keep-alive should be enabled.
 :Type: ``bool``
 :Default: ``True``
 
-**This is experimental** (see :ref:`filter-warnings-ref`).
-It might be changed or removed any time even without prior notice.
-
 
 .. _max-connection-lifetime-ref:
 


### PR DESCRIPTION
This config option has existed for many versions. It's stable in other drivers as well. In fact, the driver didn't even issue a warning on using it. It was purely marked as experimental in the API docs. This PR aims to change this by removing the experimental mark in the docs.