### PR TITLE
Fix Notification.description polyfill from GqlStatusObject

### DIFF
--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -284,6 +284,7 @@ class AsyncBolt:
             AsyncBolt5x3,
             AsyncBolt5x4,
             AsyncBolt5x5,
+            AsyncBolt5x6,
         )
 
         handlers = {
@@ -299,6 +300,7 @@ class AsyncBolt:
             AsyncBolt5x3.PROTOCOL_VERSION: AsyncBolt5x3,
             AsyncBolt5x4.PROTOCOL_VERSION: AsyncBolt5x4,
             AsyncBolt5x5.PROTOCOL_VERSION: AsyncBolt5x5,
+            AsyncBolt5x6.PROTOCOL_VERSION: AsyncBolt5x6,
         }
 
         if protocol_version is None:
@@ -413,7 +415,10 @@ class AsyncBolt:
 
         # Carry out Bolt subclass imports locally to avoid circular dependency
         # issues.
-        if protocol_version == (5, 5):
+        if protocol_version == (5, 6):
+            from ._bolt5 import AsyncBolt5x6
+            bolt_cls = AsyncBolt5x6
+        elif protocol_version == (5, 5):
             from ._bolt5 import AsyncBolt5x5
             bolt_cls = AsyncBolt5x5
         elif protocol_version == (5, 4):

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -685,6 +685,7 @@ class AsyncBolt5x4(AsyncBolt5x3):
                      Response(self, "telemetry", hydration_hooks, **handlers),
                      dehydration_hooks=dehydration_hooks)
 
+
 class AsyncBolt5x5(AsyncBolt5x4):
 
     PROTOCOL_VERSION = Version(5, 5)
@@ -822,6 +823,7 @@ class AsyncBolt5x5(AsyncBolt5x4):
             wrapped_handler=handlers.get("on_success")
         )
         super().pull(n, qid, dehydration_hooks, hydration_hooks, **handlers)
+
 
 class AsyncBolt5x6(AsyncBolt5x5):
 

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -783,7 +783,51 @@ class AsyncBolt5x5(AsyncBolt5x4):
         ("CURRENT_SCHEMA", "/"),
     )
 
-    def _make_enrich_diagnostic_record_handler(self, wrapped_handler=None):
+    def _make_enrich_statuses_handler(self, wrapped_handler=None):
+        async def handler(metadata):
+            def enrich(metadata_):
+                if not isinstance(metadata_, dict):
+                    return
+                statuses = metadata_.get("statuses")
+                if not isinstance(statuses, list):
+                    return
+                for status in statuses:
+                    if not isinstance(status, dict):
+                        continue
+                    status["description"] = status.get("status_description")
+                    diag_record = status.setdefault("diagnostic_record", {})
+                    if not isinstance(diag_record, dict):
+                        log.info("[#%04X]  _: <CONNECTION> Server supplied an "
+                                 "invalid diagnostic record (%r).",
+                                 self.local_port, diag_record)
+                        continue
+                    for key, value in self.DEFAULT_DIAGNOSTIC_RECORD:
+                        diag_record.setdefault(key, value)
+
+            enrich(metadata)
+            await AsyncUtil.callback(wrapped_handler, metadata)
+
+        return handler
+
+    def discard(self, n=-1, qid=-1, dehydration_hooks=None,
+                hydration_hooks=None, **handlers):
+        handlers["on_success"] = self._make_enrich_statuses_handler(
+            wrapped_handler=handlers.get("on_success")
+        )
+        super().discard(n, qid, dehydration_hooks, hydration_hooks, **handlers)
+
+    def pull(self, n=-1, qid=-1, dehydration_hooks=None, hydration_hooks=None,
+             **handlers):
+        handlers["on_success"] = self._make_enrich_statuses_handler(
+            wrapped_handler=handlers.get("on_success")
+        )
+        super().pull(n, qid, dehydration_hooks, hydration_hooks, **handlers)
+
+class AsyncBolt5x6(AsyncBolt5x5):
+
+    PROTOCOL_VERSION = Version(5, 6)
+
+    def _make_enrich_statuses_handler(self, wrapped_handler=None):
         async def handler(metadata):
             def enrich(metadata_):
                 if not isinstance(metadata_, dict):
@@ -807,17 +851,3 @@ class AsyncBolt5x5(AsyncBolt5x4):
             await AsyncUtil.callback(wrapped_handler, metadata)
 
         return handler
-
-    def discard(self, n=-1, qid=-1, dehydration_hooks=None,
-                hydration_hooks=None, **handlers):
-        handlers["on_success"] = self._make_enrich_diagnostic_record_handler(
-            wrapped_handler=handlers.get("on_success")
-        )
-        super().discard(n, qid, dehydration_hooks, hydration_hooks, **handlers)
-
-    def pull(self, n=-1, qid=-1, dehydration_hooks=None, hydration_hooks=None,
-             **handlers):
-        handlers["on_success"] = self._make_enrich_diagnostic_record_handler(
-            wrapped_handler=handlers.get("on_success")
-        )
-        super().pull(n, qid, dehydration_hooks, hydration_hooks, **handlers)

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -284,6 +284,7 @@ class Bolt:
             Bolt5x3,
             Bolt5x4,
             Bolt5x5,
+            Bolt5x6,
         )
 
         handlers = {
@@ -299,6 +300,7 @@ class Bolt:
             Bolt5x3.PROTOCOL_VERSION: Bolt5x3,
             Bolt5x4.PROTOCOL_VERSION: Bolt5x4,
             Bolt5x5.PROTOCOL_VERSION: Bolt5x5,
+            Bolt5x6.PROTOCOL_VERSION: Bolt5x6,
         }
 
         if protocol_version is None:
@@ -413,7 +415,10 @@ class Bolt:
 
         # Carry out Bolt subclass imports locally to avoid circular dependency
         # issues.
-        if protocol_version == (5, 5):
+        if protocol_version == (5, 6):
+            from ._bolt5 import Bolt5x6
+            bolt_cls = Bolt5x6
+        elif protocol_version == (5, 5):
             from ._bolt5 import Bolt5x5
             bolt_cls = Bolt5x5
         elif protocol_version == (5, 4):

--- a/src/neo4j/_sync/io/_bolt5.py
+++ b/src/neo4j/_sync/io/_bolt5.py
@@ -685,6 +685,7 @@ class Bolt5x4(Bolt5x3):
                      Response(self, "telemetry", hydration_hooks, **handlers),
                      dehydration_hooks=dehydration_hooks)
 
+
 class Bolt5x5(Bolt5x4):
 
     PROTOCOL_VERSION = Version(5, 5)
@@ -822,6 +823,7 @@ class Bolt5x5(Bolt5x4):
             wrapped_handler=handlers.get("on_success")
         )
         super().pull(n, qid, dehydration_hooks, hydration_hooks, **handlers)
