### PR TITLE
Fix unasync script for Python 3.12

### DIFF
--- a/bin/make-unasync
+++ b/bin/make-unasync
@@ -89,6 +89,16 @@ def _tokenize(f):
         last_end = tok.end
         if tok.type in [std_tokenize.NEWLINE, std_tokenize.NL]:
             last_end = (tok.end[0] + 1, 0)
+        elif (
+                sys.version_info >= (3, 12)
+                and tok.type == std_tokenize.FSTRING_MIDDLE
+        ):
+            last_end = (
+                last_end[0],
+                last_end[1]
+                + tok.string.count("{")
+                + tok.string.count("}")
+            )
 
 
 def _untokenize(tokens):
@@ -134,6 +144,12 @@ class CustomRule(unasync.Rule):
                             tokval[:1], tokval[1:-1], tokval[-1:]
                     tokval = \
                         left_quote + self._unasync_string(name) + right_quote
+                elif (
+                        sys.version_info >= (3, 12)
+                        and toknum == std_tokenize.FSTRING_MIDDLE
+                ):
+                    tokval = tokval.replace("{", "{{").replace("}", "}}")
+                    tokval = self._unasync_string(tokval)
                 if used_space is None:
                     used_space = space
                 yield (used_space, tokval)


### PR DESCRIPTION
Python 3.12 changed how f-strings are handled and what they're capable of. It's likely because of this reason that the `tokenizer` module changed how it handles f-strings as well.

When finding escaped curly brackets in an f-string (e.g., `f"{{"`) the tokenizer will only emit a single curly bracket and pretend the token ended one symbol earlier than the pair of brackets does. This PR basically hot-fixes those tokens to behave in a more consitent way by not swallowing the seconds bracket and by re-writing the token to end where the bracket pair actually ends.