### PR TITLE
Optional check for concurrent usage errors

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -113,6 +113,8 @@ Specifically for this driver, this will:
      It might be changed or removed any time even without prior notice.
    * the driver will raise an exception if non-concurrency-safe methods are used concurrently.
 
+     .. versionadded:: 5.15
+
 .. _development mode: https://docs.python.org/3/library/devmode.html
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -99,6 +99,23 @@ To deactivate the current active virtual environment, use:
     deactivate
 
 
+Development Environment
+=======================
+
+For development, we recommend to run Python in `development mode`_ (``python -X dev ...``).
+Specifically for this driver, this will:
+
+ * enable :class:`ResourceWarning`, which the driver emits if resources (e.g., Sessions) aren't properly closed.
+ * enable :class:`DeprecationWarning`, which the driver emits if deprecated APIs are used.
+ * enable the driver's debug mode (this can also be achieved by setting the environment variable ``PYTHONNEO4JDEBUG``):
+
+   * **This is experimental**.
+     It might be changed or removed any time even without prior notice.
+   * the driver will raise an exception if non-concurrency-safe methods are used concurrently.
+
+.. _development mode: https://docs.python.org/3/library/devmode.html
+
+
 *************
 Quick Example
 *************

--- a/docs/source/themes/neo4j/static/css/neo4j.css_t
+++ b/docs/source/themes/neo4j/static/css/neo4j.css_t
@@ -503,25 +503,16 @@ dl.field-list > dd > ol {
     margin-left: 0;
 }
 
