### PR TITLE
[4.4] CI: fix release scripts to work with PEP 625

### DIFF
--- a/bin/check-dist
+++ b/bin/check-dist
@@ -13,8 +13,13 @@ then
     exit 1
 else
     source "${ROOT}/bin/dist-functions"
-    check_file "${DIST}/neo4j-driver-${VERSION}.tar.gz"
-    check_file "${DIST}/neo4j-${VERSION}.tar.gz"
+    for PACKAGE in "neo4j-driver" "neo4j"; do
+        NORMALIZED_PACKAGE="$(normalize_dist_name "$PACKAGE")"
+        if ! (check_file "${DIST}/${NORMALIZED_PACKAGE}-${VERSION}.tar.gz" \
+              || check_file "${DIST}/${PACKAGE}-${VERSION}.tar.gz"); then
+            STATUS=1
+        fi
+    done
 fi
 
 exit ${STATUS}

--- a/bin/dist-functions
+++ b/bin/dist-functions
@@ -24,16 +24,23 @@ function set_version
     sed -i 's/^version = .*/version = "'$1'"/g' neo4j/meta.py
 }
 
+# distribution normalization according to PEP 625 https://peps.python.org/pep-0625/
+function normalize_dist_name
+{
+    echo $1 | sed 's/[._-]\+/_/g' | tr '[:upper:]' '[:lower:]'
+}
+
 function check_file
 {
     FILE=$1
-    echo -n "Checking file $(basename ${FILE})... "
+    echo -n "Checking file $(basename "${FILE}")... "
     if [ -f "${FILE}" ]
     then
         echo "OK"
+        return 0
     else
         echo "missing"
-        STATUS=1
+        return 1
     fi
 }
 
@@ -76,9 +83,13 @@ function set_metadata_and_setup
 
     # Create source distribution
     find . -name *.pyc -delete
-    rm -rf ${ROOT}/*.egg-info 2> /dev/null
+    rm -rf "${ROOT}/*.egg-info" 2> /dev/null
     python setup.py $*
-    check_file "${DIST}/${PACKAGE}-${VERSION}.tar.gz"
+    NORMALIZED_PACKAGE="$(normalize_dist_name $PACKAGE)"
+    if ! (check_file "${DIST}/${NORMALIZED_PACKAGE}-${VERSION}.tar.gz" \
+          || check_file "${DIST}/${PACKAGE}-${VERSION}.tar.gz"); then
+        STATUS=1
+    fi
 
   trap - EXIT
   cleanup


### PR DESCRIPTION
With version 69.3.0, setuptools started naming dist archives according to PEP 625. This broke our release scripts.

Backport of: https://github.com/neo4j/neo4j-python-driver/pull/1050