### PR TITLE
[4.4] Invalidate writers per database

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -105,6 +105,16 @@ from neo4j.routing import RoutingTable
 log = getLogger("neo4j")
 
 
+class ClientStateManagerBase(abc.ABC):
+    @abc.abstractmethod
+    def __init__(self, init_state, on_change=None):
+        ...
+
+    @abc.abstractmethod
+    def transition(self, message):
+        ...
+
+
 class Bolt(abc.ABC):
     """ Server connection for Bolt protocol.
 
@@ -124,6 +134,10 @@ class Bolt(abc.ABC):
 
     # The socket
     in_use = False
+
+    # The database name the connection was last used with
+    # (BEGIN for explicit transactions, RUN for auto-commit transactions)
+    last_database = None
 
     # The socket
     _closing = False
@@ -400,6 +414,10 @@ class Bolt(abc.ABC):
             pass
 
     @abc.abstractmethod
+    def _get_client_state_manager(self):
+        ...
+
+    @abc.abstractmethod
     def route(self, database=None, imp_user=None, bookmarks=None):
         """ Fetch a routing table from the server for the given
         `database`. For Bolt 4.3 and above, this appends a ROUTE
@@ -504,6 +522,8 @@ class Bolt(abc.ABC):
             self.packer.pack_struct(signature, fields)
         self.outbox.wrap_message()
         self.responses.append(response)
+        if response:
+            self._get_client_state_manager().transition(response.message)
 
     def _send_all(self):
         with self.outbox.view() as data:
@@ -867,8 +887,10 @@ class IOPool:
             if not self.connections[address]:
                 del self.connections[address]
 
