### PR TITLE
Mitigate errors during resource warning on interpreter shutdown

### DIFF
--- a/src/neo4j/_async/driver.py
+++ b/src/neo4j/_async/driver.py
@@ -503,20 +503,27 @@ class AsyncDriver:
     async def __aexit__(self, exc_type, exc_value, traceback):
         await self.close()
 
-    def __del__(self):
+    # Copy globals as function locals to make sure that they are available
+    # during Python shutdown when the Pool is destroyed.
+    def __del__(
+        self, _unclosed_resource_warn=unclosed_resource_warn,
+        _is_async_code=AsyncUtil.is_async_code,
+        _deprecation_warn=deprecation_warn,
+    ):
         if not self._closed:
-            unclosed_resource_warn(self)
+            _unclosed_resource_warn(self)
         # TODO: 6.0 - remove this
+        if _is_async_code:
+            return
         if not self._closed:
-            if not AsyncUtil.is_async_code:
-                deprecation_warn(
-                    "Relying on AsyncDriver's destructor to close the session "
-                    "is deprecated. Please make sure to close the session. "
-                    "Use it as a context (`with` statement) or make sure to "
-                    "call `.close()` explicitly. Future versions of the "
-                    "driver will not close drivers automatically."
-                )
-                self.close()
+            _deprecation_warn(
+                "Relying on AsyncDriver's destructor to close the session "
+                "is deprecated. Please make sure to close the session. "
+                "Use it as a context (`with` statement) or make sure to "
+                "call `.close()` explicitly. Future versions of the "
+                "driver will not close drivers automatically."
+            )
+            self.close()
 
     def _check_state(self):
         if self._closed:

--- a/src/neo4j/_async/work/workspace.py
+++ b/src/neo4j/_async/work/workspace.py
@@ -59,15 +59,19 @@ class AsyncWorkspace(AsyncNonConcurrentMethodChecker):
         self._closed = False
         super().__init__()
 
-    def __del__(self):
+    def __del__(
+        self, _unclosed_resource_warn=unclosed_resource_warn,
+        _is_async_code=AsyncUtil.is_async_code,
+        _deprecation_warn=deprecation_warn,
+    ):
         if self._closed:
             return
-        unclosed_resource_warn(self)
+        _unclosed_resource_warn(self)
         # TODO: 6.0 - remove this
-        if asyncio.iscoroutinefunction(self.close):
+        if _is_async_code:
             return
         try:
-            deprecation_warn(
+            _deprecation_warn(
                 "Relying on AsyncSession's destructor to close the session "
                 "is deprecated. Please make sure to close the session. Use it "
                 "as a context (`with` statement) or make sure to call "

--- a/src/neo4j/_sync/work/workspace.py
+++ b/src/neo4j/_sync/work/workspace.py
@@ -59,15 +59,19 @@ class Workspace(NonConcurrentMethodChecker):
         self._closed = False
         super().__init__()
 
-    def __del__(self):
+    def __del__(
+        self, _unclosed_resource_warn=unclosed_resource_warn,
+        _is_async_code=Util.is_async_code,
+        _deprecation_warn=deprecation_warn,
+    ):
         if self._closed:
             return
-        unclosed_resource_warn(self)
+        _unclosed_resource_warn(self)
         # TODO: 6.0 - remove this
-        if asyncio.iscoroutinefunction(self.close):
+        if _is_async_code:
             return
         try:
-            deprecation_warn(
+            _deprecation_warn(
                 "Relying on Session's destructor to close the session "
                 "is deprecated. Please make sure to close the session. Use it "
                 "as a context (`with` statement) or make sure to call "


### PR DESCRIPTION
According to https://github.com/neo4j/neo4j-python-driver/issues/1024 errors can still happend during interpreter shutdown when user code is not closing the driver properly. This PR should hopefully fix this for good (1st attempt made here https://github.com/neo4j/neo4j-python-driver/pull/942).

The solution is inspired from Python's std lib. See https://github.com/python/cpython/blob/v3.12.3/Lib/multiprocessing/pool.py#L264-L271