### PR TITLE
[4.4] Fix ITs in TeamCity

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -92,7 +92,9 @@ class Neo4jService(object):
 
     def stop(self, timeout=None):
         from shutil import rmtree
-        self.controller.stop()
+        # Killing the process as waiting for it to gracefully shutdown
+        # timed out on team city, not sure why.
+        self.controller.stop(kill=True)
         rmtree(self.home)
 
     def machines(self):


### PR DESCRIPTION
For god know what reason (couldn't reproduce locally, tried every trick in the book), boltkit shutting down Neo4j after the ITs would timeout consistently in TeamCity. Since the service is (at least currently) started and stopped for the whole test session, not per test, there's little risk in just killing it instead of gracefully shutting it down.