-    def on_write_failure(self, address):
-        raise WriteServiceUnavailable("No write service available for pool {}".format(self))
+    def on_write_failure(self, address, database):
+        raise WriteServiceUnavailable(
+            "No write service available for pool {}".format(self)
+        )
 
     def close(self):
         """ Close all connections and empty the pool.
@@ -1342,12 +1364,14 @@ class Neo4jPool(IOPool):
         log.debug("[#0000]  C: <ROUTING> table=%r", self.routing_tables)
         super(Neo4jPool, self).deactivate(address)
 
-    def on_write_failure(self, address):
+    def on_write_failure(self, address, database):
         """ Remove a writer address from the routing table, if present.
         """
-        log.debug("[#0000]  C: <ROUTING> Removing writer %r", address)
+        log.debug("[#0000]  C: <ROUTING> Removing writer %r for database %r",
+                  address, database)
         with self.refresh_lock:
-            for database in self.routing_tables.keys():
+            table = self.routing_tables.get(database)
+            if table is not None:
                 self.routing_tables[database].writers.discard(address)
         log.debug("[#0000]  C: <ROUTING> table=%r", self.routing_tables)
 

--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -1372,7 +1372,7 @@ class Neo4jPool(IOPool):
         with self.refresh_lock:
             table = self.routing_tables.get(database)
             if table is not None:
-                self.routing_tables[database].writers.discard(address)
+                table.writers.discard(address)
         log.debug("[#0000]  C: <ROUTING> table=%r", self.routing_tables)
 
 

--- a/neo4j/io/_bolt.py
+++ b/neo4j/io/_bolt.py
@@ -1,0 +1,29 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [http://neo4j.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import abc
+
+
+class ClientStateManagerBase(abc.ABC):
+    @abc.abstractmethod
+    def __init__(self, init_state, on_change=None):
+        ...
+
+    @abc.abstractmethod
+    def transition(self, message):
+        ...

--- a/tests/unit/io/test_class_bolt3.py
+++ b/tests/unit/io/test_class_bolt3.py
@@ -18,10 +18,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
+import itertools
 from unittest.mock import MagicMock
 
 import pytest
 
+from neo4j import Address
 from neo4j.io._bolt3 import Bolt3
 from neo4j.conf import PoolConfig
 from neo4j.exceptions import (
@@ -110,3 +113,75 @@ def test_hint_recv_timeout_seconds_gets_ignored(fake_socket_pair, recv_timeout):
                        PoolConfig.max_connection_lifetime)
     connection.hello()
     sockets.client.settimeout.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "actions",
+    itertools.combinations_with_replacement(
+        itertools.product(
+            ("run", "begin", "begin_run"),
+            ("reset", "commit", "rollback"),
+            (None, "some_db", "another_db"),
+        ),
+        2
+    )
+)
+def test_tracks_last_database(fake_socket_pair, actions):
+    address = Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address)
+    connection = Bolt3(address, sockets.client, 0)
+    sockets.server.send_message(0x70, {"server": "Neo4j/1.2.3"})
+    connection.hello()
+    assert connection.last_database is None
+    for action, finish, db in actions:
+        sockets.server.send_message(0x70, {})
+        if action == "run":
+            with raises_if_db(db):
+                connection.run("RETURN 1", db=db)
+        elif action == "begin":
+            with raises_if_db(db):
+                connection.begin(db=db)
+        elif action == "begin_run":
+            with raises_if_db(db):
+                connection.begin(db=db)
+            assert connection.last_database is None
+            sockets.server.send_message(0x70, {})
+            connection.run("RETURN 1")
+        else:
+            raise ValueError(action)
+
+        assert connection.last_database is None
+        connection.send_all()
+        connection.fetch_all()
+        assert connection.last_database is None
+
+        sockets.server.send_message(0x70, {})
+        if finish == "reset":
+            connection.reset()
+        elif finish == "commit":
+            if action == "run":
+                connection.pull()
+            else:
+                connection.commit()
+        elif finish == "rollback":
+            if action == "run":
+                connection.pull()
+            else:
+                connection.rollback()
+        else:
+            raise ValueError(finish)
+
+        connection.send_all()
+        connection.fetch_all()
+
+        assert connection.last_database is None
+
+
+@contextlib.contextmanager
+def raises_if_db(db):
+    if db is None:
+        yield
+    else:
+        with pytest.raises(ConfigurationError,
+                           match="selecting database is not supported"):
+            yield

--- a/tests/unit/io/test_class_bolt4x0.py
+++ b/tests/unit/io/test_class_bolt4x0.py
@@ -18,10 +18,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 from unittest.mock import MagicMock
 
 import pytest
 
+from neo4j import Address
 from neo4j.io._bolt4 import Bolt4x0
 from neo4j.conf import PoolConfig
 
@@ -197,3 +199,62 @@ def test_hint_recv_timeout_seconds_gets_ignored(fake_socket_pair, recv_timeout):
                          PoolConfig.max_connection_lifetime)
     connection.hello()
     sockets.client.settimeout.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "actions",
+    itertools.combinations_with_replacement(
+        itertools.product(
+            ("run", "begin", "begin_run"),
+            ("reset", "commit", "rollback"),
+            (None, "some_db", "another_db"),
+        ),
+        2
+    )
+)
+def test_tracks_last_database(fake_socket_pair, actions):
+    address = Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address)
+    connection = Bolt4x0(address, sockets.client, 0)
+    sockets.server.send_message(0x70, {"server": "Neo4j/1.2.3"})
+    connection.hello()
+    assert connection.last_database is None
+    for action, finish, db in actions:
+        sockets.server.send_message(0x70, {})
+        if action == "run":
+            connection.run("RETURN 1", db=db)
+        elif action == "begin":
+            connection.begin(db=db)
+        elif action == "begin_run":
+            connection.begin(db=db)
+            assert connection.last_database == db
+            sockets.server.send_message(0x70, {})
+            connection.run("RETURN 1")
+        else:
+            raise ValueError(action)
+
+        assert connection.last_database == db
+        connection.send_all()
+        connection.fetch_all()
+        assert connection.last_database == db
+
+        sockets.server.send_message(0x70, {})
+        if finish == "reset":
+            connection.reset()
+        elif finish == "commit":
+            if action == "run":
+                connection.pull()
+            else:
+                connection.commit()
+        elif finish == "rollback":
+            if action == "run":
+                connection.pull()
+            else:
+                connection.rollback()
+        else:
+            raise ValueError(finish)
+
+        connection.send_all()
+        connection.fetch_all()
+
+        assert connection.last_database == db

--- a/tests/unit/io/test_class_bolt4x1.py
+++ b/tests/unit/io/test_class_bolt4x1.py
@@ -18,10 +18,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 from unittest.mock import MagicMock
 
 import pytest
 
+from neo4j import Address
 from neo4j.io._bolt4 import Bolt4x1
 from neo4j.conf import PoolConfig
 
@@ -210,3 +212,62 @@ def test_hint_recv_timeout_seconds_gets_ignored(fake_socket_pair, recv_timeout):
                          PoolConfig.max_connection_lifetime)
     connection.hello()
     sockets.client.settimeout.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "actions",
+    itertools.combinations_with_replacement(
+        itertools.product(
+            ("run", "begin", "begin_run"),
+            ("reset", "commit", "rollback"),
+            (None, "some_db", "another_db"),
+        ),
+        2
+    )
+)
+def test_tracks_last_database(fake_socket_pair, actions):
+    address = Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address)
+    connection = Bolt4x1(address, sockets.client, 0)
+    sockets.server.send_message(0x70, {"server": "Neo4j/1.2.3"})
+    connection.hello()
+    assert connection.last_database is None
+    for action, finish, db in actions:
+        sockets.server.send_message(0x70, {})
+        if action == "run":
+            connection.run("RETURN 1", db=db)
+        elif action == "begin":
+            connection.begin(db=db)
+        elif action == "begin_run":
+            connection.begin(db=db)
+            assert connection.last_database == db
+            sockets.server.send_message(0x70, {})
+            connection.run("RETURN 1")
+        else:
+            raise ValueError(action)
+
+        assert connection.last_database == db
+        connection.send_all()
+        connection.fetch_all()
+        assert connection.last_database == db
+
+        sockets.server.send_message(0x70, {})
+        if finish == "reset":
+            connection.reset()
+        elif finish == "commit":
+            if action == "run":
+                connection.pull()
+            else:
+                connection.commit()
+        elif finish == "rollback":
+            if action == "run":
+                connection.pull()
+            else:
+                connection.rollback()
+        else:
+            raise ValueError(finish)
+
+        connection.send_all()
+        connection.fetch_all()
+
+        assert connection.last_database == db

--- a/tests/unit/io/test_class_bolt4x2.py
+++ b/tests/unit/io/test_class_bolt4x2.py
@@ -19,10 +19,12 @@
 # limitations under the License.
 
 
+import itertools
 from unittest.mock import MagicMock
 
 import pytest
 
+from neo4j import Address
 from neo4j.io._bolt4 import Bolt4x2
 from neo4j.conf import PoolConfig
 
@@ -211,3 +213,62 @@ def test_hint_recv_timeout_seconds_gets_ignored(fake_socket_pair, recv_timeout):
                          PoolConfig.max_connection_lifetime)
     connection.hello()
     sockets.client.settimeout.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "actions",
+    itertools.combinations_with_replacement(
+        itertools.product(
+            ("run", "begin", "begin_run"),
+            ("reset", "commit", "rollback"),
+            (None, "some_db", "another_db"),
+        ),
+        2
+    )
+)
+def test_tracks_last_database(fake_socket_pair, actions):
+    address = Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address)
+    connection = Bolt4x2(address, sockets.client, 0)
+    sockets.server.send_message(0x70, {"server": "Neo4j/1.2.3"})
+    connection.hello()
+    assert connection.last_database is None
+    for action, finish, db in actions:
+        sockets.server.send_message(0x70, {})
+        if action == "run":
+            connection.run("RETURN 1", db=db)
+        elif action == "begin":
+            connection.begin(db=db)
+        elif action == "begin_run":
+            connection.begin(db=db)
+            assert connection.last_database == db
+            sockets.server.send_message(0x70, {})
+            connection.run("RETURN 1")
+        else:
+            raise ValueError(action)
+
+        assert connection.last_database == db
+        connection.send_all()
+        connection.fetch_all()
+        assert connection.last_database == db
+
+        sockets.server.send_message(0x70, {})
+        if finish == "reset":
+            connection.reset()
+        elif finish == "commit":
+            if action == "run":
+                connection.pull()
+            else:
+                connection.commit()
+        elif finish == "rollback":
+            if action == "run":
+                connection.pull()
+            else:
+                connection.rollback()
+        else:
+            raise ValueError(finish)
+
+        connection.send_all()
+        connection.fetch_all()
+
+        assert connection.last_database == db

--- a/tests/unit/io/test_class_bolt4x3.py
+++ b/tests/unit/io/test_class_bolt4x3.py
@@ -18,11 +18,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import logging
 from unittest.mock import MagicMock
 
 import pytest
 
+from neo4j import Address
 from neo4j.io._bolt4 import Bolt4x3
 from neo4j.conf import PoolConfig
 
@@ -237,3 +239,62 @@ def test_hint_recv_timeout_seconds(fake_socket_pair, hints, valid,
                    and "recv_timeout_seconds" in msg
                    and "invalid" in msg
                    for msg in caplog.messages)
+
+
+@pytest.mark.parametrize(
+    "actions",
+    itertools.combinations_with_replacement(
+        itertools.product(
+            ("run", "begin", "begin_run"),
+            ("reset", "commit", "rollback"),
+            (None, "some_db", "another_db"),
+        ),
+        2
+    )
+)
+def test_tracks_last_database(fake_socket_pair, actions):
+    address = Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address)
+    connection = Bolt4x3(address, sockets.client, 0)
+    sockets.server.send_message(0x70, {"server": "Neo4j/1.2.3"})
+    connection.hello()
+    assert connection.last_database is None
+    for action, finish, db in actions:
+        sockets.server.send_message(0x70, {})
+        if action == "run":
+            connection.run("RETURN 1", db=db)
+        elif action == "begin":
+            connection.begin(db=db)
+        elif action == "begin_run":
+            connection.begin(db=db)
+            assert connection.last_database == db
+            sockets.server.send_message(0x70, {})
+            connection.run("RETURN 1")
+        else:
+            raise ValueError(action)
+
+        assert connection.last_database == db
+        connection.send_all()
+        connection.fetch_all()
+        assert connection.last_database == db
+
+        sockets.server.send_message(0x70, {})
+        if finish == "reset":
+            connection.reset()
+        elif finish == "commit":
+            if action == "run":
+                connection.pull()
+            else:
+                connection.commit()
+        elif finish == "rollback":
+            if action == "run":
+                connection.pull()
+            else:
+                connection.rollback()
+        else:
+            raise ValueError(finish)
+
+        connection.send_all()
+        connection.fetch_all()
+
+        assert connection.last_database == db

--- a/tests/unit/io/test_class_bolt4x4.py
+++ b/tests/unit/io/test_class_bolt4x4.py
@@ -18,11 +18,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import logging
 from unittest.mock import MagicMock
 
 import pytest
 
+from neo4j import Address
 from neo4j.io._bolt4 import Bolt4x4
 from neo4j.conf import PoolConfig
 
@@ -249,3 +251,62 @@ def test_hint_recv_timeout_seconds(fake_socket_pair, hints, valid,
                    and "recv_timeout_seconds" in msg
                    and "invalid" in msg
                    for msg in caplog.messages)
+
+
+@pytest.mark.parametrize(
+    "actions",
+    itertools.combinations_with_replacement(
+        itertools.product(
+            ("run", "begin", "begin_run"),
+            ("reset", "commit", "rollback"),
+            (None, "some_db", "another_db"),
+        ),
+        2
+    )
+)
+def test_tracks_last_database(fake_socket_pair, actions):
+    address = Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(address)
+    connection = Bolt4x4(address, sockets.client, 0)
+    sockets.server.send_message(0x70, {"server": "Neo4j/1.2.3"})
+    connection.hello()
+    assert connection.last_database is None
+    for action, finish, db in actions:
+        sockets.server.send_message(0x70, {})
+        if action == "run":
+            connection.run("RETURN 1", db=db)
+        elif action == "begin":
+            connection.begin(db=db)
+        elif action == "begin_run":
+            connection.begin(db=db)
+            assert connection.last_database == db
+            sockets.server.send_message(0x70, {})
+            connection.run("RETURN 1")
+        else:
+            raise ValueError(action)
+
+        assert connection.last_database == db
+        connection.send_all()
+        connection.fetch_all()
+        assert connection.last_database == db
+
+        sockets.server.send_message(0x70, {})
+        if finish == "reset":
+            connection.reset()
+        elif finish == "commit":
+            if action == "run":
+                connection.pull()
+            else:
+                connection.commit()
+        elif finish == "rollback":
+            if action == "run":
+                connection.pull()
+            else:
+                connection.rollback()
+        else:
+            raise ValueError(finish)
+
+        connection.send_all()
+        connection.fetch_all()
+
+        assert connection.last_database == db


### PR DESCRIPTION
This should improve the performance of the driver in multi database use-cases. The driver now only removes a server as a writer for a single database (before for all databases) if that server returns an error that notifies the driver that the server is no longer a writer (`Neo.ClientError.Cluster.NotALeader` or `Neo.ClientError.General.ForbiddenOnReadOnlyDatabase`).

Backport of: https://github.com/neo4j/neo4j-python-driver/pull/959