### PR TITLE
Accept transaction config for execute_query

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -187,8 +187,9 @@ Closing a driver will immediately shut down all connections in the pool.
                 query_, parameters_, routing_, database_, impersonated_user_,
                 bookmark_manager_, auth_, result_transformer_, **kwargs
             ):
+                @unit_of_work(query_.metadata, query_.timeout)
                 def work(tx):
-                    result = tx.run(query_, parameters_, **kwargs)
+                    result = tx.run(query_.text, parameters_, **kwargs)
                     return result_transformer_(result)
 
                 with driver.session(
@@ -245,16 +246,19 @@ Closing a driver will immediately shut down all connections in the pool.
                 assert isinstance(count, int)
                 return count
 
-        :param query_: cypher query to execute
-        :type query_: typing.LiteralString
+        :param query_:
+            Cypher query to execute.
+            Use a :class:`.Query` object to pass a query with additional
+            transaction configuration.
+        :type query_: typing.LiteralString | Query
         :param parameters_: parameters to use in the query
-        :type parameters_: typing.Dict[str, typing.Any] | None
+        :type parameters_: typing.Optional[typing.Dict[str, typing.Any]]
         :param routing_:
-            whether to route the query to a reader (follower/read replica) or
+            Whether to route the query to a reader (follower/read replica) or
             a writer (leader) in the cluster. Default is to route to a writer.
         :type routing_: RoutingControl
         :param database_:
-            database to execute the query against.
+            Database to execute the query against.
 
             None (default) uses the database configured on the server side.
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -379,6 +379,10 @@ Closing a driver will immediately shut down all connections in the pool.
         .. versionchanged:: 5.14
             Stabilized ``auth_`` parameter from preview.
 
+        .. versionchanged:: 5.15
+            The ``query_`` parameter now also accepts a :class:`.Query` object
+            instead of only :class:`str`.
+
 
 .. _driver-configuration-ref:
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -252,7 +252,7 @@ Closing a driver will immediately shut down all connections in the pool.
             transaction configuration.
         :type query_: typing.LiteralString | Query
         :param parameters_: parameters to use in the query
-        :type parameters_: typing.Optional[typing.Dict[str, typing.Any]]
+        :type parameters_: typing.Dict[str, typing.Any] | None
         :param routing_:
             Whether to route the query to a reader (follower/read replica) or
             a writer (leader) in the cluster. Default is to route to a writer.

--- a/docs/source/async_api.rst
+++ b/docs/source/async_api.rst
@@ -174,8 +174,9 @@ Closing a driver will immediately shut down all connections in the pool.
                 query_, parameters_, routing_, database_, impersonated_user_,
                 bookmark_manager_, auth_, result_transformer_, **kwargs
             ):
+                @unit_of_work(query_.metadata, query_.timeout)
                 async def work(tx):
