### PR TITLE
Refactor Logging Hierarchy in neo4j-python-driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
 
 ## NEXT RELEASE
 - No breaking or major changes.
-- Refactored logger names to adhere to a hierarchical structure for better log source tracing.
+- Implemented a hierarchical logger structure to improve log source identification and traceability.
+- Introduced child loggers:
+  - `neo4j.network`: For socket-related logging.
+  - `neo4j.bolt`: For protocol message logs.
+  - `neo4j.pool`: For logs pertaining to connection pooling and routing.
+  - `neo4j.auth`: For authentication-related logging.
 
 ## Version 5.15
 - No breaking or major changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
 
 ## NEXT RELEASE
 - No breaking or major changes.
-
+- Refactored logger names to adhere to a hierarchical structure for better log source tracing.
 
 ## Version 5.15
 - No breaking or major changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
 
 ## NEXT RELEASE
 - No breaking or major changes.
-- Implemented a hierarchical logger structure to improve log source identification and traceability.
-- Introduced child loggers:
-  - `neo4j.network`: For socket-related logging.
-  - `neo4j.bolt`: For protocol message logs.
+- Implemented a hierarchical logger structure to improve log source
+  identification and traceability.  
+  Introduced child loggers:
+  - `neo4j.io`: For socket and bolt protocol related logging.
   - `neo4j.pool`: For logs pertaining to connection pooling and routing.
-  - `neo4j.auth`: For authentication-related logging.
+  - `neo4j.auth_management`: For logging inside the provided AuthManager
+    implementations.
+
 
 ## Version 5.15
 - No breaking or major changes.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2080,9 +2080,30 @@ following code:
 Logging
 *******
 
-The driver offers logging for debugging purposes. It is not recommended to
-enable logging for anything other than debugging. For instance, if the driver is
-not able to connect to the database server or if undesired behavior is observed.
+The driver offers logging for debugging purposes.
+It is not recommended to enable logging for anything other than debugging.
+For instance, if the driver is not able to connect to the database server or if
+undesired behavior is observed.
+
+This includes messages logged on ``WARNING`` level or higher.
+They are logged to help understand what is going on *inside* the driver.
+All relevant information is passed through return values, raised exceptions,
+warnings, etc.
+The logs are not the right place to look for actionable information.
+
+The driver supports hierarchical logging.
+This means you can selectively configure all of the driver's logging or only
+parts of it.
+Currently available:
+
+* ``neo4j``: The root logger for the driver.
+  High-level code (e.g., Session, Transaction, Driver, etc.) logs here.
+
+  * ``neo4j.io``: Logs network activity and bolt protocol messages, handshakes,
+    etc.
+  * ``neo4j.pool``: Logs connection pool activity (including routing).
+  * ``neo4j.auth_management``: Logger for provided :class:`.AuthManager`
+    implementations.
 
 There are different ways of enabling logging as listed below.
 

--- a/src/neo4j/_async/auth_management.py
+++ b/src/neo4j/_async/auth_management.py
@@ -32,7 +32,7 @@ if t.TYPE_CHECKING:
     from ..exceptions import Neo4jError
 
 
-log = getLogger("neo4j")
+log = getLogger("neo4j.async")
 
 
 class AsyncStaticAuthManager(AsyncAuthManager):

--- a/src/neo4j/_async/auth_management.py
+++ b/src/neo4j/_async/auth_management.py
@@ -32,7 +32,7 @@ if t.TYPE_CHECKING:
     from ..exceptions import Neo4jError
 
 
-log = getLogger("neo4j.async")
+log = getLogger("neo4j.auth")
 
 
 class AsyncStaticAuthManager(AsyncAuthManager):

--- a/src/neo4j/_async/auth_management.py
+++ b/src/neo4j/_async/auth_management.py
@@ -32,7 +32,7 @@ if t.TYPE_CHECKING:
     from ..exceptions import Neo4jError
 
 
