### PR TITLE
Harden driver against unexpected RESET responses

### DIFF
--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -857,7 +857,7 @@ class AsyncBolt:
                  messages fetched
         """
         detail_count = summary_count = 0
-        while self.responses:
+        while not self._closed and self.responses:
             response = self.responses[0]
             while not response.complete:
                 detail_delta, summary_delta = await self.fetch_message()

--- a/src/neo4j/_async/io/_bolt3.py
+++ b/src/neo4j/_async/io/_bolt3.py
@@ -45,6 +45,7 @@ from ._common import (
     check_supported_server_product,
     CommitResponse,
     InitResponse,
+    ResetResponse,
     Response,
 )
 
@@ -391,17 +392,14 @@ class AsyncBolt3(AsyncBolt):
                      dehydration_hooks=dehydration_hooks)
 
     async def reset(self, dehydration_hooks=None, hydration_hooks=None):
-        """ Add a RESET message to the outgoing queue, send
-        it and consume all remaining messages.
+        """Reset the connection.
+
+        Add a RESET message to the outgoing queue, send it and consume all
+        remaining messages.
         """
-
-        def fail(metadata):
-            raise BoltProtocolError("RESET failed %r" % metadata, address=self.unresolved_address)
-
         log.debug("[#%04X]  C: RESET", self.local_port)
-        self._append(b"\x0F",
-                     response=Response(self, "reset", hydration_hooks,
-                                       on_failure=fail),
+        response = ResetResponse(self, "reset", hydration_hooks)
+        self._append(b"\x0F", response=response,
                      dehydration_hooks=dehydration_hooks)
         await self.send_all()
         await self.fetch_all()

--- a/src/neo4j/_async/io/_bolt4.py
+++ b/src/neo4j/_async/io/_bolt4.py
@@ -47,6 +47,7 @@ from ._common import (
     check_supported_server_product,
     CommitResponse,
     InitResponse,
+    ResetResponse,
     Response,
 )
 
@@ -311,17 +312,14 @@ class AsyncBolt4x0(AsyncBolt):
                      dehydration_hooks=dehydration_hooks)
 
     async def reset(self, dehydration_hooks=None, hydration_hooks=None):
-        """ Add a RESET message to the outgoing queue, send
-        it and consume all remaining messages.
+        """Reset the connection.
+
+        Add a RESET message to the outgoing queue, send it and consume all
+        remaining messages.
         """
-
-        def fail(metadata):
-            raise BoltProtocolError("RESET failed %r" % metadata, self.unresolved_address)
-
         log.debug("[#%04X]  C: RESET", self.local_port)
-        self._append(b"\x0F",
-                     response=Response(self, "reset", hydration_hooks,
-                                       on_failure=fail),
+        response = ResetResponse(self, "reset", hydration_hooks)
+        self._append(b"\x0F", response=response,
                      dehydration_hooks=dehydration_hooks)
         await self.send_all()
         await self.fetch_all()

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -50,6 +50,7 @@ from ._common import (
     CommitResponse,
     InitResponse,
     LogonResponse,
+    ResetResponse,
     Response,
 )
 
@@ -314,15 +315,9 @@ class AsyncBolt5x0(AsyncBolt):
         Add a RESET message to the outgoing queue, send it and consume all
         remaining messages.
         """
-
-        def fail(metadata):
-            raise BoltProtocolError("RESET failed %r" % metadata,
-                                    self.unresolved_address)
-
         log.debug("[#%04X]  C: RESET", self.local_port)
