### PR TITLE
Switch build front-end to `build`

### DIFF
--- a/bin/dist-functions
+++ b/bin/dist-functions
@@ -99,7 +99,7 @@ function set_metadata_and_setup
     # Create source distribution
     find . -name *.pyc -delete
     rm -rf "${SRC}/*.egg-info" 2> /dev/null
-    python setup.py $*
+    python -m build $*
     check_file "${DIST}/${PACKAGE}-${VERSION}.tar.gz"
 
     trap - EXIT

--- a/bin/make-dist
+++ b/bin/make-dist
@@ -11,5 +11,5 @@ then
     exit 1
 else
     source "${ROOT}/bin/dist-functions"
-    setup "${VERSION}" sdist
+    setup "${VERSION}" --sdist
 fi

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,9 @@
 # the driver itself
 -e .[pandas,numpy,pyarrow]
 
+# needed for packaging
+build
+
 # auto-generate sync driver from async code
 unasync>=0.5.0
 # pre-commit hooks and tools


### PR DESCRIPTION
[build](https://pypi.org/project/build/) builds the package in an isolated environment providing the requested build tools per `pyproject.toml`. This way we can be sure that wheel builds from source dist will also work one the customers' machines.