### PR TITLE
Docs: fix minimum required server version

### DIFF
--- a/src/neo4j/_api.py
+++ b/src/neo4j/_api.py
@@ -151,9 +151,8 @@ class NotificationDisabledCategory(str, Enum):
     PERFORMANCE = "PERFORMANCE"
     DEPRECATION = "DEPRECATION"
     GENERIC = "GENERIC"
-    #: Requires server version 5.14 or newer.
     SECURITY = "SECURITY"
-    #: Requires server version 5.14 or newer.
+    #: Requires server version 5.13 or newer.
     TOPOLOGY = "TOPOLOGY"
 
 


### PR DESCRIPTION
The notification category `TOPOLOGY` was introduced in Neo4j 5.13, not 5.14.

The category `SECURITY` has existed since at least 5.7, which is the minimum required version for notification filtering. 