### PR TITLE
Deprecate multi-target routing driver

### DIFF
--- a/src/neo4j/_async/driver.py
+++ b/src/neo4j/_async/driver.py
@@ -381,6 +381,15 @@ class AsyncGraphDatabase:
         """ Create a driver for routing-capable Neo4j service access
         that uses socket I/O and thread-based concurrency.
         """
+
+        # TODO: 6.0 - adjust signature to only take one target
+        if len(targets) > 1:
+            deprecation_warn(
+                "Creating a routing driver with multiple targets is "
+                "deprecated. The driver only uses the first target anyway. "
+                "The method signature will change in a future release.",
+            )
+
         from .._exceptions import (
             BoltHandshakeError,
             BoltSecurityError,

--- a/src/neo4j/_sync/driver.py
+++ b/src/neo4j/_sync/driver.py
@@ -380,6 +380,15 @@ class GraphDatabase:
         """ Create a driver for routing-capable Neo4j service access
         that uses socket I/O and thread-based concurrency.
         """
+
+        # TODO: 6.0 - adjust signature to only take one target
+        if len(targets) > 1:
+            deprecation_warn(
+                "Creating a routing driver with multiple targets is "
+                "deprecated. The driver only uses the first target anyway. "
+                "The method signature will change in a future release.",
+            )
+
         from .._exceptions import (
             BoltHandshakeError,
             BoltSecurityError,


### PR DESCRIPTION
Frankly, the deprecation might be overkill.
When constructing a driver via `GraphDatabase.driver(...)`, you cannot run into this case, but only when using the undocumented and cumbersome `GraphDatabase.neo4j_driver(...)` method. Even then, the driver will ignore everything but the first target.