-        self._append(b"\x0F",
-                     response=Response(self, "reset", hydration_hooks,
-                                       on_failure=fail),
+        response = ResetResponse(self, "reset", hydration_hooks)
+        self._append(b"\x0F", response=response,
                      dehydration_hooks=dehydration_hooks)
         await self.send_all()
         await self.fetch_all()

--- a/src/neo4j/_async/io/_common.py
+++ b/src/neo4j/_async/io/_common.py
@@ -281,6 +281,26 @@ class LogonResponse(InitResponse):
         raise Neo4jError.hydrate(**metadata)
 
 
+class ResetResponse(Response):
+    async def _unexpected_message(self, response):
+        log.warning("[#%04X]  _: <CONNECTION> RESET received %s "
+                    "(unexpected response) => dropping connection",
+                    self.connection.local_port, response)
+        await self.connection.close()
+
+    async def on_records(self, records):
+        await self._unexpected_message("RECORD")
+
+    async def on_success(self, metadata):
+        pass
+
+    async def on_failure(self, metadata):
+        await self._unexpected_message("FAILURE")
+
+    async def on_ignored(self, metadata=None):
+        await self._unexpected_message("IGNORED")
+
+
 class CommitResponse(Response):
     pass
 

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -857,7 +857,7 @@ class Bolt:
                  messages fetched
         """
         detail_count = summary_count = 0
-        while self.responses:
+        while not self._closed and self.responses:
             response = self.responses[0]
             while not response.complete:
                 detail_delta, summary_delta = self.fetch_message()

--- a/src/neo4j/_sync/io/_bolt3.py
+++ b/src/neo4j/_sync/io/_bolt3.py
@@ -45,6 +45,7 @@ from ._common import (
     check_supported_server_product,
     CommitResponse,
     InitResponse,
+    ResetResponse,
     Response,
 )
 
@@ -391,17 +392,14 @@ class Bolt3(Bolt):
                      dehydration_hooks=dehydration_hooks)
 
     def reset(self, dehydration_hooks=None, hydration_hooks=None):
-        """ Add a RESET message to the outgoing queue, send
-        it and consume all remaining messages.
+        """Reset the connection.
+
+        Add a RESET message to the outgoing queue, send it and consume all
+        remaining messages.
         """
-
-        def fail(metadata):
-            raise BoltProtocolError("RESET failed %r" % metadata, address=self.unresolved_address)
-
         log.debug("[#%04X]  C: RESET", self.local_port)
-        self._append(b"\x0F",
-                     response=Response(self, "reset", hydration_hooks,
-                                       on_failure=fail),
+        response = ResetResponse(self, "reset", hydration_hooks)
+        self._append(b"\x0F", response=response,
                      dehydration_hooks=dehydration_hooks)
         self.send_all()
         self.fetch_all()

--- a/src/neo4j/_sync/io/_bolt4.py
+++ b/src/neo4j/_sync/io/_bolt4.py
@@ -47,6 +47,7 @@ from ._common import (
     check_supported_server_product,
     CommitResponse,
     InitResponse,
+    ResetResponse,
     Response,
 )
 
@@ -311,17 +312,14 @@ class Bolt4x0(Bolt):
                      dehydration_hooks=dehydration_hooks)
 
     def reset(self, dehydration_hooks=None, hydration_hooks=None):
-        """ Add a RESET message to the outgoing queue, send
-        it and consume all remaining messages.
+        """Reset the connection.
+
+        Add a RESET message to the outgoing queue, send it and consume all
+        remaining messages.
         """
-
-        def fail(metadata):
-            raise BoltProtocolError("RESET failed %r" % metadata, self.unresolved_address)
-
         log.debug("[#%04X]  C: RESET", self.local_port)
-        self._append(b"\x0F",
-                     response=Response(self, "reset", hydration_hooks,
-                                       on_failure=fail),
+        response = ResetResponse(self, "reset", hydration_hooks)
+        self._append(b"\x0F", response=response,
                      dehydration_hooks=dehydration_hooks)
         self.send_all()
         self.fetch_all()

--- a/src/neo4j/_sync/io/_bolt5.py
+++ b/src/neo4j/_sync/io/_bolt5.py
@@ -50,6 +50,7 @@ from ._common import (
     CommitResponse,
     InitResponse,
     LogonResponse,
+    ResetResponse,
     Response,
 )
 
@@ -314,15 +315,9 @@ class Bolt5x0(Bolt):
         Add a RESET message to the outgoing queue, send it and consume all
         remaining messages.
         """
-
-        def fail(metadata):
-            raise BoltProtocolError("RESET failed %r" % metadata,
-                                    self.unresolved_address)
-
         log.debug("[#%04X]  C: RESET", self.local_port)
-        self._append(b"\x0F",
-                     response=Response(self, "reset", hydration_hooks,
-                                       on_failure=fail),
+        response = ResetResponse(self, "reset", hydration_hooks)
+        self._append(b"\x0F", response=response,
                      dehydration_hooks=dehydration_hooks)
         self.send_all()
         self.fetch_all()

--- a/src/neo4j/_sync/io/_common.py
+++ b/src/neo4j/_sync/io/_common.py
@@ -281,6 +281,26 @@ class LogonResponse(InitResponse):
         raise Neo4jError.hydrate(**metadata)
 
 
+class ResetResponse(Response):
+    def _unexpected_message(self, response):
+        log.warning("[#%04X]  _: <CONNECTION> RESET received %s "
+                    "(unexpected response) => dropping connection",
+                    self.connection.local_port, response)
+        self.connection.close()
+
+    def on_records(self, records):
+        self._unexpected_message("RECORD")
+
+    def on_success(self, metadata):
+        pass
+
+    def on_failure(self, metadata):
+        self._unexpected_message("FAILURE")
+
+    def on_ignored(self, metadata=None):
+        self._unexpected_message("IGNORED")
+
+
 class CommitResponse(Response):
     pass
 


### PR DESCRIPTION
The server has been observed to reply with `FAILURE` and `IGNORED` to `RESET` requests. The former is according to spec and the driver should drop the connection (which it didn't), the latter isn't.

The right combination of those two unexpected responses at the right time could get the driver stuck in an infinite loop.

This change makes the driver drop the connection in either case to gracefully handle the situation.