### PR TITLE
[4.4] Fix: use cached port for logging

### DIFF
--- a/neo4j/io/__init__.py
+++ b/neo4j/io/__init__.py
@@ -588,7 +588,7 @@ class Bolt(abc.ABC):
         direct_driver = isinstance(self.pool, BoltPool)
 
         if error:
-            log.debug("[#%04X]  %r", self.socket.getsockname()[1], error)
+            log.debug("[#%04X]  %r", self.local_port, error)
         log.error(message)
         # We were attempting to receive data but the connection
         # has unexpectedly terminated. So, we need to close the


### PR DESCRIPTION
Especially in the error handler, it's worth using the cached port as the underlying socket might already have been close which can lead to errors masking the actual exception that should be surfaced to the user instead.