-                    result = await tx.run(query_, parameters_, **kwargs)
+                    result = await tx.run(query_.text, parameters_, **kwargs)
                     return await result_transformer_(result)
 
                 async with driver.session(
@@ -232,16 +233,19 @@ Closing a driver will immediately shut down all connections in the pool.
                 assert isinstance(count, int)
                 return count
 
-        :param query_: cypher query to execute
-        :type query_: typing.LiteralString
+        :param query_:
+            Cypher query to execute.
+            Use a :class:`.Query` object to pass a query with additional
+            transaction configuration.
+        :type query_: typing.LiteralString | Query
         :param parameters_: parameters to use in the query
-        :type parameters_: typing.Dict[str, typing.Any] | None
+        :type parameters_: typing.Optional[typing.Dict[str, typing.Any]]
         :param routing_:
-            whether to route the query to a reader (follower/read replica) or
+            Whether to route the query to a reader (follower/read replica) or
             a writer (leader) in the cluster. Default is to route to a writer.
         :type routing_: RoutingControl
         :param database_:
-            database to execute the query against.
+            Database to execute the query against.
 
             None (default) uses the database configured on the server side.
 

--- a/docs/source/async_api.rst
+++ b/docs/source/async_api.rst
@@ -366,6 +366,10 @@ Closing a driver will immediately shut down all connections in the pool.
         .. versionchanged:: 5.14
             Stabilized ``auth_`` parameter from preview.
 
+        .. versionchanged:: 5.15
+            The ``query_`` parameter now also accepts a :class:`.Query` object
+            instead of only :class:`str`.
+
 
 .. _async-driver-configuration-ref:
 

--- a/docs/source/async_api.rst
+++ b/docs/source/async_api.rst
@@ -239,7 +239,7 @@ Closing a driver will immediately shut down all connections in the pool.
             transaction configuration.
         :type query_: typing.LiteralString | Query
         :param parameters_: parameters to use in the query
-        :type parameters_: typing.Optional[typing.Dict[str, typing.Any]]
+        :type parameters_: typing.Dict[str, typing.Any] | None
         :param routing_:
             Whether to route the query to a reader (follower/read replica) or
             a writer (leader) in the cluster. Default is to route to a writer.

--- a/src/neo4j/_async/driver.py
+++ b/src/neo4j/_async/driver.py
@@ -49,7 +49,11 @@ from .._meta import (
     experimental_warn,
     unclosed_resource_warn,
 )
-from .._work import EagerResult
+from .._work import (
+    EagerResult,
+    Query,
+    unit_of_work,
+)
 from ..addressing import Address
 from ..api import (
     AsyncBookmarkManager,
@@ -583,7 +587,7 @@ class AsyncDriver:
     @t.overload
     async def execute_query(
         self,
-        query_: te.LiteralString,
+        query_: t.Union[te.LiteralString, Query],
         parameters_: t.Optional[t.Dict[str, t.Any]] = None,
         routing_: T_RoutingControl = RoutingControl.WRITE,
         database_: t.Optional[str] = None,
@@ -602,7 +606,7 @@ class AsyncDriver:
     @t.overload
     async def execute_query(
         self,
-        query_: te.LiteralString,
+        query_: t.Union[te.LiteralString, Query],
         parameters_: t.Optional[t.Dict[str, t.Any]] = None,
         routing_: T_RoutingControl = RoutingControl.WRITE,
         database_: t.Optional[str] = None,
@@ -620,7 +624,7 @@ class AsyncDriver:
 
     async def execute_query(
         self,
-        query_: te.LiteralString,
+        query_: t.Union[te.LiteralString, Query],
         parameters_: t.Optional[t.Dict[str, t.Any]] = None,
         routing_: T_RoutingControl = RoutingControl.WRITE,
         database_: t.Optional[str] = None,
@@ -653,8 +657,9 @@ class AsyncDriver:
                 query_, parameters_, routing_, database_, impersonated_user_,
                 bookmark_manager_, auth_, result_transformer_, **kwargs
             ):
+                @unit_of_work(query_.metadata, query_.timeout)
                 async def work(tx):
-                    result = await tx.run(query_, parameters_, **kwargs)
+                    result = await tx.run(query_.text, parameters_, **kwargs)
                     return await result_transformer_(result)
 
                 async with driver.session(
@@ -711,16 +716,19 @@ class AsyncDriver:
                 assert isinstance(count, int)
                 return count
 
-        :param query_: cypher query to execute
-        :type query_: typing.LiteralString
+        :param query_:
+            Cypher query to execute.
+            Use a :class:`.Query` object to pass a query with additional
+            transaction configuration.
+        :type query_: typing.LiteralString | Query
         :param parameters_: parameters to use in the query
         :type parameters_: typing.Optional[typing.Dict[str, typing.Any]]
         :param routing_:
-            whether to route the query to a reader (follower/read replica) or
+            Whether to route the query to a reader (follower/read replica) or
             a writer (leader) in the cluster. Default is to route to a writer.
         :type routing_: RoutingControl
         :param database_:
-            database to execute the query against.
+            Database to execute the query against.
 
             None (default) uses the database configured on the server side.
 
@@ -852,6 +860,14 @@ class AsyncDriver:
                 "latter case, use the `parameters_` dictionary instead."
                 % invalid_kwargs
             )
+        if isinstance(query_, Query):
+            timeout = query_.timeout
+            metadata = query_.metadata
+            query_str = query_.text
+            work = unit_of_work(metadata, timeout)(_work)
+        else:
+            query_str = query_
+            work = _work
         parameters = dict(parameters_ or {}, **kwargs)
 
         if bookmark_manager_ is _default:
@@ -878,7 +894,7 @@ class AsyncDriver:
             with session._pipelined_begin:
                 return await session._run_transaction(
                     access_mode, TelemetryAPI.DRIVER,
-                    _work, (query_, parameters, result_transformer_), {}
+                    work, (query_str, parameters, result_transformer_), {}
                 )
 
     @property
@@ -1197,7 +1213,7 @@ class AsyncDriver:
 
 async def _work(
     tx: AsyncManagedTransaction,
-    query: str,
+    query: te.LiteralString,
     parameters: t.Dict[str, t.Any],
     transformer: t.Callable[[AsyncResult], t.Awaitable[_T]]
 ) -> _T:

--- a/src/neo4j/_async/driver.py
+++ b/src/neo4j/_async/driver.py
@@ -846,6 +846,10 @@ class AsyncDriver:
 
         .. versionchanged:: 5.14
             Stabilized ``auth_`` parameter from preview.
+
+        .. versionchanged:: 5.15
+            The ``query_`` parameter now also accepts a :class:`.Query` object
+            instead of only :class:`str`.
         """
         self._check_state()
         invalid_kwargs = [k for k in kwargs if

--- a/src/neo4j/_sync/driver.py
+++ b/src/neo4j/_sync/driver.py
@@ -845,6 +845,10 @@ class Driver:
 
         .. versionchanged:: 5.14
             Stabilized ``auth_`` parameter from preview.
+
+        .. versionchanged:: 5.15
+            The ``query_`` parameter now also accepts a :class:`.Query` object
+            instead of only :class:`str`.
         """
         self._check_state()
         invalid_kwargs = [k for k in kwargs if

--- a/src/neo4j/_work/query.py
+++ b/src/neo4j/_work/query.py
@@ -31,8 +31,10 @@ class Query:
     """A query with attached extra data.
 
     This wrapper class for queries is used to attach extra data to queries
-    passed to :meth:`.Session.run` and :meth:`.AsyncSession.run`, fulfilling
-    a similar role as :func:`.unit_of_work` for transactions functions.
+    passed to :meth:`.Session.run`/:meth:`.AsyncSession.run` and
+    :meth:`.Driver.execute_query`/:meth:`.AsyncDriver.execute_query`,
+    fulfilling a similar role as :func:`.unit_of_work` for transactions
+    functions.
 
     :param text: The query text.
     :type text: typing.LiteralString
@@ -76,7 +78,7 @@ class Query:
         self.timeout = timeout
 
     def __str__(self) -> te.LiteralString:
-        return str(self.text)
+        return t.cast(te.LiteralString, str(self.text))
 
 
 def unit_of_work(

--- a/src/neo4j/_work/query.py
+++ b/src/neo4j/_work/query.py
@@ -78,7 +78,12 @@ class Query:
         self.timeout = timeout
 
     def __str__(self) -> te.LiteralString:
-        return t.cast(te.LiteralString, str(self.text))
+        # we know that if Query is constructed with a LiteralString,
+        # str(self.text) will be a LiteralString as well. The conversion isn't
+        # necessary if the user adheres to the type hints. However, it was
+        # here before, and we don't want to break backwards compatibility.
+        text: te.LiteralString = str(self.text)  # type: ignore[assignment]
+        return text
 
 
 def unit_of_work(

--- a/testkitbackend/_async/requests.py
+++ b/testkitbackend/_async/requests.py
@@ -365,6 +365,11 @@ async def ExecuteQuery(backend, data):
         value = config.get(config_key, None)
         if value is not None:
             kwargs[kwargs_key] = value
+    tx_kwargs = fromtestkit.to_tx_kwargs(config)
+    if tx_kwargs:
+        query = neo4j.Query(cypher, **tx_kwargs)
+    else:
+        query = cypher
     bookmark_manager_id = config.get("bookmarkManagerId")
     if bookmark_manager_id is not None:
         if bookmark_manager_id == -1:
@@ -373,7 +378,7 @@ async def ExecuteQuery(backend, data):
             bookmark_manager = backend.bookmark_managers[bookmark_manager_id]
             kwargs["bookmark_manager_"] = bookmark_manager
 
-    eager_result = await driver.execute_query(cypher, params, **kwargs)
+    eager_result = await driver.execute_query(query, params, **kwargs)
     await backend.send_response("EagerResult", {
         "keys": eager_result.keys,
         "records": list(map(totestkit.record, eager_result.records)),

--- a/testkitbackend/_sync/requests.py
+++ b/testkitbackend/_sync/requests.py
@@ -365,6 +365,11 @@ def ExecuteQuery(backend, data):
         value = config.get(config_key, None)
         if value is not None:
             kwargs[kwargs_key] = value
+    tx_kwargs = fromtestkit.to_tx_kwargs(config)
+    if tx_kwargs:
+        query = neo4j.Query(cypher, **tx_kwargs)
+    else:
+        query = cypher
     bookmark_manager_id = config.get("bookmarkManagerId")
     if bookmark_manager_id is not None:
         if bookmark_manager_id == -1:
@@ -373,7 +378,7 @@ def ExecuteQuery(backend, data):
             bookmark_manager = backend.bookmark_managers[bookmark_manager_id]
             kwargs["bookmark_manager_"] = bookmark_manager
 
-    eager_result = driver.execute_query(cypher, params, **kwargs)
+    eager_result = driver.execute_query(query, params, **kwargs)
     backend.send_response("EagerResult", {
         "keys": eager_result.keys,
         "records": list(map(totestkit.record, eager_result.records)),

--- a/tests/unit/async_/test_driver.py
+++ b/tests/unit/async_/test_driver.py
@@ -35,6 +35,7 @@ from neo4j import (
     ExperimentalWarning,
     NotificationDisabledCategory,
     NotificationMinimumSeverity,
+    Query,
     TRUST_ALL_CERTIFICATES,
     TRUST_SYSTEM_CA_SIGNED_CERTIFICATES,
     TrustAll,
@@ -72,6 +73,13 @@ def session_cls_mock(mocker):
     session_cls_mock.return_value.attach_mock(mocker.NonCallableMagicMock(),
                                               "_pipelined_begin")
     yield session_cls_mock
+
+
+@pytest.fixture
+def unit_of_work_mock(mocker):
+    unit_of_work_mock = mocker.patch("neo4j._async.driver.unit_of_work",
+                                     autospec=True)
+    yield unit_of_work_mock
 
 
 @pytest.mark.parametrize("protocol", ("bolt://", "bolt+s://", "bolt+ssc://"))
@@ -627,11 +635,20 @@ async def test_execute_query_work(mocker) -> None:
     assert res is transformer_mock.return_value
 
 
-@pytest.mark.parametrize("query", ("foo", "bar", "RETURN 1 AS n"))
+@pytest.mark.parametrize("query", (
+    "foo",
+    "bar",
+    "RETURN 1 AS n",
+    Query("RETURN 1 AS n"),
+    Query("RETURN 1 AS n", metadata={"key": "value"}),
+    Query("RETURN 1 AS n", timeout=1234),
+    Query("RETURN 1 AS n", metadata={"key": "value"}, timeout=1234),
+))
 @pytest.mark.parametrize("positional", (True, False))
 @mark_async_test
 async def test_execute_query_query(
-    query: str, positional: bool, session_cls_mock, mocker
+    query: te.LiteralString | Query, positional: bool, session_cls_mock,
+    unit_of_work_mock, mocker
 ) -> None:
     driver = AsyncGraphDatabase.driver("bolt://localhost")
 
@@ -646,10 +663,21 @@ async def test_execute_query_query(
     session_mock.__aenter__.assert_awaited_once()
     session_mock.__aexit__.assert_awaited_once()
     session_executor_mock = session_mock._run_transaction
-    session_executor_mock.assert_awaited_once_with(
-        WRITE_ACCESS, TelemetryAPI.DRIVER, _work,
-        (query, mocker.ANY, mocker.ANY), {}
-    )
+    if isinstance(query, Query):
+        unit_of_work_mock.assert_called_once_with(query.metadata,
+                                                  query.timeout)
+        unit_of_work = unit_of_work_mock.return_value
+        unit_of_work.assert_called_once_with(_work)
+        session_executor_mock.assert_awaited_once_with(
+            WRITE_ACCESS, TelemetryAPI.DRIVER, unit_of_work.return_value,
+            (query.text, mocker.ANY, mocker.ANY), {}
+        )
+    else:
+        unit_of_work_mock.assert_not_called()
+        session_executor_mock.assert_awaited_once_with(
+            WRITE_ACCESS, TelemetryAPI.DRIVER, _work,
+            (query, mocker.ANY, mocker.ANY), {}
+        )
     assert res is session_executor_mock.return_value
 
 


### PR DESCRIPTION
`Driver.execute_query` now accepts a `Query` object to specify transaction config like metadata and transaction timeout. Example:

```python
from neo4j import (
    GraphDatabase,
    Query,
)

with GraphDatabase.driver(...) as driver:
    driver.execute_query(
        Query(
            "MATCH (n) RETURN n",
            # metadata to be logged with the transaction
            metadata={"foo": "bar"},
            # give the transaction 5 seconds to complete on the DBMS
            timeout=5,
        ),
        # all the other configuration options as before
        database_="neo4j",
        # ...
    )
```

Related:
 * https://github.com/neo4j-drivers/testkit/pull/607