### PR TITLE
Refine TLS certificate handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
 
 ## NEXT RELEASE
-- No breaking or major changes.
+- Made `neo4j.auth_management.RotatingClientCertificateProvider` and
+  `...AsyncRotatingClientCertificateProvider` (in preview)
+  abstract classes, meaning they can no longer be instantiated directly.  
+  Please use the provided factory methods instead:
+  `neo4j.auth_management.RotatingClientCertificateProvider.rotating` and
+  `....AsyncRotatingClientCertificateProvider.rotating()` respectively.
 
 
 ## Version 5.23

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -664,8 +664,17 @@ https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
 .. versionadded:: 5.19
 
 .. autoclass:: neo4j.auth_management.ClientCertificate
+    :members:
 
 .. autoclass:: neo4j.auth_management.ClientCertificateProvider
+    :members:
+
+.. autoclass:: neo4j.auth_management.ClientCertificateProviders
+    :members:
+
+.. autoclass:: neo4j.auth_management.RotatingClientCertificateProvider
+    :show-inheritance:
+    :members:
 
 
 .. _user-agent-ref:

--- a/docs/source/async_api.rst
+++ b/docs/source/async_api.rst
@@ -457,6 +457,14 @@ https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
 .. versionadded:: 5.19
 
 .. autoclass:: neo4j.auth_management.AsyncClientCertificateProvider
+    :members:
+
+.. autoclass:: neo4j.auth_management.AsyncClientCertificateProviders
+    :members:
+
+.. autoclass:: neo4j.auth_management.AsyncRotatingClientCertificateProvider
+    :show-inheritance:
+    :members:
 
 
 

--- a/src/neo4j/_auth_management.py
+++ b/src/neo4j/_auth_management.py
@@ -37,7 +37,8 @@ else:
 
 @dataclass
 class ExpiringAuth:
-    """Represents potentially expiring authentication information.
+    """
+    Represents potentially expiring authentication information.
 
     This class is used with :meth:`.AuthManagers.bearer` and
     :meth:`.AsyncAuthManagers.bearer`.
@@ -68,7 +69,8 @@ class ExpiringAuth:
     expires_at: t.Optional[float] = None
 
     def expires_in(self, seconds: float) -> ExpiringAuth:
-        """Return a (flat) copy of this object with a new expiration time.
+        """
+        Return a (flat) copy of this object with a new expiration time.
 
         This is a convenience method for creating an :class:`.ExpiringAuth`
         for a relative expiration time ("expires in" instead of "expires at").
@@ -96,7 +98,8 @@ def expiring_auth_has_expired(auth: ExpiringAuth) -> bool:
 
 
 class AuthManager(metaclass=abc.ABCMeta):
-    """Baseclass for authentication information managers.
+    """
+    Abstract base class for authentication information managers.
 
     The driver provides some default implementations of this class in
     :class:`.AuthManagers` for convenience.