-ol.simple p, ul.simple p {
-    margin-bottom: 0;
-}
-
-ol.simple > li:not(:first-child) > p,
-ul.simple > li:not(:first-child) > p,
-:not(li) > ol > li:first-child > :first-child,
-:not(li) > ul > li:first-child > :first-child {
+.content ol li > p:first-of-type,
+.content ul li > p:first-of-type {
     margin-top: 0;
 }
 
-
-li > p:last-child {
-    margin-top: 10px;
+.content ol li > p:last-of-type,
+.content ul li > p:last-of-type {
+    margin-bottom: 0;
 }
 
-li > p:first-child {
-    margin-top: 10px;
-}
 
 table.docutils {
     margin-top: 10px;

--- a/src/neo4j/_async/_debug/__init__.py
+++ b/src/neo4j/_async/_debug/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from ._concurrency_check import AsyncNonConcurrentMethodChecker
+
+
+__all__ = ["AsyncNonConcurrentMethodChecker"]

--- a/src/neo4j/_async/_debug/_concurrency_check.py
+++ b/src/neo4j/_async/_debug/_concurrency_check.py
@@ -1,0 +1,154 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import traceback
+import typing as t
+from copy import deepcopy
+from functools import wraps
+
+from ..._async_compat.concurrency import (
+    AsyncLock,
+    AsyncRLock,
+)
+from ..._async_compat.util import AsyncUtil
+from ..._meta import copy_signature
+
+
+_TWrapped = t.TypeVar("_TWrapped", bound=t.Callable[..., t.Awaitable[t.Any]])
+_TWrappedIter = t.TypeVar("_TWrappedIter",
+                          bound=t.Callable[..., t.AsyncIterator])
+
+
+ENABLED = sys.flags.dev_mode or bool(os.getenv("PYTHONNEO4JDEBUG"))
+
+
+class NonConcurrentMethodError(RuntimeError):
+    pass
+
+
+class AsyncNonConcurrentMethodChecker:
+    if ENABLED:
+
+        def __init__(self):
+            self.__lock = AsyncRLock()
+            self.__tracebacks_lock = AsyncLock()
+            self.__tracebacks = []
+
+        def __make_error(self, tbs):
+            msg = (f"Methods of {self.__class__} are not concurrency "
+                   "safe, but were invoked concurrently.")
+            if tbs:
+                msg += ("\n\nOther invocation site:\n\n"
+                        f"{''.join(traceback.format_list(tbs[0]))}")
+            return NonConcurrentMethodError(msg)
+
+        @classmethod
+        def non_concurrent_method(cls, f: _TWrapped) -> _TWrapped:
+            if AsyncUtil.is_async_code:
+                if not inspect.iscoroutinefunction(f):
+                    raise TypeError(
+                        "cannot decorate non-coroutine function with "
+                        "AsyncNonConcurrentMethodChecked.non_concurrent_method"
+                    )
+            else:
+                if not callable(f):
+                    raise TypeError(
+                        "cannot decorate non-callable object with "
+                        "NonConcurrentMethodChecked.non_concurrent_method"
+                    )
+
+            @wraps(f)
+            @copy_signature(f)
+            async def inner(*args, **kwargs):
+                self = args[0]
+                assert isinstance(self, cls)
+
+                async with self.__tracebacks_lock:
+                    acquired = await self.__lock.acquire(blocking=False)
+                    if acquired:
+                        self.__tracebacks.append(AsyncUtil.extract_stack())
+                    else:
+                        tbs = deepcopy(self.__tracebacks)
+                if acquired:
+                    try:
+                        return await f(*args, **kwargs)
+                    finally:
+                        async with self.__tracebacks_lock:
+                            self.__tracebacks.pop()
+                            self.__lock.release()
+                else:
+                    raise self.__make_error(tbs)
+
+            return inner
+
+        @classmethod
+        def non_concurrent_iter(cls, f: _TWrappedIter) -> _TWrappedIter:
+            if AsyncUtil.is_async_code:
+                if not inspect.isasyncgenfunction(f):
+                    raise TypeError(
+                        "cannot decorate non-async-generator function with "
+                        "AsyncNonConcurrentMethodChecked.non_concurrent_iter"
+                    )
+            else:
+                if not inspect.isgeneratorfunction(f):
+                    raise TypeError(
+                        "cannot decorate non-generator function with "
+                        "NonConcurrentMethodChecked.non_concurrent_iter"
+                    )
+
+            @wraps(f)
+            @copy_signature(f)
+            async def inner(*args, **kwargs):
+                self = args[0]
+                assert isinstance(self, cls)
+
+                iter_ = f(*args, **kwargs)
+                while True:
+                    async with self.__tracebacks_lock:
+                        acquired = await self.__lock.acquire(blocking=False)
+                        if acquired:
+                            self.__tracebacks.append(AsyncUtil.extract_stack())
+                        else:
+                            tbs = deepcopy(self.__tracebacks)
+                    if acquired:
+                        try:
+                            item = await iter_.__anext__()
+                        finally:
+                            async with self.__tracebacks_lock:
+                                self.__tracebacks.pop()
+                                self.__lock.release()
+                        yield item
+                    else:
+                        raise self.__make_error(tbs)
+
+            return inner
+
+    else:
+
+        @classmethod
+        def non_concurrent_method(cls, f: _TWrapped) -> _TWrapped:
+            return f
+
+        @classmethod
+        def non_concurrent_iter(cls, f: _TWrappedIter) -> _TWrappedIter:
+            return f

--- a/src/neo4j/_async/work/result.py
+++ b/src/neo4j/_async/work/result.py
@@ -45,6 +45,7 @@ from ...time import (
     Date,
     DateTime,
 )
+from .._debug import AsyncNonConcurrentMethodChecker
 from ..io import ConnectionErrorHandler
 
 
@@ -73,7 +74,7 @@ _RESULT_CONSUMED_ERROR = (
 )
 
 
-class AsyncResult:
+class AsyncResult(AsyncNonConcurrentMethodChecker):
     """Handler for the result of Cypher query execution.
 
     Instances of this class are typically constructed and returned by
@@ -111,6 +112,7 @@ class AsyncResult:
         self._out_of_scope = False
         # exception shared across all results of a transaction
         self._exception = None
+        super().__init__()
 
     async def _connection_error_handler(self, exc):
         self._exception = exc
@@ -253,11 +255,15 @@ class AsyncResult:
         )
         self._streaming = True
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_iter
     async def __aiter__(self) -> t.AsyncIterator[Record]:
         """Iterator returning Records.
 
-        :returns: Record, it is an immutable ordered collection of key-value pairs.
-        :rtype: :class:`neo4j.Record`
+        Advancing the iterator advances the underlying result stream.
+        So even when creating multiple iterators from the same result, each
+        Record will only be returned once.
+
+        :returns: Iterator over the result stream's records.
         """
         while self._record_buffer or self._attached:
             if self._record_buffer:
@@ -280,7 +286,9 @@ class AsyncResult:
         if self._consumed:
             raise ResultConsumedError(self, _RESULT_CONSUMED_ERROR)
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def __anext__(self) -> Record:
+        """Advance the result stream and return the record."""
         return await self.__aiter__().__anext__()
 
     async def _attach(self):
@@ -369,6 +377,7 @@ class AsyncResult:
         self._attached = False
         self._exception = exc
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def consume(self) -> ResultSummary:
         """Consume the remainder of this result and return a :class:`neo4j.ResultSummary`.
 
@@ -436,6 +445,7 @@ class AsyncResult:
     async def single(self, strict: te.Literal[True]) -> Record:
         ...
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def single(self, strict: bool = False) -> t.Optional[Record]:
         """Obtain the next and only remaining record or None.
 
@@ -497,6 +507,7 @@ class AsyncResult:
                 )
         return buffer.popleft()
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def fetch(self, n: int) -> t.List[Record]:
         """Obtain up to n records from this result.
 
@@ -519,6 +530,7 @@ class AsyncResult:
             for _ in range(min(n, len(self._record_buffer)))
         ]
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def peek(self) -> t.Optional[Record]:
         """Obtain the next record from this result without consuming it.
 
@@ -539,6 +551,7 @@ class AsyncResult:
             return self._record_buffer[0]
         return None
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def graph(self) -> Graph:
         """Turn the result into a :class:`neo4j.Graph`.
 
@@ -561,6 +574,7 @@ class AsyncResult:
         await self._buffer_all()
         return self._hydration_scope.get_graph()
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def value(
         self, key: _TResultKey = 0, default: t.Optional[object] = None
     ) -> t.List[t.Any]:
@@ -582,6 +596,7 @@ class AsyncResult:
         """
         return [record.value(key, default) async for record in self]
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def values(
         self, *keys: _TResultKey
     ) -> t.List[t.List[t.Any]]:
@@ -602,6 +617,7 @@ class AsyncResult:
         """
         return [record.values(*keys) async for record in self]
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def data(self, *keys: _TResultKey) -> t.List[t.Dict[str, t.Any]]:
         """Return the remainder of the result as a list of dictionaries.
 
@@ -628,6 +644,7 @@ class AsyncResult:
         """
         return [record.data(*keys) async for record in self]
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def to_eager_result(self) -> EagerResult:
         """Convert this result to an :class:`.EagerResult`.
 
@@ -652,6 +669,7 @@ class AsyncResult:
             summary=await self.consume()
         )
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def to_df(
         self,
         expand: bool = False,

--- a/src/neo4j/_async/work/session.py
+++ b/src/neo4j/_async/work/session.py
@@ -44,6 +44,7 @@ from ...exceptions import (
     SessionExpired,
     TransactionError,
 )
+from .._debug import AsyncNonConcurrentMethodChecker
 from ..auth_management import AsyncAuthManagers
 from .result import AsyncResult
 from .transaction import (
@@ -180,6 +181,7 @@ class AsyncSession(AsyncWorkspace):
         await self._connect(READ_ACCESS, force_auth=True)
         await self._disconnect()
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def close(self) -> None:
         """Close the session.
 
@@ -249,6 +251,7 @@ class AsyncSession(AsyncWorkspace):
             """
             self._handle_cancellation(message="manual cancel")
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def run(
         self,
         query: t.Union[te.LiteralString, Query],
@@ -322,6 +325,7 @@ class AsyncSession(AsyncWorkspace):
         "`last_bookmark` has been deprecated in favor of `last_bookmarks`. "
         "This method can lead to unexpected behaviour."
     )
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def last_bookmark(self) -> t.Optional[str]:
         """Get the bookmark received following the last completed transaction.
 
@@ -436,6 +440,7 @@ class AsyncSession(AsyncWorkspace):
             pipelined=self._pipelined_begin
         )
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def begin_transaction(
         self,
         metadata: t.Optional[t.Dict[str, t.Any]] = None,
@@ -585,6 +590,7 @@ class AsyncSession(AsyncWorkspace):
         else:
             raise ServiceUnavailable("Transaction failed")
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def execute_read(
         self,
         transaction_function: t.Callable[
@@ -660,6 +666,7 @@ class AsyncSession(AsyncWorkspace):
 
     # TODO: 6.0 - Remove this method
     @deprecated("read_transaction has been renamed to execute_read")
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def read_transaction(
         self,
         transaction_function: t.Callable[
@@ -697,6 +704,7 @@ class AsyncSession(AsyncWorkspace):
             transaction_function, args, kwargs
         )
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def execute_write(
         self,
         transaction_function: t.Callable[
@@ -754,6 +762,7 @@ class AsyncSession(AsyncWorkspace):
 
     # TODO: 6.0 - Remove this method
     @deprecated("write_transaction has been renamed to execute_write")
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def write_transaction(
         self,
         transaction_function: t.Callable[

--- a/src/neo4j/_async/work/transaction.py
+++ b/src/neo4j/_async/work/transaction.py
@@ -25,6 +25,7 @@ from functools import wraps
 from ..._async_compat.util import AsyncUtil
 from ..._work import Query
 from ...exceptions import TransactionError
+from .._debug import AsyncNonConcurrentMethodChecker
 from ..io import ConnectionErrorHandler
 from .result import AsyncResult
 
@@ -40,7 +41,7 @@ __all__ = (
 )
 
 
-class AsyncTransactionBase:
+class AsyncTransactionBase(AsyncNonConcurrentMethodChecker):
     def __init__(self, connection, fetch_size, on_closed, on_error,
                  on_cancel):
         self._connection = connection
@@ -56,10 +57,12 @@ class AsyncTransactionBase:
         self._on_closed = on_closed
         self._on_error = on_error
         self._on_cancel = on_cancel
+        super().__init__()
 
     async def _enter(self):
         return self
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def _exit(self, exception_type, exception_value, traceback):
         if self._closed_flag:
             return
@@ -71,6 +74,7 @@ class AsyncTransactionBase:
             return
         await self._close()
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def _begin(
         self, database, imp_user, bookmarks, access_mode, metadata, timeout,
         notifications_min_severity, notifications_disabled_categories,
@@ -104,6 +108,7 @@ class AsyncTransactionBase:
             await result._tx_end()
         self._results = []
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def run(
         self,
         query: te.LiteralString,
@@ -167,6 +172,7 @@ class AsyncTransactionBase:
 
         return result
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def _commit(self):
         """Mark this transaction as successful and close in order to trigger a COMMIT.
 
@@ -196,6 +202,7 @@ class AsyncTransactionBase:
 
         return self._bookmark
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def _rollback(self):
         """Mark this transaction as unsuccessful and close in order to trigger a ROLLBACK.
 
@@ -221,6 +228,7 @@ class AsyncTransactionBase:
             self._closed_flag = True
             await AsyncUtil.callback(self._on_closed)
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def _close(self):
         """Close this transaction, triggering a ROLLBACK if not closed.
         """

--- a/src/neo4j/_async/work/workspace.py
+++ b/src/neo4j/_async/work/workspace.py
@@ -33,6 +33,7 @@ from ...exceptions import (
     SessionError,
     SessionExpired,
 )
+from .._debug import AsyncNonConcurrentMethodChecker
 from ..io import (
     AcquireAuth,
     AsyncNeo4jPool,
@@ -42,7 +43,7 @@ from ..io import (
 log = logging.getLogger("neo4j")
 
 
-class AsyncWorkspace:
+class AsyncWorkspace(AsyncNonConcurrentMethodChecker):
 
     def __init__(self, pool, config):
         assert isinstance(config, WorkspaceConfig)
@@ -58,6 +59,7 @@ class AsyncWorkspace:
         self._last_from_bookmark_manager = None
         # Workspace has been closed.
         self._closed = False
+        super().__init__()
 
     def __del__(self):
         if self._closed:
@@ -191,6 +193,7 @@ class AsyncWorkspace:
                 self._connection = None
             self._connection_access_mode = None
 
+    @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def close(self) -> None:
         if self._closed:
             return

--- a/src/neo4j/_async_compat/util.py
+++ b/src/neo4j/_async_compat/util.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import traceback
 import typing as t
 from functools import wraps
 
@@ -88,6 +89,14 @@ class AsyncUtil:
 
     is_async_code: t.ClassVar = True
 
+    @staticmethod
+    def extract_stack(limit=None):
+        # can maybe be improved in the future
+        # https://github.com/python/cpython/issues/91048
+        stack = asyncio.current_task().get_stack(limit=limit)
+        stack_walk = ((f, f.f_lineno) for f in stack)
+        return traceback.StackSummary.extract(stack_walk, limit=limit)
+
 
 class Util:
     iter: t.ClassVar = iter
@@ -115,3 +124,7 @@ class Util:
         return coro_function
 
     is_async_code: t.ClassVar = False
+
+    @staticmethod
+    def extract_stack(limit=None):
+        return traceback.extract_stack(limit=limit)[:-1]

--- a/src/neo4j/_sync/_debug/__init__.py
+++ b/src/neo4j/_sync/_debug/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from ._concurrency_check import NonConcurrentMethodChecker
+
+
+__all__ = ["NonConcurrentMethodChecker"]

--- a/src/neo4j/_sync/_debug/_concurrency_check.py
+++ b/src/neo4j/_sync/_debug/_concurrency_check.py
@@ -1,0 +1,154 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+import traceback
+import typing as t
+from copy import deepcopy
+from functools import wraps
+
+from ..._async_compat.concurrency import (
+    Lock,
+    RLock,
+)
+from ..._async_compat.util import Util
+from ..._meta import copy_signature
+
+
+_TWrapped = t.TypeVar("_TWrapped", bound=t.Callable[..., t.Union[t.Any]])
+_TWrappedIter = t.TypeVar("_TWrappedIter",
+                          bound=t.Callable[..., t.Iterator])
+
+
+ENABLED = sys.flags.dev_mode or bool(os.getenv("PYTHONNEO4JDEBUG"))
+
+
+class NonConcurrentMethodError(RuntimeError):
+    pass
+
+
+class NonConcurrentMethodChecker:
+    if ENABLED:
+
+        def __init__(self):
+            self.__lock = RLock()
+            self.__tracebacks_lock = Lock()
+            self.__tracebacks = []
+
+        def __make_error(self, tbs):
+            msg = (f"Methods of {self.__class__} are not concurrency "
+                   "safe, but were invoked concurrently.")
+            if tbs:
+                msg += ("\n\nOther invocation site:\n\n"
+                        f"{''.join(traceback.format_list(tbs[0]))}")
+            return NonConcurrentMethodError(msg)
+
+        @classmethod
+        def non_concurrent_method(cls, f: _TWrapped) -> _TWrapped:
+            if Util.is_async_code:
+                if not inspect.iscoroutinefunction(f):
+                    raise TypeError(
+                        "cannot decorate non-coroutine function with "
+                        "NonConcurrentMethodChecked.non_concurrent_method"
+                    )
+            else:
+                if not callable(f):
+                    raise TypeError(
+                        "cannot decorate non-callable object with "
+                        "NonConcurrentMethodChecked.non_concurrent_method"
+                    )
+
+            @wraps(f)
+            @copy_signature(f)
+            def inner(*args, **kwargs):
+                self = args[0]
+                assert isinstance(self, cls)
+
+                with self.__tracebacks_lock:
+                    acquired = self.__lock.acquire(blocking=False)
+                    if acquired:
+                        self.__tracebacks.append(Util.extract_stack())
+                    else:
+                        tbs = deepcopy(self.__tracebacks)
+                if acquired:
+                    try:
+                        return f(*args, **kwargs)
+                    finally:
+                        with self.__tracebacks_lock:
+                            self.__tracebacks.pop()
+                            self.__lock.release()
+                else:
+                    raise self.__make_error(tbs)
+
+            return inner
+
+        @classmethod
+        def non_concurrent_iter(cls, f: _TWrappedIter) -> _TWrappedIter:
+            if Util.is_async_code:
+                if not inspect.isasyncgenfunction(f):
+                    raise TypeError(
+                        "cannot decorate non-async-generator function with "
+                        "NonConcurrentMethodChecked.non_concurrent_iter"
+                    )
+            else:
+                if not inspect.isgeneratorfunction(f):
+                    raise TypeError(
+                        "cannot decorate non-generator function with "
+                        "NonConcurrentMethodChecked.non_concurrent_iter"
+                    )
+
+            @wraps(f)
+            @copy_signature(f)
+            def inner(*args, **kwargs):
+                self = args[0]
+                assert isinstance(self, cls)
+
+                iter_ = f(*args, **kwargs)
+                while True:
+                    with self.__tracebacks_lock:
+                        acquired = self.__lock.acquire(blocking=False)
+                        if acquired:
+                            self.__tracebacks.append(Util.extract_stack())
+                        else:
+                            tbs = deepcopy(self.__tracebacks)
+                    if acquired:
+                        try:
+                            item = iter_.__next__()
+                        finally:
+                            with self.__tracebacks_lock:
+                                self.__tracebacks.pop()
+                                self.__lock.release()
+                        yield item
+                    else:
+                        raise self.__make_error(tbs)
+
+            return inner
+
+    else:
+
+        @classmethod
+        def non_concurrent_method(cls, f: _TWrapped) -> _TWrapped:
+            return f
+
+        @classmethod
+        def non_concurrent_iter(cls, f: _TWrappedIter) -> _TWrappedIter:
+            return f

--- a/src/neo4j/_sync/work/result.py
+++ b/src/neo4j/_sync/work/result.py
@@ -45,6 +45,7 @@ from ...time import (
     Date,
     DateTime,
 )
+from .._debug import NonConcurrentMethodChecker
 from ..io import ConnectionErrorHandler
 
 
@@ -73,7 +74,7 @@ _RESULT_CONSUMED_ERROR = (
 )
 
 
-class Result:
+class Result(NonConcurrentMethodChecker):
     """Handler for the result of Cypher query execution.
 
     Instances of this class are typically constructed and returned by
@@ -111,6 +112,7 @@ class Result:
         self._out_of_scope = False
         # exception shared across all results of a transaction
         self._exception = None
+        super().__init__()
 
     def _connection_error_handler(self, exc):
         self._exception = exc
@@ -253,11 +255,15 @@ class Result:
         )
         self._streaming = True
 
+    @NonConcurrentMethodChecker.non_concurrent_iter
     def __iter__(self) -> t.Iterator[Record]:
         """Iterator returning Records.
 
-        :returns: Record, it is an immutable ordered collection of key-value pairs.
-        :rtype: :class:`neo4j.Record`
+        Advancing the iterator advances the underlying result stream.
+        So even when creating multiple iterators from the same result, each
+        Record will only be returned once.
+
+        :returns: Iterator over the result stream's records.
         """
         while self._record_buffer or self._attached:
             if self._record_buffer:
@@ -280,7 +286,9 @@ class Result:
         if self._consumed:
             raise ResultConsumedError(self, _RESULT_CONSUMED_ERROR)
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def __next__(self) -> Record:
+        """Advance the result stream and return the record."""
         return self.__iter__().__next__()
 
     def _attach(self):
@@ -369,6 +377,7 @@ class Result:
         self._attached = False
         self._exception = exc
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def consume(self) -> ResultSummary:
         """Consume the remainder of this result and return a :class:`neo4j.ResultSummary`.
 
@@ -436,6 +445,7 @@ class Result:
     def single(self, strict: te.Literal[True]) -> Record:
         ...
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def single(self, strict: bool = False) -> t.Optional[Record]:
         """Obtain the next and only remaining record or None.
 
@@ -497,6 +507,7 @@ class Result:
                 )
         return buffer.popleft()
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def fetch(self, n: int) -> t.List[Record]:
         """Obtain up to n records from this result.
 
@@ -519,6 +530,7 @@ class Result:
             for _ in range(min(n, len(self._record_buffer)))
         ]
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def peek(self) -> t.Optional[Record]:
         """Obtain the next record from this result without consuming it.
 
@@ -539,6 +551,7 @@ class Result:
             return self._record_buffer[0]
         return None
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def graph(self) -> Graph:
         """Turn the result into a :class:`neo4j.Graph`.
 
@@ -561,6 +574,7 @@ class Result:
         self._buffer_all()
         return self._hydration_scope.get_graph()
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def value(
         self, key: _TResultKey = 0, default: t.Optional[object] = None
     ) -> t.List[t.Any]:
@@ -582,6 +596,7 @@ class Result:
         """
         return [record.value(key, default) for record in self]
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def values(
         self, *keys: _TResultKey
     ) -> t.List[t.List[t.Any]]:
@@ -602,6 +617,7 @@ class Result:
         """
         return [record.values(*keys) for record in self]
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def data(self, *keys: _TResultKey) -> t.List[t.Dict[str, t.Any]]:
         """Return the remainder of the result as a list of dictionaries.
 
@@ -628,6 +644,7 @@ class Result:
         """
         return [record.data(*keys) for record in self]
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def to_eager_result(self) -> EagerResult:
         """Convert this result to an :class:`.EagerResult`.
 
@@ -652,6 +669,7 @@ class Result:
             summary=self.consume()
         )
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def to_df(
         self,
         expand: bool = False,

--- a/src/neo4j/_sync/work/session.py
+++ b/src/neo4j/_sync/work/session.py
@@ -44,6 +44,7 @@ from ...exceptions import (
     SessionExpired,
     TransactionError,
 )
+from .._debug import NonConcurrentMethodChecker
 from ..auth_management import AuthManagers
 from .result import Result
 from .transaction import (
@@ -180,6 +181,7 @@ class Session(Workspace):
         self._connect(READ_ACCESS, force_auth=True)
         self._disconnect()
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def close(self) -> None:
         """Close the session.
 
@@ -249,6 +251,7 @@ class Session(Workspace):
             """
             self._handle_cancellation(message="manual cancel")
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def run(
         self,
         query: t.Union[te.LiteralString, Query],
@@ -322,6 +325,7 @@ class Session(Workspace):
         "`last_bookmark` has been deprecated in favor of `last_bookmarks`. "
         "This method can lead to unexpected behaviour."
     )
+    @NonConcurrentMethodChecker.non_concurrent_method
     def last_bookmark(self) -> t.Optional[str]:
         """Get the bookmark received following the last completed transaction.
 
@@ -436,6 +440,7 @@ class Session(Workspace):
             pipelined=self._pipelined_begin
         )
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def begin_transaction(
         self,
         metadata: t.Optional[t.Dict[str, t.Any]] = None,
@@ -585,6 +590,7 @@ class Session(Workspace):
         else:
             raise ServiceUnavailable("Transaction failed")
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def execute_read(
         self,
         transaction_function: t.Callable[
@@ -660,6 +666,7 @@ class Session(Workspace):
 
     # TODO: 6.0 - Remove this method
     @deprecated("read_transaction has been renamed to execute_read")
+    @NonConcurrentMethodChecker.non_concurrent_method
     def read_transaction(
         self,
         transaction_function: t.Callable[
@@ -697,6 +704,7 @@ class Session(Workspace):
             transaction_function, args, kwargs
         )
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def execute_write(
         self,
         transaction_function: t.Callable[
@@ -754,6 +762,7 @@ class Session(Workspace):
 
     # TODO: 6.0 - Remove this method
     @deprecated("write_transaction has been renamed to execute_write")
+    @NonConcurrentMethodChecker.non_concurrent_method
     def write_transaction(
         self,
         transaction_function: t.Callable[

--- a/src/neo4j/_sync/work/transaction.py
+++ b/src/neo4j/_sync/work/transaction.py
@@ -25,6 +25,7 @@ from functools import wraps
 from ..._async_compat.util import Util
 from ..._work import Query
 from ...exceptions import TransactionError
+from .._debug import NonConcurrentMethodChecker
 from ..io import ConnectionErrorHandler
 from .result import Result
 
@@ -40,7 +41,7 @@ __all__ = (
 )
 
 
-class TransactionBase:
+class TransactionBase(NonConcurrentMethodChecker):
     def __init__(self, connection, fetch_size, on_closed, on_error,
                  on_cancel):
         self._connection = connection
@@ -56,10 +57,12 @@ class TransactionBase:
         self._on_closed = on_closed
         self._on_error = on_error
         self._on_cancel = on_cancel
+        super().__init__()
 
     def _enter(self):
         return self
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def _exit(self, exception_type, exception_value, traceback):
         if self._closed_flag:
             return
@@ -71,6 +74,7 @@ class TransactionBase:
             return
         self._close()
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def _begin(
         self, database, imp_user, bookmarks, access_mode, metadata, timeout,
         notifications_min_severity, notifications_disabled_categories,
@@ -104,6 +108,7 @@ class TransactionBase:
             result._tx_end()
         self._results = []
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def run(
         self,
         query: te.LiteralString,
@@ -167,6 +172,7 @@ class TransactionBase:
 
         return result
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def _commit(self):
         """Mark this transaction as successful and close in order to trigger a COMMIT.
 
@@ -196,6 +202,7 @@ class TransactionBase:
 
         return self._bookmark
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def _rollback(self):
         """Mark this transaction as unsuccessful and close in order to trigger a ROLLBACK.
 
@@ -221,6 +228,7 @@ class TransactionBase:
             self._closed_flag = True
             Util.callback(self._on_closed)
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def _close(self):
         """Close this transaction, triggering a ROLLBACK if not closed.
         """

--- a/src/neo4j/_sync/work/workspace.py
+++ b/src/neo4j/_sync/work/workspace.py
@@ -33,6 +33,7 @@ from ...exceptions import (
     SessionError,
     SessionExpired,
 )
+from .._debug import NonConcurrentMethodChecker
 from ..io import (
     AcquireAuth,
     Neo4jPool,
@@ -42,7 +43,7 @@ from ..io import (
 log = logging.getLogger("neo4j")
 
 
-class Workspace:
+class Workspace(NonConcurrentMethodChecker):
 
     def __init__(self, pool, config):
         assert isinstance(config, WorkspaceConfig)
@@ -58,6 +59,7 @@ class Workspace:
         self._last_from_bookmark_manager = None
         # Workspace has been closed.
         self._closed = False
+        super().__init__()
 
     def __del__(self):
         if self._closed:
@@ -191,6 +193,7 @@ class Workspace:
                 self._connection = None
             self._connection_access_mode = None
 
+    @NonConcurrentMethodChecker.non_concurrent_method
     def close(self) -> None:
         if self._closed:
             return


### PR DESCRIPTION
Some driver objects (e.g, Sessions, Transactions, Result streams) are not safe for concurrent use. By default, it will cause hard to interpret errors or, in the worst case, wrong behavior.

To aid finding such bugs, the driver now detects if the Python interpreter is running development mode and enables extra locking around those objects. If they are used concurrently, an error will be raised. The way this is implemented, it will only cause a one-time overhead when loading the driver's modules if the checks are disabled.

Obviously, those checks are somewhat expensive as they entail locks (less so in the async driver). Therefore, the checks are only happening if either
 * Python is started in development mode (`python -X dev ...`) or
 * The environment variable `PYTHONNEO4JDEBUG` is set (to anything non-empty) at the time the driver's modules is loaded.