+
 
 class Bolt5x6(Bolt5x5):
 

--- a/src/neo4j/_work/summary.py
+++ b/src/neo4j/_work/summary.py
@@ -163,7 +163,7 @@ class ResultSummary:
                 for notification_key, status_key in (
                     ("title", "title"),
                     ("code", "neo4j_code"),
-                    ("description", "status_description"),
+                    ("description", "description"),
                 ):
                     value = status.get(status_key)
                     if not isinstance(value, str) or not value:

--- a/testkitbackend/test_config.json
+++ b/testkitbackend/test_config.json
@@ -57,6 +57,7 @@
     "Feature:Bolt:5.3": true,
     "Feature:Bolt:5.4": true,
     "Feature:Bolt:5.5": true,
+    "Feature:Bolt:5.6": true,
     "Feature:Bolt:Patch:UTC": true,
     "Feature:Impersonation": true,
     "Feature:TLS:1.1": "Driver blocks TLS 1.1 for security reasons.",

--- a/tests/unit/async_/io/test_class_bolt.py
+++ b/tests/unit/async_/io/test_class_bolt.py
@@ -37,7 +37,7 @@ def test_class_method_protocol_handlers():
     expected_handlers = {
         (3, 0),
         (4, 1), (4, 2), (4, 3), (4, 4),
-        (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), (5, 5),
+        (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (5, 6),
     }
 
     protocol_handlers = AsyncBolt.protocol_handlers()
@@ -65,7 +65,8 @@ def test_class_method_protocol_handlers():
         ((5, 3), 1),
         ((5, 4), 1),
         ((5, 5), 1),
-        ((5, 6), 0),
+        ((5, 6), 1),
+        ((5, 7), 0),
         ((6, 0), 0),
     ]
 )
@@ -85,7 +86,7 @@ def test_class_method_protocol_handlers_with_invalid_protocol_version():
 # [bolt-version-bump] search tag when changing bolt version support
 def test_class_method_get_handshake():
     handshake = AsyncBolt.get_handshake()
-    assert (b"\x00\x05\x05\x05\x00\x02\x04\x04\x00\x00\x01\x04\x00\x00\x00\x03"
+    assert (b"\x00\x06\x06\x05\x00\x02\x04\x04\x00\x00\x01\x04\x00\x00\x00\x03"
             == handshake)
 
 
@@ -134,6 +135,7 @@ async def test_cancel_hello_in_open(mocker, none_auth):
         ((5, 3), "neo4j._async.io._bolt5.AsyncBolt5x3"),
         ((5, 4), "neo4j._async.io._bolt5.AsyncBolt5x4"),
         ((5, 5), "neo4j._async.io._bolt5.AsyncBolt5x5"),
+        ((5, 6), "neo4j._async.io._bolt5.AsyncBolt5x6"),
     ),
 )
 @mark_async_test
@@ -166,14 +168,14 @@ async def test_version_negotiation(
     (2, 0),
     (4, 0),
     (3, 1),
-    (5, 6),
+    (5, 7),
     (6, 0),
 ))
 @mark_async_test
 async def test_failing_version_negotiation(mocker, bolt_version, none_auth):
     supported_protocols = (
         "('3.0', '4.1', '4.2', '4.3', '4.4', "
-        "'5.0', '5.1', '5.2', '5.3', '5.4', '5.5')"
+        "'5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6')"
     )
 
     address = ("localhost", 7687)

--- a/tests/unit/async_/io/test_class_bolt5x6.py
+++ b/tests/unit/async_/io/test_class_bolt5x6.py
@@ -22,7 +22,7 @@ import pytest
 import neo4j
 from neo4j._api import TelemetryAPI
 from neo4j._async.config import AsyncPoolConfig
-from neo4j._async.io._bolt5 import AsyncBolt5x5
+from neo4j._async.io._bolt5 import AsyncBolt5x6
 from neo4j._meta import (
     BOLT_AGENT_DICT,
     USER_AGENT,
@@ -36,7 +36,7 @@ from ....iter_util import powerset
 def test_conn_is_stale(fake_socket, set_stale):
     address = neo4j.Address(("127.0.0.1", 7687))
     max_connection_lifetime = 0
-    connection = AsyncBolt5x5(address, fake_socket(address), max_connection_lifetime)
+    connection = AsyncBolt5x6(address, fake_socket(address), max_connection_lifetime)
     if set_stale:
         connection.set_stale()
     assert connection.stale() is True
@@ -46,7 +46,7 @@ def test_conn_is_stale(fake_socket, set_stale):
 def test_conn_is_not_stale_if_not_enabled(fake_socket, set_stale):
     address = neo4j.Address(("127.0.0.1", 7687))
     max_connection_lifetime = -1
-    connection = AsyncBolt5x5(address, fake_socket(address), max_connection_lifetime)
+    connection = AsyncBolt5x6(address, fake_socket(address), max_connection_lifetime)
     if set_stale:
         connection.set_stale()
     assert connection.stale() is set_stale
@@ -56,7 +56,7 @@ def test_conn_is_not_stale_if_not_enabled(fake_socket, set_stale):
 def test_conn_is_not_stale(fake_socket, set_stale):
     address = neo4j.Address(("127.0.0.1", 7687))
     max_connection_lifetime = 999999999
-    connection = AsyncBolt5x5(address, fake_socket(address), max_connection_lifetime)
+    connection = AsyncBolt5x6(address, fake_socket(address), max_connection_lifetime)
     if set_stale:
         connection.set_stale()
     assert connection.stale() is set_stale
@@ -74,8 +74,8 @@ def test_conn_is_not_stale(fake_socket, set_stale):
 @mark_async_test
 async def test_extra_in_begin(fake_socket, args, kwargs, expected_fields):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, AsyncBolt5x6.UNPACKER_CLS)
+    connection = AsyncBolt5x6(address, socket, AsyncPoolConfig.max_connection_lifetime)
     connection.begin(*args, **kwargs)
     await connection.send_all()
     tag, is_fields = await socket.pop_message()
@@ -95,8 +95,8 @@ async def test_extra_in_begin(fake_socket, args, kwargs, expected_fields):
 @mark_async_test
 async def test_extra_in_run(fake_socket, args, kwargs, expected_fields):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, AsyncBolt5x6.UNPACKER_CLS)
+    connection = AsyncBolt5x6(address, socket, AsyncPoolConfig.max_connection_lifetime)
     connection.run(*args, **kwargs)
     await connection.send_all()
     tag, is_fields = await socket.pop_message()
@@ -107,8 +107,8 @@ async def test_extra_in_run(fake_socket, args, kwargs, expected_fields):
 @mark_async_test
 async def test_n_extra_in_discard(fake_socket):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, AsyncBolt5x6.UNPACKER_CLS)
+    connection = AsyncBolt5x6(address, socket, AsyncPoolConfig.max_connection_lifetime)
     connection.discard(n=666)
     await connection.send_all()
     tag, fields = await socket.pop_message()
