### PR TITLE
CI: fix release scripts to work with PEP 625

### DIFF
--- a/bin/check-dist
+++ b/bin/check-dist
@@ -13,8 +13,10 @@ then
     exit 1
 else
     source "${ROOT}/bin/dist-functions"
-    check_file "${DIST}/neo4j-driver-${VERSION}.tar.gz"
-    check_file "${DIST}/neo4j-${VERSION}.tar.gz"
+    for PACKAGE in "neo4j-driver" "neo4j"; do
+        PACKAGE="$(normalize_dist_name "$PACKAGE")"
+        check_file "${DIST}/${PACKAGE}-${VERSION}.tar.gz"
+    done
 fi
 
 exit ${STATUS}

--- a/bin/check-dist
+++ b/bin/check-dist
@@ -14,8 +14,11 @@ then
 else
     source "${ROOT}/bin/dist-functions"
     for PACKAGE in "neo4j-driver" "neo4j"; do
-        PACKAGE="$(normalize_dist_name "$PACKAGE")"
-        check_file "${DIST}/${PACKAGE}-${VERSION}.tar.gz"
+        NORMALIZED_PACKAGE="$(normalize_dist_name "$PACKAGE")"
+        if ! (check_file "${DIST}/${NORMALIZED_PACKAGE}-${VERSION}.tar.gz" \
+              || check_file "${DIST}/${PACKAGE}-${VERSION}.tar.gz"); then
+            STATUS=1
+        fi
     done
 fi
 

--- a/bin/dist-functions
+++ b/bin/dist-functions
@@ -39,10 +39,16 @@ function set_deprecated {
     sed -i 's/^deprecated_package = .*/deprecated_package = '$1'/g' "${SRC}/neo4j/_meta.py"
 }
 
+# distribution normalization according to PEP 625 https://peps.python.org/pep-0625/
+function normalize_dist_name
+{
+    echo $1 | sed 's/[._-]\+/_/g' | tr '[:upper:]' '[:lower:]'
+}
+
 function check_file
 {
     FILE=$1
-    echo -n "Checking file $(basename ${FILE})... "
+    echo -n "Checking file $(basename "${FILE}")... "
     if [ -f "${FILE}" ]
     then
         echo "OK"
@@ -100,7 +106,7 @@ function set_metadata_and_setup
     find . -name *.pyc -delete
     rm -rf "${SRC}/*.egg-info" 2> /dev/null
     python -m build $*
-    check_file "${DIST}/${PACKAGE}-${VERSION}.tar.gz"
+    check_file "${DIST}/$(normalize_dist_name $PACKAGE)-${VERSION}.tar.gz"
 
     trap - EXIT
     cleanup

--- a/bin/dist-functions
+++ b/bin/dist-functions
@@ -52,9 +52,10 @@ function check_file
     if [ -f "${FILE}" ]
     then
         echo "OK"
+        return 0
     else
         echo "missing"
-        STATUS=1
+        return 1
     fi
 }
 
@@ -106,7 +107,11 @@ function set_metadata_and_setup
     find . -name *.pyc -delete
     rm -rf "${SRC}/*.egg-info" 2> /dev/null
     python -m build $*
-    check_file "${DIST}/$(normalize_dist_name $PACKAGE)-${VERSION}.tar.gz"
+    NORMALIZED_PACKAGE="$(normalize_dist_name $PACKAGE)"
+    if ! (check_file "${DIST}/${NORMALIZED_PACKAGE}-${VERSION}.tar.gz" \
+          || check_file "${DIST}/${PACKAGE}-${VERSION}.tar.gz"); then
+        STATUS=1
+    fi
 
     trap - EXIT
     cleanup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ pyarrow = ["pyarrow >= 1.0.0"]
 
 [build-system]
 requires = [
-    "setuptools >= 69.3.0",
+    "setuptools >= 66.1.0",
     # TODO: 6.0 - can be removed once `setup.py` is simplified
     "tomlkit ~= 0.11.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ pyarrow = ["pyarrow >= 1.0.0"]
 
 [build-system]
 requires = [
-    "setuptools >= 66.1.0",
+    "setuptools >= 69.3.0",
     # TODO: 6.0 - can be removed once `setup.py` is simplified
     "tomlkit ~= 0.11.6",
 ]


### PR DESCRIPTION
With version 69.3.0, setuptools started naming dist archives according to PEP 625. This broke our release scripts.