### PR TITLE
Revert breaking change in summary.notification introduced in #1060

### DIFF
--- a/src/neo4j/_work/summary.py
+++ b/src/neo4j/_work/summary.py
@@ -175,7 +175,7 @@ class ResultSummary:
 
         return notification
 
-    def _set_notifications(self):
+    def _set_notifications(self) -> None:
         if "notifications" in self.metadata:
             notifications = self.metadata["notifications"]
             if not isinstance(notifications, list):
@@ -197,7 +197,7 @@ class ResultSummary:
                     continue
                 notification = self._notification_from_status(status)
                 notifications.append(notification)
-            self.notifications = notifications
+            self.notifications = notifications or None
             return
 
         self.notifications = None

--- a/testkitbackend/totestkit.py
+++ b/testkitbackend/totestkit.py
@@ -64,7 +64,8 @@ def summary(summary_: neo4j.ResultSummary) -> dict:
 
     def serialize_notifications() -> list[dict] | None:
         if summary_.notifications is None:
-            return None
+            gql_aware_protocol = summary_.server.protocol_version >= (5, 5)
+            return [] if gql_aware_protocol else None
         return [
             serialize_notification(n) for n in summary_.summary_notifications
         ]

--- a/tests/unit/common/work/test_summary.py
+++ b/tests/unit/common/work/test_summary.py
@@ -1465,7 +1465,7 @@ def test_no_notification_from_status(raw_status, summary_args_kwargs) -> None:
         summary.summary_notifications
     )
 
-    assert notifications == []
+    assert notifications is None
     assert summary_notifications == []
 
 
@@ -1736,7 +1736,7 @@ def test_no_notification_from_wrong_type_status(
     notifications = summary.notifications
     summary_notifications = summary.summary_notifications
 
-    assert notifications == []
+    assert notifications is None
     assert summary_notifications == []
 
 
@@ -1930,7 +1930,7 @@ def test_no_notification_from_status_without_neo4j_code(
     notifications = summary.notifications
     summary_notifications = summary.summary_notifications
 
-    assert notifications == []
+    assert notifications is None
     assert summary_notifications == []
 
 
@@ -2081,7 +2081,7 @@ def test_notification_from_broken_status(
     summary = ResultSummary(*args, **kwargs)
 
     notifications = summary.notifications
-    assert notifications == []
+    assert notifications is None
 
 
 def test_notifications_from_statuses_keep_order(


### PR DESCRIPTION
When introducing bolt 5.5 support for GQL statuses in the summary, the driver gained the ability to polyfill old-style notifications from the statuses. However, `ResultSummary.notifications` used to be `None` when the server didn't send any notifications. When using the polyfill, the field would be set to `[]` instead in the same scenario. This PR fixes this.