@@ -127,8 +127,8 @@ async def test_n_extra_in_discard(fake_socket):
 @mark_async_test
 async def test_qid_extra_in_discard(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, AsyncBolt5x6.UNPACKER_CLS)
+    connection = AsyncBolt5x6(address, socket, AsyncPoolConfig.max_connection_lifetime)
     connection.discard(qid=test_input)
     await connection.send_all()
     tag, fields = await socket.pop_message()
@@ -147,8 +147,8 @@ async def test_qid_extra_in_discard(fake_socket, test_input, expected):
 @mark_async_test
 async def test_n_and_qid_extras_in_discard(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, AsyncBolt5x6.UNPACKER_CLS)
+    connection = AsyncBolt5x6(address, socket, AsyncPoolConfig.max_connection_lifetime)
     connection.discard(n=666, qid=test_input)
     await connection.send_all()
     tag, fields = await socket.pop_message()
@@ -167,8 +167,8 @@ async def test_n_and_qid_extras_in_discard(fake_socket, test_input, expected):
 @mark_async_test
 async def test_n_extra_in_pull(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, AsyncBolt5x6.UNPACKER_CLS)
+    connection = AsyncBolt5x6(address, socket, AsyncPoolConfig.max_connection_lifetime)
     connection.pull(n=test_input)
     await connection.send_all()
     tag, fields = await socket.pop_message()
@@ -187,8 +187,8 @@ async def test_n_extra_in_pull(fake_socket, test_input, expected):
 @mark_async_test
 async def test_qid_extra_in_pull(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, AsyncBolt5x6.UNPACKER_CLS)
+    connection = AsyncBolt5x6(address, socket, AsyncPoolConfig.max_connection_lifetime)
     connection.pull(qid=test_input)
     await connection.send_all()
     tag, fields = await socket.pop_message()
@@ -200,8 +200,8 @@ async def test_qid_extra_in_pull(fake_socket, test_input, expected):
 @mark_async_test
 async def test_n_and_qid_extras_in_pull(fake_socket):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, AsyncBolt5x6.UNPACKER_CLS)
+    connection = AsyncBolt5x6(address, socket, AsyncPoolConfig.max_connection_lifetime)
     connection.pull(n=666, qid=777)
     await connection.send_all()
     tag, fields = await socket.pop_message()
@@ -214,11 +214,11 @@ async def test_n_and_qid_extras_in_pull(fake_socket):
 async def test_hello_passes_routing_metadata(fake_socket_pair):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
