### PR TITLE
Use wheel for pyarrow on Python 3.12

### DIFF
--- a/testkit/Dockerfile
+++ b/testkit/Dockerfile
@@ -57,14 +57,3 @@ RUN for version in $PYTHON_VERSIONS; do \
         python$version -m pip install -U pip && \
         python$version -m pip install -U coverage tox; \
     done
-
-# Installing pyarrow lib until pre-built wheel for Python 3.12 exists
-# https://github.com/apache/arrow/issues/37880
-RUN apt update && \
-    apt install -y -V lsb-release cmake gcc && \
-    distro_name=$(lsb_release --id --short | tr 'A-Z' 'a-z') && \
-    code_name=$(lsb_release --codename --short) && \
-    wget https://apache.jfrog.io/artifactory/arrow/${distro_name}/apache-arrow-apt-source-latest-${code_name}.deb && \
-    apt install -y -V ./apache-arrow-apt-source-latest-${code_name}.deb && \
-    apt update && \
-    apt install -y -V libarrow-dev # For C++ \


### PR DESCRIPTION
Since pyarrow now ships a pre-built wheel for python 3.12, we no longer need to build it from source for testing.