### PR TITLE
API docs: improve result stream

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1347,9 +1347,9 @@ A :class:`neo4j.Result` is attached to an active connection, through a :class:`n
 
 .. autoclass:: neo4j.Result()
 
-    .. describe:: iter(result)
+    .. automethod:: __iter__
 
-    .. describe:: next(result)
+    .. automethod:: __next__
 
     .. automethod:: keys
 

--- a/docs/source/async_api.rst
+++ b/docs/source/async_api.rst
@@ -865,11 +865,9 @@ A :class:`neo4j.AsyncResult` is attached to an active connection, through a :cla
 
 .. autoclass:: neo4j.AsyncResult()
 
-    .. method:: __aiter__()
-        :async:
+    .. automethod:: __aiter__()
 
-    .. method:: __anext__()
-        :async:
+    .. automethod:: __anext__()
 
     .. automethod:: keys
 

--- a/src/neo4j/_async/work/result.py
+++ b/src/neo4j/_async/work/result.py
@@ -286,7 +286,10 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
 
     @AsyncNonConcurrentMethodChecker.non_concurrent_method
     async def __anext__(self) -> Record:
-        """Advance the result stream and return the record."""
+        """Advance the result stream and return the record.
+
+        :raises StopAsyncIteration: if no more records are available.
+        """
         return await self.__aiter__().__anext__()
 
     async def _attach(self):

--- a/src/neo4j/_sync/work/result.py
+++ b/src/neo4j/_sync/work/result.py
@@ -286,7 +286,10 @@ class Result(NonConcurrentMethodChecker):
 
     @NonConcurrentMethodChecker.non_concurrent_method
     def __next__(self) -> Record:
-        """Advance the result stream and return the record."""
+        """Advance the result stream and return the record.
+
+        :raises StopIteration: if no more records are available.
+        """
         return self.__iter__().__next__()
 
     def _attach(self):


### PR DESCRIPTION
 * Show `__aiter__` and `__anext__` methods' docs string and type annotations.
 * Mention `StopAsyncIteration` exception raised by `__atier__`.
 * Same corresponding changes to the sync API.