+                               packer_cls=AsyncBolt5x6.PACKER_CLS,
+                               unpacker_cls=AsyncBolt5x6.UNPACKER_CLS)
     await sockets.server.send_message(b"\x70", {"server": "Neo4j/4.4.0"})
     await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x5(
+    connection = AsyncBolt5x6(
         address, sockets.client, AsyncPoolConfig.max_connection_lifetime,
         routing_context={"foo": "bar"}
     )
@@ -237,8 +237,8 @@ async def test_telemetry_message(
     fake_socket, api, serv_enabled, driver_disabled
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(
+    socket = fake_socket(address, AsyncBolt5x6.UNPACKER_CLS)
+    connection = AsyncBolt5x6(
         address, socket, AsyncPoolConfig.max_connection_lifetime,
         telemetry_disabled=driver_disabled
     )
@@ -274,14 +274,14 @@ async def test_hint_recv_timeout_seconds(
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
+                               packer_cls=AsyncBolt5x6.PACKER_CLS,
+                               unpacker_cls=AsyncBolt5x6.UNPACKER_CLS)
     sockets.client.settimeout = mocker.Mock()
     await sockets.server.send_message(
         b"\x70", {"server": "Neo4j/4.3.4", "hints": hints}
     )
     await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x5(
+    connection = AsyncBolt5x6(
         address, sockets.client, AsyncPoolConfig.max_connection_lifetime
     )
     with caplog.at_level(logging.INFO):
@@ -319,11 +319,11 @@ CREDENTIALS = "+++super-secret-sauce+++"
 async def test_credentials_are_not_logged(auth, fake_socket_pair, caplog):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
+                               packer_cls=AsyncBolt5x6.PACKER_CLS,
+                               unpacker_cls=AsyncBolt5x6.UNPACKER_CLS)
     await sockets.server.send_message(b"\x70", {"server": "Neo4j/4.3.4"})
     await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x5(
+    connection = AsyncBolt5x6(
         address, sockets.client, AsyncPoolConfig.max_connection_lifetime, auth=auth
     )
     with caplog.at_level(logging.DEBUG):
@@ -363,8 +363,8 @@ async def test_supports_notification_filters(
     cls_dis_clss, method_dis_clss
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(
+    socket = fake_socket(address, AsyncBolt5x6.UNPACKER_CLS)
+    connection = AsyncBolt5x6(
         address, socket, AsyncPoolConfig.max_connection_lifetime,
         notifications_min_severity=cls_min_sev,
         notifications_disabled_classifications=cls_dis_clss
@@ -394,11 +394,11 @@ async def test_hello_supports_notification_filters(
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
+                               packer_cls=AsyncBolt5x6.PACKER_CLS,
+                               unpacker_cls=AsyncBolt5x6.UNPACKER_CLS)
     await sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
     await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x5(
+    connection = AsyncBolt5x6(
         address, sockets.client, AsyncPoolConfig.max_connection_lifetime,
         notifications_min_severity=min_sev,
         notifications_disabled_classifications=dis_clss
@@ -423,12 +423,12 @@ async def test_hello_supports_notification_filters(
 async def test_user_agent(fake_socket_pair, user_agent):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
+                               packer_cls=AsyncBolt5x6.PACKER_CLS,
+                               unpacker_cls=AsyncBolt5x6.UNPACKER_CLS)
     await sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
     await sockets.server.send_message(b"\x70", {})
     max_connection_lifetime = 0
-    connection = AsyncBolt5x5(
+    connection = AsyncBolt5x6(
         address, sockets.client, max_connection_lifetime, user_agent=user_agent
     )
     await connection.hello()
@@ -448,12 +448,12 @@ async def test_user_agent(fake_socket_pair, user_agent):
 async def test_sends_bolt_agent(fake_socket_pair, user_agent):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
+                               packer_cls=AsyncBolt5x6.PACKER_CLS,
+                               unpacker_cls=AsyncBolt5x6.UNPACKER_CLS)
     await sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
     await sockets.server.send_message(b"\x70", {})
     max_connection_lifetime = 0
-    connection = AsyncBolt5x5(
+    connection = AsyncBolt5x6(
         address, sockets.client, max_connection_lifetime, user_agent=user_agent
     )
     await connection.hello()
@@ -506,10 +506,10 @@ async def test_tx_timeout(
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
+                               packer_cls=AsyncBolt5x6.PACKER_CLS,
+                               unpacker_cls=AsyncBolt5x6.UNPACKER_CLS)
     await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x5(address, sockets.client, 0)
+    connection = AsyncBolt5x6(address, sockets.client, 0)
     func = getattr(connection, func)
     if isinstance(res, Exception):
         with pytest.raises(type(res), match=str(res)):
@@ -540,9 +540,9 @@ async def test_tx_timeout(
 async def test_tracks_last_database(fake_socket_pair, actions):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, sockets.client, 0)
+                               packer_cls=AsyncBolt5x6.PACKER_CLS,
+                               unpacker_cls=AsyncBolt5x6.UNPACKER_CLS)
+    connection = AsyncBolt5x6(address, sockets.client, 0)
     await sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
     await sockets.server.send_message(b"\x70", {})
     await connection.hello()
@@ -622,15 +622,15 @@ async def test_enriches_statuses(
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, sockets.client, 0)
+                               packer_cls=AsyncBolt5x6.PACKER_CLS,
+                               unpacker_cls=AsyncBolt5x6.UNPACKER_CLS)
+    connection = AsyncBolt5x6(address, sockets.client, 0)
 
     sent_metadata = {
         "statuses": [
-            {"status_description": "the status description", "diagnostic_record": r}
+            {"status_description": "the status description", "description": "description", "diagnostic_record": r}
             if r is not ...
-            else { "status_description": "the status description" }
+            else { "status_description": "the status description", "description": "description" }
             for r in sent_diag_records
         ]
     }
@@ -656,9 +656,9 @@ async def test_enriches_statuses(
     expected_diag_records = [extend_diag_record(r) for r in sent_diag_records]
     expected_metadata = {
         "statuses": [
-            {"status_description": "the status description", "description": "the status description", "diagnostic_record": r}
+            {"status_description": "the status description", "description": "description", "diagnostic_record": r}
             if r is not ...
-            else { "status_description": "the status description", "description": "the status description" }
+            else { "status_description": "the status description", "description": "description" }
             for r in expected_diag_records
         ]
     }

--- a/tests/unit/common/work/test_summary.py
+++ b/tests/unit/common/work/test_summary.py
@@ -190,6 +190,7 @@ def test_statuses_and_notifications_dont_mix(summary_args_kwargs) -> None:
     raw_status = {
         "gql_status": "12345",
         "status_description": "cool description",
+        "description": "cool notification description",
         "neo4j_code": "Neo.Foo.Bar.Baz",
         "title": "nice title",
         "diagnostic_record": raw_diag_rec,
@@ -314,6 +315,7 @@ class StatusOrderHelper:
             "gql_status": gql_status,
             "status_description": "note: successful completion - "
                                   f"custom stuff {i}",
+            "description": f"notification description {i}",
             "neo4j_code": f"Neo.Foo.Bar.{type_}-{i}",
             "title": f"Some cool title which defo is dope! {i}",
             "diagnostic_record": {
@@ -606,15 +608,18 @@ def test_status(
 ) -> None:
     args, kwargs = summary_args_kwargs
     default_position = SummaryInputPosition(line=1337, column=42, offset=420)
-    default_description = "some nice description goes here"
+    default_status_description = "some nice description goes here"
+    default_description = "some nice notification description here"
     default_severity = "WARNING"
     default_classification = "HINT"
     default_code = "Neo.Cool.Legacy.Code"
     default_title = "Cool Title"
     default_gql_status = "12345"
+
     raw_status: t.Dict[str, t.Any] = {
         "gql_status": default_gql_status,
-        "status_description": default_description,
+        "status_description": default_status_description,
+        "description": default_description,
         "neo4j_code": default_code,
         "title": default_title,
         "diagnostic_record": {
@@ -661,7 +666,7 @@ def test_status(
             == expectation_overwrite.get("gql_status", default_gql_status))
     assert (status.status_description
             == expectation_overwrite.get("status_description",
-                                         default_description))
+                                         default_status_description))
     assert (status.position
             == expectation_overwrite.get("position", default_position))
     assert (status.raw_classification
@@ -837,6 +842,7 @@ def test_summary_result_counters(summary_args_kwargs, counters_set) -> None:
     ((5, 3), "t_first"),
     ((5, 4), "t_first"),
     ((5, 5), "t_first"),
+    ((5, 6), "t_first"),
 ))
 def test_summary_result_available_after(
     summary_args_kwargs, exists, bolt_version, meta_name
@@ -869,6 +875,7 @@ def test_summary_result_available_after(
     ((5, 3), "t_last"),
     ((5, 4), "t_last"),
     ((5, 5), "t_last"),
+    ((5, 6), "t_last"),
 ))
 def test_summary_result_consumed_after(
     summary_args_kwargs, exists, bolt_version, meta_name
@@ -1438,9 +1445,9 @@ def test_no_notification_from_status(raw_status, summary_args_kwargs) -> None:
                                 ("FOOBAR", None, ..., -1, 1.6, False, [], {}))
         ),
 
-        # copies status_description to description
+        # copies description to description
         (
-            {"status_description": "something completely different 👀"}, {},
+            {"description": "something completely different 👀"}, {},
             {"description": "something completely different 👀"}
         ),
 
@@ -1537,15 +1544,17 @@ def test_notification_from_status(
     summary_args_kwargs
 ) -> None:
     default_status = "03BAZ"
-    default_description = "note: successful completion - custom stuff"
+    default_status_description = "note: successful completion - custom stuff"
     default_code = "Neo.Foo.Bar.Baz"
     default_title = "Some cool title which defo is dope!"
     default_severity = "INFORMATION"
     default_classification = "HINT"
+    default_description = "nice message"
     default_position = SummaryInputPosition(line=1337, column=42, offset=420)
     raw_status_obj: t.Dict[str, t.Any] = {
         "gql_status": default_status,
-        "status_description": default_description,
+        "status_description": default_status_description,
+        "description": default_description,
         "neo4j_code": default_code,
         "title": default_title,
         "diagnostic_record": {
@@ -1767,7 +1776,7 @@ def test_broken_diagnostic_record(in_status, summary_args_kwargs) -> None:
     ("status_overwrite", "diagnostic_record_overwrite"),
     (
         *(
-            ({"status_description": value}, {})
+            ({"description": value}, {})
             for value in t.cast(t.Iterable[t.Any],
                                 ("", None, ..., 1, False, [], {}))
         ),
@@ -1818,7 +1827,8 @@ def test_no_notification_from_broken_status(
     status_overwrite, diagnostic_record_overwrite, summary_args_kwargs
 ) -> None:
     default_status = "03BAZ"
-    default_description = "note: successful completion - custom stuff"
+    default_status_description = "note: successful completion - custom stuff"
+    default_description = "some description"
     default_code = "Neo.Foo.Bar.Baz"
     default_title = "Some cool title which defo is dope!"
     default_severity = "INFORMATION"
@@ -1826,7 +1836,8 @@ def test_no_notification_from_broken_status(
     default_position = SummaryInputPosition(line=1337, column=42, offset=420)
     raw_status_obj: t.Dict[str, t.Any] = {
         "gql_status": default_status,
-        "status_description": default_description,
+        "description": default_description,
+        "status_description": default_status_description,
         "neo4j_code": default_code,
         "title": default_title,
         "diagnostic_record": {

--- a/tests/unit/sync/io/test_class_bolt.py
+++ b/tests/unit/sync/io/test_class_bolt.py
@@ -37,7 +37,7 @@ def test_class_method_protocol_handlers():
     expected_handlers = {
         (3, 0),
         (4, 1), (4, 2), (4, 3), (4, 4),
-        (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), (5, 5),
+        (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (5, 6),
     }
 
     protocol_handlers = Bolt.protocol_handlers()
@@ -65,7 +65,8 @@ def test_class_method_protocol_handlers():
         ((5, 3), 1),
         ((5, 4), 1),
         ((5, 5), 1),
-        ((5, 6), 0),
+        ((5, 6), 1),
+        ((5, 7), 0),
         ((6, 0), 0),
     ]
 )
@@ -85,7 +86,7 @@ def test_class_method_protocol_handlers_with_invalid_protocol_version():
 # [bolt-version-bump] search tag when changing bolt version support
 def test_class_method_get_handshake():
     handshake = Bolt.get_handshake()
-    assert (b"\x00\x05\x05\x05\x00\x02\x04\x04\x00\x00\x01\x04\x00\x00\x00\x03"
+    assert (b"\x00\x06\x06\x05\x00\x02\x04\x04\x00\x00\x01\x04\x00\x00\x00\x03"
             == handshake)
 
 
@@ -134,6 +135,7 @@ def test_cancel_hello_in_open(mocker, none_auth):
         ((5, 3), "neo4j._sync.io._bolt5.Bolt5x3"),
         ((5, 4), "neo4j._sync.io._bolt5.Bolt5x4"),
         ((5, 5), "neo4j._sync.io._bolt5.Bolt5x5"),
+        ((5, 6), "neo4j._sync.io._bolt5.Bolt5x6"),
     ),
 )
 @mark_sync_test
@@ -166,14 +168,14 @@ def test_version_negotiation(
     (2, 0),
     (4, 0),
     (3, 1),
-    (5, 6),
+    (5, 7),
     (6, 0),
 ))
 @mark_sync_test
 def test_failing_version_negotiation(mocker, bolt_version, none_auth):
     supported_protocols = (
         "('3.0', '4.1', '4.2', '4.3', '4.4', "
-        "'5.0', '5.1', '5.2', '5.3', '5.4', '5.5')"
+        "'5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6')"
     )
 
     address = ("localhost", 7687)

--- a/tests/unit/sync/io/test_class_bolt5x5.py
+++ b/tests/unit/sync/io/test_class_bolt5x5.py
@@ -615,7 +615,7 @@ DEFAULT_DIAG_REC_PAIRS = (
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))
 @mark_sync_test
-def test_enriches_diagnostic_record(
+def test_enriches_statuses(
     sent_diag_records,
     method,
     fake_socket_pair,
@@ -628,7 +628,9 @@ def test_enriches_diagnostic_record(
 
     sent_metadata = {
         "statuses": [
-            {"diagnostic_record": r} if r is not ... else {}
+            {"status_description": "the status description", "diagnostic_record": r}
+            if r is not ...
+            else { "status_description": "the status description" }
             for r in sent_diag_records
         ]
     }
@@ -654,7 +656,9 @@ def test_enriches_diagnostic_record(
     expected_diag_records = [extend_diag_record(r) for r in sent_diag_records]
     expected_metadata = {
         "statuses": [
-            {"diagnostic_record": r} if r is not ... else {}
+            {"status_description": "the status description", "description": "the status description", "diagnostic_record": r}
+            if r is not ...
+            else { "status_description": "the status description", "description": "the status description" }
             for r in expected_diag_records
         ]
     }

--- a/tests/unit/sync/io/test_class_bolt5x6.py
+++ b/tests/unit/sync/io/test_class_bolt5x6.py
@@ -21,14 +21,14 @@ import pytest
 
 import neo4j
 from neo4j._api import TelemetryAPI
-from neo4j._async.config import AsyncPoolConfig
-from neo4j._async.io._bolt5 import AsyncBolt5x5
 from neo4j._meta import (
     BOLT_AGENT_DICT,
     USER_AGENT,
 )
+from neo4j._sync.config import PoolConfig
+from neo4j._sync.io._bolt5 import Bolt5x6
 
-from ...._async_compat import mark_async_test
+from ...._async_compat import mark_sync_test
 from ....iter_util import powerset
 
 
@@ -36,7 +36,7 @@ from ....iter_util import powerset
 def test_conn_is_stale(fake_socket, set_stale):
     address = neo4j.Address(("127.0.0.1", 7687))
     max_connection_lifetime = 0
-    connection = AsyncBolt5x5(address, fake_socket(address), max_connection_lifetime)
+    connection = Bolt5x6(address, fake_socket(address), max_connection_lifetime)
     if set_stale:
         connection.set_stale()
     assert connection.stale() is True
@@ -46,7 +46,7 @@ def test_conn_is_stale(fake_socket, set_stale):
 def test_conn_is_not_stale_if_not_enabled(fake_socket, set_stale):
     address = neo4j.Address(("127.0.0.1", 7687))
     max_connection_lifetime = -1
-    connection = AsyncBolt5x5(address, fake_socket(address), max_connection_lifetime)
+    connection = Bolt5x6(address, fake_socket(address), max_connection_lifetime)
     if set_stale:
         connection.set_stale()
     assert connection.stale() is set_stale
@@ -56,7 +56,7 @@ def test_conn_is_not_stale_if_not_enabled(fake_socket, set_stale):
 def test_conn_is_not_stale(fake_socket, set_stale):
     address = neo4j.Address(("127.0.0.1", 7687))
     max_connection_lifetime = 999999999
-    connection = AsyncBolt5x5(address, fake_socket(address), max_connection_lifetime)
+    connection = Bolt5x6(address, fake_socket(address), max_connection_lifetime)
     if set_stale:
         connection.set_stale()
     assert connection.stale() is set_stale
@@ -71,14 +71,14 @@ def test_conn_is_not_stale(fake_socket, set_stale):
         ({"db": "something", "imp_user": "imposter"},)
     ),
 ))
-@mark_async_test
-async def test_extra_in_begin(fake_socket, args, kwargs, expected_fields):
+@mark_sync_test
+def test_extra_in_begin(fake_socket, args, kwargs, expected_fields):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
+    connection = Bolt5x6(address, socket, PoolConfig.max_connection_lifetime)
     connection.begin(*args, **kwargs)
-    await connection.send_all()
-    tag, is_fields = await socket.pop_message()
+    connection.send_all()
+    tag, is_fields = socket.pop_message()
     assert tag == b"\x11"
     assert tuple(is_fields) == expected_fields
 
@@ -92,26 +92,26 @@ async def test_extra_in_begin(fake_socket, args, kwargs, expected_fields):
         ("", {}, {"db": "something", "imp_user": "imposter"})
     ),
 ))
-@mark_async_test
-async def test_extra_in_run(fake_socket, args, kwargs, expected_fields):
+@mark_sync_test
+def test_extra_in_run(fake_socket, args, kwargs, expected_fields):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
+    connection = Bolt5x6(address, socket, PoolConfig.max_connection_lifetime)
     connection.run(*args, **kwargs)
-    await connection.send_all()
-    tag, is_fields = await socket.pop_message()
+    connection.send_all()
+    tag, is_fields = socket.pop_message()
     assert tag == b"\x10"
     assert tuple(is_fields) == expected_fields
 
 
-@mark_async_test
-async def test_n_extra_in_discard(fake_socket):
+@mark_sync_test
+def test_n_extra_in_discard(fake_socket):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
+    connection = Bolt5x6(address, socket, PoolConfig.max_connection_lifetime)
     connection.discard(n=666)
-    await connection.send_all()
-    tag, fields = await socket.pop_message()
+    connection.send_all()
+    tag, fields = socket.pop_message()
     assert tag == b"\x2F"
     assert len(fields) == 1
     assert fields[0] == {"n": 666}
@@ -124,14 +124,14 @@ async def test_n_extra_in_discard(fake_socket):
         (-1, {"n": -1}),
     ]
 )
-@mark_async_test
-async def test_qid_extra_in_discard(fake_socket, test_input, expected):
+@mark_sync_test
+def test_qid_extra_in_discard(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
+    connection = Bolt5x6(address, socket, PoolConfig.max_connection_lifetime)
     connection.discard(qid=test_input)
-    await connection.send_all()
-    tag, fields = await socket.pop_message()
+    connection.send_all()
+    tag, fields = socket.pop_message()
     assert tag == b"\x2F"
     assert len(fields) == 1
     assert fields[0] == expected
@@ -144,14 +144,14 @@ async def test_qid_extra_in_discard(fake_socket, test_input, expected):
         (-1, {"n": 666}),
     ]
 )
-@mark_async_test
-async def test_n_and_qid_extras_in_discard(fake_socket, test_input, expected):
+@mark_sync_test
+def test_n_and_qid_extras_in_discard(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
+    connection = Bolt5x6(address, socket, PoolConfig.max_connection_lifetime)
     connection.discard(n=666, qid=test_input)
-    await connection.send_all()
-    tag, fields = await socket.pop_message()
+    connection.send_all()
+    tag, fields = socket.pop_message()
     assert tag == b"\x2F"
     assert len(fields) == 1
     assert fields[0] == expected
@@ -164,14 +164,14 @@ async def test_n_and_qid_extras_in_discard(fake_socket, test_input, expected):
         (-1, {"n": -1}),
     ]
 )
-@mark_async_test
-async def test_n_extra_in_pull(fake_socket, test_input, expected):
+@mark_sync_test
+def test_n_extra_in_pull(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
+    connection = Bolt5x6(address, socket, PoolConfig.max_connection_lifetime)
     connection.pull(n=test_input)
-    await connection.send_all()
-    tag, fields = await socket.pop_message()
+    connection.send_all()
+    tag, fields = socket.pop_message()
     assert tag == b"\x3F"
     assert len(fields) == 1
     assert fields[0] == expected
@@ -184,46 +184,46 @@ async def test_n_extra_in_pull(fake_socket, test_input, expected):
         (-1, {"n": -1}),
     ]
 )
-@mark_async_test
-async def test_qid_extra_in_pull(fake_socket, test_input, expected):
+@mark_sync_test
+def test_qid_extra_in_pull(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
+    connection = Bolt5x6(address, socket, PoolConfig.max_connection_lifetime)
     connection.pull(qid=test_input)
-    await connection.send_all()
-    tag, fields = await socket.pop_message()
+    connection.send_all()
+    tag, fields = socket.pop_message()
     assert tag == b"\x3F"
     assert len(fields) == 1
     assert fields[0] == expected
 
 
-@mark_async_test
-async def test_n_and_qid_extras_in_pull(fake_socket):
+@mark_sync_test
+def test_n_and_qid_extras_in_pull(fake_socket):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, socket, AsyncPoolConfig.max_connection_lifetime)
+    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
+    connection = Bolt5x6(address, socket, PoolConfig.max_connection_lifetime)
     connection.pull(n=666, qid=777)
-    await connection.send_all()
-    tag, fields = await socket.pop_message()
+    connection.send_all()
+    tag, fields = socket.pop_message()
     assert tag == b"\x3F"
     assert len(fields) == 1
     assert fields[0] == {"n": 666, "qid": 777}
 
 
-@mark_async_test
-async def test_hello_passes_routing_metadata(fake_socket_pair):
+@mark_sync_test
+def test_hello_passes_routing_metadata(fake_socket_pair):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
-    await sockets.server.send_message(b"\x70", {"server": "Neo4j/4.4.0"})
-    await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x5(
-        address, sockets.client, AsyncPoolConfig.max_connection_lifetime,
+                               packer_cls=Bolt5x6.PACKER_CLS,
+                               unpacker_cls=Bolt5x6.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {"server": "Neo4j/4.4.0"})
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt5x6(
+        address, sockets.client, PoolConfig.max_connection_lifetime,
         routing_context={"foo": "bar"}
     )
-    await connection.hello()
-    tag, fields = await sockets.server.pop_message()
+    connection.hello()
+    tag, fields = sockets.server.pop_message()
     assert tag == b"\x01"
     assert len(fields) == 1
     assert fields[0]["routing"] == {"foo": "bar"}
@@ -232,28 +232,28 @@ async def test_hello_passes_routing_metadata(fake_socket_pair):
 @pytest.mark.parametrize("api", TelemetryAPI)
 @pytest.mark.parametrize("serv_enabled", (True, False))
 @pytest.mark.parametrize("driver_disabled", (True, False))
-@mark_async_test
-async def test_telemetry_message(
+@mark_sync_test
+def test_telemetry_message(
     fake_socket, api, serv_enabled, driver_disabled
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(
-        address, socket, AsyncPoolConfig.max_connection_lifetime,
+    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
+    connection = Bolt5x6(
+        address, socket, PoolConfig.max_connection_lifetime,
         telemetry_disabled=driver_disabled
     )
     if serv_enabled:
         connection.configuration_hints["telemetry.enabled"] = True
     connection.telemetry(api)
-    await connection.send_all()
+    connection.send_all()
 
     if serv_enabled and not driver_disabled:
-        tag, fields = await socket.pop_message()
+        tag, fields = socket.pop_message()
         assert tag == b"\x54"
         assert fields == [int(api)]
     else:
         with pytest.raises(OSError):
-            await socket.pop_message()
+            socket.pop_message()
 
 
 @pytest.mark.parametrize(("hints", "valid"), (
@@ -268,24 +268,24 @@ async def test_telemetry_message(
     ({"connection.recv_timeout_seconds": False}, False),
     ({"connection.recv_timeout_seconds": "1"}, False),
 ))
-@mark_async_test
-async def test_hint_recv_timeout_seconds(
+@mark_sync_test
+def test_hint_recv_timeout_seconds(
     fake_socket_pair, hints, valid, caplog, mocker
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
+                               packer_cls=Bolt5x6.PACKER_CLS,
+                               unpacker_cls=Bolt5x6.UNPACKER_CLS)
     sockets.client.settimeout = mocker.Mock()
-    await sockets.server.send_message(
+    sockets.server.send_message(
         b"\x70", {"server": "Neo4j/4.3.4", "hints": hints}
     )
-    await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x5(
-        address, sockets.client, AsyncPoolConfig.max_connection_lifetime
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt5x6(
+        address, sockets.client, PoolConfig.max_connection_lifetime
     )
     with caplog.at_level(logging.INFO):
-        await connection.hello()
+        connection.hello()
     if valid:
         if "connection.recv_timeout_seconds" in hints:
             sockets.client.settimeout.assert_called_once_with(
@@ -315,19 +315,19 @@ CREDENTIALS = "+++super-secret-sauce+++"
     neo4j.custom_auth("user", CREDENTIALS, "realm", "scheme"),
     neo4j.Auth("scheme", "principal", CREDENTIALS, "realm", foo="bar"),
 ))
-@mark_async_test
-async def test_credentials_are_not_logged(auth, fake_socket_pair, caplog):
+@mark_sync_test
+def test_credentials_are_not_logged(auth, fake_socket_pair, caplog):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
-    await sockets.server.send_message(b"\x70", {"server": "Neo4j/4.3.4"})
-    await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x5(
-        address, sockets.client, AsyncPoolConfig.max_connection_lifetime, auth=auth
+                               packer_cls=Bolt5x6.PACKER_CLS,
+                               unpacker_cls=Bolt5x6.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {"server": "Neo4j/4.3.4"})
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt5x6(
+        address, sockets.client, PoolConfig.max_connection_lifetime, auth=auth
     )
     with caplog.at_level(logging.DEBUG):
-        await connection.hello()
+        connection.hello()
 
     if isinstance(auth, tuple):
         auth = neo4j.basic_auth(*auth)
@@ -357,15 +357,15 @@ def _assert_notifications_in_extra(extra, expected):
     ("cls_dis_clss", "method_dis_clss"),
     itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2)
 )
-@mark_async_test
-async def test_supports_notification_filters(
+@mark_sync_test
+def test_supports_notification_filters(
     fake_socket, method, args, extra_idx, cls_min_sev, method_min_sev,
     cls_dis_clss, method_dis_clss
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(
-        address, socket, AsyncPoolConfig.max_connection_lifetime,
+    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
+    connection = Bolt5x6(
+        address, socket, PoolConfig.max_connection_lifetime,
         notifications_min_severity=cls_min_sev,
         notifications_disabled_classifications=cls_dis_clss
     )
@@ -373,9 +373,9 @@ async def test_supports_notification_filters(
 
     method(*args, notifications_min_severity=method_min_sev,
            notifications_disabled_classifications=method_dis_clss)
-    await connection.send_all()
+    connection.send_all()
 
-    _, fields = await socket.pop_message()
+    _, fields = socket.pop_message()
     extra = fields[extra_idx]
     expected = {}
     if method_min_sev is not None:
@@ -388,25 +388,25 @@ async def test_supports_notification_filters(
 @pytest.mark.parametrize("min_sev", (None, "WARNING", "OFF"))
 @pytest.mark.parametrize("dis_clss",
                          (None, [], ["HINT"], ["HINT", "DEPRECATION"]))
-@mark_async_test
-async def test_hello_supports_notification_filters(
+@mark_sync_test
+def test_hello_supports_notification_filters(
     fake_socket_pair, min_sev, dis_clss
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
-    await sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
-    await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x5(
-        address, sockets.client, AsyncPoolConfig.max_connection_lifetime,
+                               packer_cls=Bolt5x6.PACKER_CLS,
+                               unpacker_cls=Bolt5x6.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt5x6(
+        address, sockets.client, PoolConfig.max_connection_lifetime,
         notifications_min_severity=min_sev,
         notifications_disabled_classifications=dis_clss
     )
 
-    await connection.hello()
+    connection.hello()
 
-    tag, fields = await sockets.server.pop_message()
+    tag, fields = sockets.server.pop_message()
     extra = fields[0]
     expected = {}
     if min_sev is not None:
@@ -416,24 +416,24 @@ async def test_hello_supports_notification_filters(
     _assert_notifications_in_extra(extra, expected)
 
 
-@mark_async_test
+@mark_sync_test
 @pytest.mark.parametrize(
     "user_agent", (None, "test user agent", "", USER_AGENT)
 )
-async def test_user_agent(fake_socket_pair, user_agent):
+def test_user_agent(fake_socket_pair, user_agent):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
-    await sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
-    await sockets.server.send_message(b"\x70", {})
+                               packer_cls=Bolt5x6.PACKER_CLS,
+                               unpacker_cls=Bolt5x6.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
+    sockets.server.send_message(b"\x70", {})
     max_connection_lifetime = 0
-    connection = AsyncBolt5x5(
+    connection = Bolt5x6(
         address, sockets.client, max_connection_lifetime, user_agent=user_agent
     )
-    await connection.hello()
+    connection.hello()
 
-    tag, fields = await sockets.server.pop_message()
+    tag, fields = sockets.server.pop_message()
     extra = fields[0]
     if not user_agent:
         assert extra["user_agent"] == USER_AGENT
@@ -441,29 +441,29 @@ async def test_user_agent(fake_socket_pair, user_agent):
         assert extra["user_agent"] == user_agent
 
 
-@mark_async_test
+@mark_sync_test
 @pytest.mark.parametrize(
     "user_agent", (None, "test user agent", "", USER_AGENT)
 )
-async def test_sends_bolt_agent(fake_socket_pair, user_agent):
+def test_sends_bolt_agent(fake_socket_pair, user_agent):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
-    await sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
-    await sockets.server.send_message(b"\x70", {})
+                               packer_cls=Bolt5x6.PACKER_CLS,
+                               unpacker_cls=Bolt5x6.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
+    sockets.server.send_message(b"\x70", {})
     max_connection_lifetime = 0
-    connection = AsyncBolt5x5(
+    connection = Bolt5x6(
         address, sockets.client, max_connection_lifetime, user_agent=user_agent
     )
-    await connection.hello()
+    connection.hello()
 
-    tag, fields = await sockets.server.pop_message()
+    tag, fields = sockets.server.pop_message()
     extra = fields[0]
     assert extra["bolt_agent"] == BOLT_AGENT_DICT
 
 
-@mark_async_test
+@mark_sync_test
 @pytest.mark.parametrize(
     ("func", "args", "extra_idx"),
     (
@@ -501,23 +501,23 @@ async def test_sends_bolt_agent(fake_socket_pair, user_agent):
         )
     )
 )
-async def test_tx_timeout(
+def test_tx_timeout(
     fake_socket_pair, func, args, extra_idx, timeout, res
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
-    await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x5(address, sockets.client, 0)
+                               packer_cls=Bolt5x6.PACKER_CLS,
+                               unpacker_cls=Bolt5x6.UNPACKER_CLS)
+    sockets.server.send_message(b"\x70", {})
+    connection = Bolt5x6(address, sockets.client, 0)
     func = getattr(connection, func)
     if isinstance(res, Exception):
         with pytest.raises(type(res), match=str(res)):
             func(*args, timeout=timeout)
     else:
         func(*args, timeout=timeout)
-        await connection.send_all()
-        tag, fields = await sockets.server.pop_message()
+        connection.send_all()
+        tag, fields = sockets.server.pop_message()
         extra = fields[extra_idx]
         if timeout is None:
             assert "tx_timeout" not in extra
@@ -536,19 +536,19 @@ async def test_tx_timeout(
         2
     )
 )
-@mark_async_test
-async def test_tracks_last_database(fake_socket_pair, actions):
+@mark_sync_test
+def test_tracks_last_database(fake_socket_pair, actions):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, sockets.client, 0)
-    await sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
-    await sockets.server.send_message(b"\x70", {})
-    await connection.hello()
+                               packer_cls=Bolt5x6.PACKER_CLS,
+                               unpacker_cls=Bolt5x6.UNPACKER_CLS)
+    connection = Bolt5x6(address, sockets.client, 0)
+    sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
+    sockets.server.send_message(b"\x70", {})
+    connection.hello()
     assert connection.last_database is None
     for action, finish, db in actions:
-        await sockets.server.send_message(b"\x70", {})
+        sockets.server.send_message(b"\x70", {})
         if action == "run":
             connection.run("RETURN 1", db=db)
         elif action == "begin":
@@ -556,19 +556,19 @@ async def test_tracks_last_database(fake_socket_pair, actions):
         elif action == "begin_run":
             connection.begin(db=db)
             assert connection.last_database == db
-            await sockets.server.send_message(b"\x70", {})
+            sockets.server.send_message(b"\x70", {})
             connection.run("RETURN 1")
         else:
             raise ValueError(action)
 
         assert connection.last_database == db
-        await connection.send_all()
-        await connection.fetch_all()
+        connection.send_all()
+        connection.fetch_all()
         assert connection.last_database == db
 
-        await sockets.server.send_message(b"\x70", {})
+        sockets.server.send_message(b"\x70", {})
         if finish == "reset":
-            await connection.reset()
+            connection.reset()
         elif finish == "commit":
             if action == "run":
                 connection.pull()
@@ -582,8 +582,8 @@ async def test_tracks_last_database(fake_socket_pair, actions):
         else:
             raise ValueError(finish)
 
-        await connection.send_all()
-        await connection.fetch_all()
+        connection.send_all()
+        connection.fetch_all()
 
         assert connection.last_database == db
 
@@ -614,27 +614,27 @@ DEFAULT_DIAG_REC_PAIRS = (
     )
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))
-@mark_async_test
-async def test_enriches_statuses(
+@mark_sync_test
+def test_enriches_statuses(
     sent_diag_records,
     method,
     fake_socket_pair,
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(address,
-                               packer_cls=AsyncBolt5x5.PACKER_CLS,
-                               unpacker_cls=AsyncBolt5x5.UNPACKER_CLS)
-    connection = AsyncBolt5x5(address, sockets.client, 0)
+                               packer_cls=Bolt5x6.PACKER_CLS,
+                               unpacker_cls=Bolt5x6.UNPACKER_CLS)
+    connection = Bolt5x6(address, sockets.client, 0)
 
     sent_metadata = {
         "statuses": [
-            {"status_description": "the status description", "diagnostic_record": r}
+            {"status_description": "the status description", "description": "description", "diagnostic_record": r}
             if r is not ...
-            else { "status_description": "the status description" }
+            else { "status_description": "the status description", "description": "description" }
             for r in sent_diag_records
         ]
     }
-    await sockets.server.send_message(b"\x70", sent_metadata)
+    sockets.server.send_message(b"\x70", sent_metadata)
 
     received_metadata = None
 
@@ -643,8 +643,8 @@ async def test_enriches_statuses(
         received_metadata = metadata
 
     getattr(connection, method)(on_success=on_success)
-    await connection.send_all()
-    await connection.fetch_all()
+    connection.send_all()
+    connection.fetch_all()
 
     def extend_diag_record(r):
         if r is ...:
@@ -656,9 +656,9 @@ async def test_enriches_statuses(
     expected_diag_records = [extend_diag_record(r) for r in sent_diag_records]
     expected_metadata = {
         "statuses": [
-            {"status_description": "the status description", "description": "the status description", "diagnostic_record": r}
+            {"status_description": "the status description", "description": "description", "diagnostic_record": r}
             if r is not ...
-            else { "status_description": "the status description", "description": "the status description" }
+            else { "status_description": "the status description", "description": "description" }
             for r in expected_diag_records
         ]
     }


### PR DESCRIPTION
Bolt 5.6 introduces the original notification description back in the protocol level. This avoids the `Notification.description` changes when connected to GQL aware servers.

This issues was detected during homologation, so the problem won't happen with any released server since the bolt version which miss information will not be released.

<!--
    Thanks for making the effort to create a Pull Request!
    Please read the comment in its entirety fist.

    If you haven't already, please sign our Contributor License Agreement at
    https://neo4j.com/developer/cla/
    Commits from accounts that have not signed the CLA will fail the CI and
    will not be reviewed. If you are a first-time contributor and have just
    signed the CLA, please include a note about this in the PR comment as some
    manual steps from our side are required.
-->

<!--
    Title:

    PRs targeting the current default branch (nightly driver) don't follow a
    fixed naming scheme.

    If your PR is a backport, please use the following naming scheme:

    [targeted version] description

    e.g.,

    [4.4] Remove a banana from the code
-->

<!--
    Description:

    Please include a summary of the changes in this PR and their purpose.
    Link any related issues or PRs.
-->