@@ -132,7 +135,8 @@ class AuthManager(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_auth(self) -> _TAuth:
-        """Return the current authentication information.
+        """
+        Return the current authentication information.
 
         The driver will call this method very frequently. It is recommended
         to implement some form of caching to avoid unnecessary overhead.
@@ -151,7 +155,8 @@ class AuthManager(metaclass=abc.ABCMeta):
     def handle_security_exception(
         self, auth: _TAuth, error: Neo4jError
     ) -> bool:
-        """Handle the server indicating authentication failure.
+        """
+        Handle the server indicating authentication failure.
 
         The driver will call this method when the server returns any
         `Neo.ClientError.Security.*` error. The error will then be processed
@@ -174,7 +179,8 @@ class AuthManager(metaclass=abc.ABCMeta):
 
 
 class AsyncAuthManager(_Protocol, metaclass=abc.ABCMeta):
-    """Async version of :class:`.AuthManager`.
+    """
+    Async version of :class:`.AuthManager`.
 
     .. seealso:: :class:`.AuthManager`
 
@@ -234,10 +240,14 @@ class ClientCertificate:
 
 class ClientCertificateProvider(_Protocol, metaclass=abc.ABCMeta):
     """
-    Provides a client certificate to the driver for mutual TLS.
+    Interface for providing a client certificate to the driver for mutual TLS.
+
+    This is an abstract base class (:class:`abc.ABC`) as well as a protocol
+    (:class:`typing.Protocol`). Meaning you can either inherit from it or just
+    implement all required method on a class to satisfy the type constraints.
 
     The package provides some default implementations of this class in
-    :class:`.AsyncClientCertificateProviders` for convenience.
+    :class:`.ClientCertificateProviders` for convenience.
 
     The driver will call :meth:`.get_certificate` to check if the client wants
     the driver to use as new certificate for mutual TLS.
@@ -286,12 +296,17 @@ class AsyncClientCertificateProvider(_Protocol, metaclass=abc.ABCMeta):
     """
     Async version of :class:`.ClientCertificateProvider`.
 
+    The package provides some default implementations of this class in
+    :class:`.AsyncClientCertificateProviders` for convenience.
+
     **This is a preview** (see :ref:`filter-warnings-ref`).
     It might be changed without following the deprecation policy.
     See also
     https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
 
-    .. seealso:: :class:`.ClientCertificateProvider`
+    .. seealso::
+        :class:`.ClientCertificateProvider`,
+        :class:`.AsyncClientCertificateProviders`
 
     .. versionadded:: 5.19
     """

--- a/src/neo4j/_conf.py
+++ b/src/neo4j/_conf.py
@@ -102,7 +102,7 @@ class TrustCustomCAs(TrustStore):
     authority at the specified paths. This option is primarily intended for
     self-signed and custom certificates.
 
-    :param certificates (str): paths to the certificates to trust.
+    :param certificates: paths to the certificates to trust.
         Those are not the certificates you expect to see from the server but
         the CA certificates you expect to be used to sign the server's
         certificate.
@@ -118,7 +118,7 @@ class TrustCustomCAs(TrustStore):
             )
         )
     """
-    def __init__(self, *certificates):
+    def __init__(self, *certificates: str):
         self.certs = certificates
 
 

--- a/tests/unit/async_/test_auth_management.py
+++ b/tests/unit/async_/test_auth_management.py
@@ -260,12 +260,6 @@ def static_cert_provider(*args, **kwargs):
         return AsyncClientCertificateProviders.static(*args, **kwargs)
 
 
-@copy_signature(AsyncRotatingClientCertificateProvider)
-def rotating_cert_provider_direct(*args, **kwargs):
-    with pytest.warns(PreviewWarning, match="Mutual TLS"):
-        return AsyncRotatingClientCertificateProvider(*args, **kwargs)
-
-
 @copy_signature(AsyncClientCertificateProviders.rotating)
 def rotating_cert_provider(*args, **kwargs):
     with pytest.warns(PreviewWarning, match="Mutual TLS"):
@@ -285,15 +279,6 @@ async def test_static_client_cert_provider(client_cert_factory) -> None:
 if t.TYPE_CHECKING:
     # Tests for type checker only. No need to run the test.
 
-    async def test_rotating_client_cert_provider_type_init(
-        client_cert_factory
-    ) -> None:
-        cert1: ClientCertificate = client_cert_factory()
-        provider: AsyncRotatingClientCertificateProvider = \
-            rotating_cert_provider_direct(cert1)
-        _: AsyncClientCertificateProvider = provider
-
-
     async def test_rotating_client_cert_provider_type_factory(
         client_cert_factory
     ) -> None:
@@ -303,19 +288,13 @@ if t.TYPE_CHECKING:
         _: AsyncClientCertificateProvider = provider
 
 
-@pytest.mark.parametrize(
-    "factory", (rotating_cert_provider, rotating_cert_provider_direct)
-)
 @mark_async_test
-async def test_rotating_client_cert_provider(
-    factory: t.Callable[[ClientCertificate],
-                        AsyncRotatingClientCertificateProvider],
-    client_cert_factory
-) -> None:
+async def test_rotating_client_cert_provider(client_cert_factory) -> None:
     cert1: ClientCertificate = client_cert_factory()
     cert2: ClientCertificate = client_cert_factory()
     assert cert1 is not cert2  # sanity check
-    provider: AsyncRotatingClientCertificateProvider = factory(cert1)
+    provider: AsyncRotatingClientCertificateProvider = \
+        rotating_cert_provider(cert1)
 
     assert await provider.get_certificate() is cert1
     for _ in range(10):

--- a/tests/unit/sync/test_auth_management.py
+++ b/tests/unit/sync/test_auth_management.py
@@ -260,12 +260,6 @@ def static_cert_provider(*args, **kwargs):
         return ClientCertificateProviders.static(*args, **kwargs)
 
 
-@copy_signature(RotatingClientCertificateProvider)
-def rotating_cert_provider_direct(*args, **kwargs):
-    with pytest.warns(PreviewWarning, match="Mutual TLS"):
-        return RotatingClientCertificateProvider(*args, **kwargs)
-
-
 @copy_signature(ClientCertificateProviders.rotating)
 def rotating_cert_provider(*args, **kwargs):
     with pytest.warns(PreviewWarning, match="Mutual TLS"):
@@ -285,15 +279,6 @@ def test_static_client_cert_provider(client_cert_factory) -> None:
 if t.TYPE_CHECKING:
     # Tests for type checker only. No need to run the test.
 
-    def test_rotating_client_cert_provider_type_init(
-        client_cert_factory
-    ) -> None:
-        cert1: ClientCertificate = client_cert_factory()
-        provider: RotatingClientCertificateProvider = \
-            rotating_cert_provider_direct(cert1)
-        _: ClientCertificateProvider = provider
-
-
     def test_rotating_client_cert_provider_type_factory(
         client_cert_factory
     ) -> None:
@@ -303,19 +288,13 @@ if t.TYPE_CHECKING:
         _: ClientCertificateProvider = provider
 
 
-@pytest.mark.parametrize(
-    "factory", (rotating_cert_provider, rotating_cert_provider_direct)
-)
 @mark_sync_test
-def test_rotating_client_cert_provider(
-    factory: t.Callable[[ClientCertificate],
-                        RotatingClientCertificateProvider],
-    client_cert_factory
-) -> None:
+def test_rotating_client_cert_provider(client_cert_factory) -> None:
     cert1: ClientCertificate = client_cert_factory()
     cert2: ClientCertificate = client_cert_factory()
     assert cert1 is not cert2  # sanity check
-    provider: RotatingClientCertificateProvider = factory(cert1)
+    provider: RotatingClientCertificateProvider = \
+        rotating_cert_provider(cert1)
 
     assert provider.get_certificate() is cert1
     for _ in range(10):


### PR DESCRIPTION
 * Improve API docs.
   * Document missing classes from the mTLS feature in preview.
   * Improve wording and references.
 * Made `neo4j.auth_management.RotatingClientCertificateProvider` an abstract class. This means it can no longer be instantiated directly. Please use the provided factory method `neo4j.auth_management.RotatingClientCertificateProvider.rotating` instead.
   * Analogously for the async APIs.
 * Fix missing type hint for parameter of `TrustCustomCAs.__init__`.