-log = getLogger("neo4j.auth")
+log = getLogger("neo4j.auth_management")
 
 
 class AsyncStaticAuthManager(AsyncAuthManager):
@@ -67,7 +67,11 @@ class AsyncNeo4jAuthTokenManager(AsyncAuthManager):
         self._lock = AsyncLock()
 
     async def _refresh_auth(self):
-        self._current_auth = await self._provider()
+        try:
+            self._current_auth = await self._provider()
+        except BaseException as e:
+            log.error("[     ]  _: <AUTH MANAGER> provider failed: %r", e)
+            raise
         if self._current_auth is None:
             raise TypeError(
                 "Auth provider function passed to expiration_based "

--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -57,7 +57,7 @@ from ._common import (
 
 
 # Set up logger
-log = getLogger("neo4j")
+log = getLogger("neo4j.async.io")
 
 
 class ServerStateManagerBase(abc.ABC):

--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -57,7 +57,7 @@ from ._common import (
 
 
 # Set up logger
-log = getLogger("neo4j.bolt")
+log = getLogger("neo4j.io")
 
 
 class ServerStateManagerBase(abc.ABC):

--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -57,7 +57,7 @@ from ._common import (
 
 
 # Set up logger
-log = getLogger("neo4j.async.io")
+log = getLogger("neo4j.bolt")
 
 
 class ServerStateManagerBase(abc.ABC):

--- a/src/neo4j/_async/io/_bolt3.py
+++ b/src/neo4j/_async/io/_bolt3.py
@@ -49,7 +49,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j.bolt")
+log = getLogger("neo4j.io")
 
 
 class BoltStates(Enum):

--- a/src/neo4j/_async/io/_bolt3.py
+++ b/src/neo4j/_async/io/_bolt3.py
@@ -49,7 +49,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j")
+log = getLogger("neo4j.async.io")
 
 
 class BoltStates(Enum):

--- a/src/neo4j/_async/io/_bolt3.py
+++ b/src/neo4j/_async/io/_bolt3.py
@@ -49,7 +49,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j.async.io")
+log = getLogger("neo4j.bolt")
 
 
 class BoltStates(Enum):

--- a/src/neo4j/_async/io/_bolt4.py
+++ b/src/neo4j/_async/io/_bolt4.py
@@ -51,7 +51,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j.bolt")
+log = getLogger("neo4j.io")
 
 
 class AsyncBolt4x0(AsyncBolt):

--- a/src/neo4j/_async/io/_bolt4.py
+++ b/src/neo4j/_async/io/_bolt4.py
@@ -51,7 +51,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j")
+log = getLogger("neo4j.async.io")
 
 
 class AsyncBolt4x0(AsyncBolt):

--- a/src/neo4j/_async/io/_bolt4.py
+++ b/src/neo4j/_async/io/_bolt4.py
@@ -51,7 +51,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j.async.io")
+log = getLogger("neo4j.bolt")
 
 
 class AsyncBolt4x0(AsyncBolt):

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -54,7 +54,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j.bolt")
+log = getLogger("neo4j.io")
 
 
 class AsyncBolt5x0(AsyncBolt):

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -54,7 +54,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j.async.io")
+log = getLogger("neo4j.bolt")
 
 
 class AsyncBolt5x0(AsyncBolt):

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -54,7 +54,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j")
+log = getLogger("neo4j.async.io")
 
 
 class AsyncBolt5x0(AsyncBolt):

--- a/src/neo4j/_async/io/_common.py
+++ b/src/neo4j/_async/io/_common.py
@@ -28,7 +28,7 @@ from ...exceptions import (
 )
 
 
-log = logging.getLogger("neo4j")
+log = logging.getLogger("neo4j.async.io")
 
 
 class AsyncInbox:

--- a/src/neo4j/_async/io/_common.py
+++ b/src/neo4j/_async/io/_common.py
@@ -28,7 +28,7 @@ from ...exceptions import (
 )
 
 
-log = logging.getLogger("neo4j")
+log = logging.getLogger("neo4j.io")
 
 
 class AsyncInbox:

--- a/src/neo4j/_async/io/_common.py
+++ b/src/neo4j/_async/io/_common.py
@@ -28,7 +28,7 @@ from ...exceptions import (
 )
 
 
-log = logging.getLogger("neo4j.async.io")
+log = logging.getLogger("neo4j")
 
 
 class AsyncInbox:

--- a/src/neo4j/_async/io/_pool.py
+++ b/src/neo4j/_async/io/_pool.py
@@ -68,7 +68,7 @@ from ._bolt import AsyncBolt
 
 
 # Set up logger
-log = getLogger("neo4j.async.io")
+log = getLogger("neo4j.pool")
 
 
 @dataclass

--- a/src/neo4j/_async/io/_pool.py
+++ b/src/neo4j/_async/io/_pool.py
@@ -68,7 +68,7 @@ from ._bolt import AsyncBolt
 
 
 # Set up logger
-log = getLogger("neo4j")
+log = getLogger("neo4j.async.io")
 
 
 @dataclass

--- a/src/neo4j/_async/work/session.py
+++ b/src/neo4j/_async/work/session.py
@@ -61,7 +61,7 @@ if t.TYPE_CHECKING:
     _P = te.ParamSpec("_P")
 
 
-log = getLogger("neo4j.async.work")
+log = getLogger("neo4j.pool")
 
 
 class AsyncSession(AsyncWorkspace):

--- a/src/neo4j/_async/work/session.py
+++ b/src/neo4j/_async/work/session.py
@@ -61,7 +61,7 @@ if t.TYPE_CHECKING:
     _P = te.ParamSpec("_P")
 
 
-log = getLogger("neo4j")
+log = getLogger("neo4j.async.work")
 
 
 class AsyncSession(AsyncWorkspace):

--- a/src/neo4j/_async/work/workspace.py
+++ b/src/neo4j/_async/work/workspace.py
@@ -38,7 +38,7 @@ from ..io import (
 )
 
 
-log = logging.getLogger("neo4j.async.work")
+log = logging.getLogger("neo4j.pool")
 
 
 class AsyncWorkspace(AsyncNonConcurrentMethodChecker):

--- a/src/neo4j/_async/work/workspace.py
+++ b/src/neo4j/_async/work/workspace.py
@@ -38,7 +38,7 @@ from ..io import (
 )
 
 
-log = logging.getLogger("neo4j.pool")
+log = logging.getLogger("neo4j")
 
 
 class AsyncWorkspace(AsyncNonConcurrentMethodChecker):

--- a/src/neo4j/_async/work/workspace.py
+++ b/src/neo4j/_async/work/workspace.py
@@ -38,7 +38,7 @@ from ..io import (
 )
 
 
-log = logging.getLogger("neo4j")
+log = logging.getLogger("neo4j.async.work")
 
 
 class AsyncWorkspace(AsyncNonConcurrentMethodChecker):

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -62,7 +62,7 @@ if t.TYPE_CHECKING:
     from ..._sync.io import Bolt
 
 
-log = logging.getLogger("neo4j.network")
+log = logging.getLogger("neo4j.io")
 
 
 def _sanitize_deadline(deadline):

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -62,7 +62,7 @@ if t.TYPE_CHECKING:
     from ..._sync.io import Bolt
 
 
-log = logging.getLogger("neo4j")
+log = logging.getLogger("neo4j.async_compat.network")
 
 
 def _sanitize_deadline(deadline):

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -62,7 +62,7 @@ if t.TYPE_CHECKING:
     from ..._sync.io import Bolt
 
 
-log = logging.getLogger("neo4j.async_compat.network")
+log = logging.getLogger("neo4j.network")
 
 
 def _sanitize_deadline(deadline):

--- a/src/neo4j/_async_compat/network/_util.py
+++ b/src/neo4j/_async_compat/network/_util.py
@@ -5,7 +5,7 @@ import socket
 from ... import addressing
 
 
-log = logging.getLogger("neo4j.network")
+log = logging.getLogger("neo4j.io")
 
 
 def _resolved_addresses_from_info(info, host_name):
@@ -142,7 +142,7 @@ class NetworkUtil:
             yield address
             return
 
-        addressing.log.debug("[#0000]  _: <RESOLVE> in: %s", address)
+        log.debug("[#0000]  _: <RESOLVE> in: %s", address)
         if resolver:
             for address in map(addressing.Address, resolver(address)):
                 log.debug("[#0000]  _: <RESOLVE> custom resolver out: %s",

--- a/src/neo4j/_async_compat/network/_util.py
+++ b/src/neo4j/_async_compat/network/_util.py
@@ -5,7 +5,7 @@ import socket
 from ... import addressing
 
 
-log = logging.getLogger("neo4j")
+log = logging.getLogger("neo4j.async_compat.network")
 
 
 def _resolved_addresses_from_info(info, host_name):

--- a/src/neo4j/_async_compat/network/_util.py
+++ b/src/neo4j/_async_compat/network/_util.py
@@ -5,7 +5,7 @@ import socket
 from ... import addressing
 
 
-log = logging.getLogger("neo4j.async_compat.network")
+log = logging.getLogger("neo4j.network")
 
 
 def _resolved_addresses_from_info(info, host_name):

--- a/src/neo4j/_routing.py
+++ b/src/neo4j/_routing.py
@@ -21,7 +21,7 @@ from time import perf_counter
 from .addressing import Address
 
 
-log = getLogger("neo4j")
+log = getLogger("neo4j.routing")
 
 
 class OrderedSet(MutableSet):

--- a/src/neo4j/_routing.py
+++ b/src/neo4j/_routing.py
@@ -21,7 +21,7 @@ from time import perf_counter
 from .addressing import Address
 
 
-log = getLogger("neo4j.routing")
+log = getLogger("neo4j.pool")
 
 
 class OrderedSet(MutableSet):

--- a/src/neo4j/_sync/auth_management.py
+++ b/src/neo4j/_sync/auth_management.py
@@ -32,7 +32,7 @@ if t.TYPE_CHECKING:
     from ..exceptions import Neo4jError
 
 
-log = getLogger("neo4j.sync")
+log = getLogger("neo4j.auth")
 
 
 class StaticAuthManager(AuthManager):

--- a/src/neo4j/_sync/auth_management.py
+++ b/src/neo4j/_sync/auth_management.py
@@ -32,7 +32,7 @@ if t.TYPE_CHECKING:
     from ..exceptions import Neo4jError
 
 
-log = getLogger("neo4j")
+log = getLogger("neo4j.sync")
 
 
 class StaticAuthManager(AuthManager):

--- a/src/neo4j/_sync/auth_management.py
+++ b/src/neo4j/_sync/auth_management.py
@@ -32,7 +32,7 @@ if t.TYPE_CHECKING:
     from ..exceptions import Neo4jError
 
 
-log = getLogger("neo4j.auth")
+log = getLogger("neo4j.auth_management")
 
 
 class StaticAuthManager(AuthManager):
@@ -67,7 +67,11 @@ class Neo4jAuthTokenManager(AuthManager):
         self._lock = Lock()
 
     def _refresh_auth(self):
-        self._current_auth = self._provider()
+        try:
+            self._current_auth = self._provider()
+        except BaseException as e:
+            log.error("[     ]  _: <AUTH MANAGER> provider failed: %r", e)
+            raise
         if self._current_auth is None:
             raise TypeError(
                 "Auth provider function passed to expiration_based "

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -57,7 +57,7 @@ from ._common import (
 
 
 # Set up logger
-log = getLogger("neo4j.bolt")
+log = getLogger("neo4j.io")
 
 
 class ServerStateManagerBase(abc.ABC):

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -57,7 +57,7 @@ from ._common import (
 
 
 # Set up logger
-log = getLogger("neo4j")
+log = getLogger("neo4j.sync.io")
 
 
 class ServerStateManagerBase(abc.ABC):

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -57,7 +57,7 @@ from ._common import (
 
 
 # Set up logger
-log = getLogger("neo4j.sync.io")
+log = getLogger("neo4j.bolt")
 
 
 class ServerStateManagerBase(abc.ABC):

--- a/src/neo4j/_sync/io/_bolt3.py
+++ b/src/neo4j/_sync/io/_bolt3.py
@@ -49,7 +49,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j")
+log = getLogger("neo4j.sync.io")
 
 
 class BoltStates(Enum):

--- a/src/neo4j/_sync/io/_bolt3.py
+++ b/src/neo4j/_sync/io/_bolt3.py
@@ -49,7 +49,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j.bolt")
+log = getLogger("neo4j.io")
 
 
 class BoltStates(Enum):

--- a/src/neo4j/_sync/io/_bolt3.py
+++ b/src/neo4j/_sync/io/_bolt3.py
@@ -49,7 +49,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j.sync.io")
+log = getLogger("neo4j.bolt")
 
 
 class BoltStates(Enum):

--- a/src/neo4j/_sync/io/_bolt4.py
+++ b/src/neo4j/_sync/io/_bolt4.py
@@ -51,7 +51,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j.sync.io")
+log = getLogger("neo4j.bolt")
 
 
 class Bolt4x0(Bolt):

--- a/src/neo4j/_sync/io/_bolt4.py
+++ b/src/neo4j/_sync/io/_bolt4.py
@@ -51,7 +51,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j.bolt")
+log = getLogger("neo4j.io")
 
 
 class Bolt4x0(Bolt):

--- a/src/neo4j/_sync/io/_bolt4.py
+++ b/src/neo4j/_sync/io/_bolt4.py
@@ -51,7 +51,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j")
+log = getLogger("neo4j.sync.io")
 
 
 class Bolt4x0(Bolt):

--- a/src/neo4j/_sync/io/_bolt5.py
+++ b/src/neo4j/_sync/io/_bolt5.py
@@ -54,7 +54,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j.bolt")
+log = getLogger("neo4j.io")
 
 
 class Bolt5x0(Bolt):

--- a/src/neo4j/_sync/io/_bolt5.py
+++ b/src/neo4j/_sync/io/_bolt5.py
@@ -54,7 +54,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j.sync.io")
+log = getLogger("neo4j.bolt")
 
 
 class Bolt5x0(Bolt):

--- a/src/neo4j/_sync/io/_bolt5.py
+++ b/src/neo4j/_sync/io/_bolt5.py
@@ -54,7 +54,7 @@ from ._common import (
 )
 
 
-log = getLogger("neo4j")
+log = getLogger("neo4j.sync.io")
 
 
 class Bolt5x0(Bolt):

--- a/src/neo4j/_sync/io/_common.py
+++ b/src/neo4j/_sync/io/_common.py
@@ -28,7 +28,7 @@ from ...exceptions import (
 )
 
 
-log = logging.getLogger("neo4j.sync.io")
+log = logging.getLogger("neo4j")
 
 
 class Inbox:

--- a/src/neo4j/_sync/io/_common.py
+++ b/src/neo4j/_sync/io/_common.py
@@ -28,7 +28,7 @@ from ...exceptions import (
 )
 
 
-log = logging.getLogger("neo4j")
+log = logging.getLogger("neo4j.sync.io")
 
 
 class Inbox:

--- a/src/neo4j/_sync/io/_common.py
+++ b/src/neo4j/_sync/io/_common.py
@@ -28,7 +28,7 @@ from ...exceptions import (
 )
 
 
-log = logging.getLogger("neo4j")
+log = logging.getLogger("neo4j.io")
 
 
 class Inbox:

--- a/src/neo4j/_sync/io/_pool.py
+++ b/src/neo4j/_sync/io/_pool.py
@@ -65,7 +65,7 @@ from ._bolt import Bolt
 
 
 # Set up logger
-log = getLogger("neo4j.sync.io")
+log = getLogger("neo4j.pool")
 
 
 @dataclass

--- a/src/neo4j/_sync/io/_pool.py
+++ b/src/neo4j/_sync/io/_pool.py
@@ -65,7 +65,7 @@ from ._bolt import Bolt
 
 
 # Set up logger
-log = getLogger("neo4j")
+log = getLogger("neo4j.sync.io")
 
 
 @dataclass

--- a/src/neo4j/_sync/work/session.py
+++ b/src/neo4j/_sync/work/session.py
@@ -61,7 +61,7 @@ if t.TYPE_CHECKING:
     _P = te.ParamSpec("_P")
 
 
-log = getLogger("neo4j")
+log = getLogger("neo4j.sync.work")
 
 
 class Session(Workspace):

--- a/src/neo4j/_sync/work/session.py
+++ b/src/neo4j/_sync/work/session.py
@@ -61,7 +61,7 @@ if t.TYPE_CHECKING:
     _P = te.ParamSpec("_P")
 
 
-log = getLogger("neo4j.sync.work")
+log = getLogger("neo4j.pool")
 
 
 class Session(Workspace):

--- a/src/neo4j/_sync/work/workspace.py
+++ b/src/neo4j/_sync/work/workspace.py
@@ -38,7 +38,7 @@ from ..io import (
 )
 
 
-log = logging.getLogger("neo4j.sync.work")
+log = logging.getLogger("neo4j.pool")
 
 
 class Workspace(NonConcurrentMethodChecker):

--- a/src/neo4j/_sync/work/workspace.py
+++ b/src/neo4j/_sync/work/workspace.py
@@ -38,7 +38,7 @@ from ..io import (
 )
 
 
-log = logging.getLogger("neo4j.pool")
+log = logging.getLogger("neo4j")
 
 
 class Workspace(NonConcurrentMethodChecker):

--- a/src/neo4j/_sync/work/workspace.py
+++ b/src/neo4j/_sync/work/workspace.py
@@ -38,7 +38,7 @@ from ..io import (
 )
 
 
-log = logging.getLogger("neo4j")
+log = logging.getLogger("neo4j.sync.work")
 
 
 class Workspace(NonConcurrentMethodChecker):

--- a/src/neo4j/addressing.py
+++ b/src/neo4j/addressing.py
@@ -30,7 +30,7 @@ if t.TYPE_CHECKING:
     import typing_extensions as te
 
 
-log = logging.getLogger("neo4j")
+log = logging.getLogger("neo4j.addressing")
 
 
 _T = t.TypeVar("_T")

--- a/src/neo4j/addressing.py
+++ b/src/neo4j/addressing.py
@@ -30,7 +30,7 @@ if t.TYPE_CHECKING:
     import typing_extensions as te
 
 
-log = logging.getLogger("neo4j.addressing")
+log = logging.getLogger("neo4j.pool")
 
 
 _T = t.TypeVar("_T")

--- a/src/neo4j/addressing.py
+++ b/src/neo4j/addressing.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import logging
 import typing as t
 from socket import (
     AddressFamily,
@@ -28,9 +27,6 @@ from socket import (
 
 if t.TYPE_CHECKING:
     import typing_extensions as te
-
-
-log = logging.getLogger("neo4j.pool")
 
 
 _T = t.TypeVar("_T")


### PR DESCRIPTION
This PR includes a refactor of the logger names in the neo4j-python-driver to adhere to a hierarchical structure. 

Moving to hierarchical loggers is a non-breaking changed designed to offer more control when managing logs and provides a mechanism for better organisation and filtering of logs. 

``` python
import logging

logger = logging.getLogger("neo4j.async.io")
logger.setLevel(logging.CRITICAL)
```