### PR TITLE
GQL Compliant Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
 
 ## NEXT RELEASE
-- TODO: list the deprecations (making error properties read-only)
+- Deprecated setting attributes on `Neo4jError` like `message` and `code`.
+- Deprecated undocumented method `Neo4jError.hydrate`.  
+  It's internal and should not be used by client code.
 
 
 ## Version 5.24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
 
 ## NEXT RELEASE
-- No breaking or major changes.
+- TODO: list the deprecations (making error properties read-only)
 
 
 ## Version 5.24

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1989,6 +1989,17 @@ Errors
 ******
 
 
+GQL Errors
+==========
+.. autoexception:: neo4j.exceptions.GqlError()
+    :show-inheritance:
+    :members: gql_status, message, gql_status_description, gql_raw_classification, gql_classification, diagnostic_record, __cause__
+
+.. autoclass:: neo4j.exceptions.GqlErrorClassification()
+    :show-inheritance:
+    :members:
+
+
 Neo4j Errors
 ============
 

--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -458,7 +458,10 @@ class AsyncBolt:
 
         # avoid new lines after imports for better readability and conciseness
         # fmt: off
-        if protocol_version == (5, 6):
+        if protocol_version == (5, 7):
+            from ._bolt5 import AsyncBolt5x7
+            bolt_cls = AsyncBolt5x7
+        elif protocol_version == (5, 6):
             from ._bolt5 import AsyncBolt5x6
             bolt_cls = AsyncBolt5x6
         elif protocol_version == (5, 5):

--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -217,6 +217,7 @@ class AsyncBolt:
             try:
                 return vars(auth)
             except (KeyError, TypeError) as e:
+                # TODO: 6.0 - change this to be a DriverError (or subclass)
                 raise AuthError(
                     f"Cannot determine auth details from {auth!r}"
                 ) from e
@@ -306,6 +307,7 @@ class AsyncBolt:
             AsyncBolt5x4,
             AsyncBolt5x5,
             AsyncBolt5x6,
+            AsyncBolt5x7,
         )
 
         handlers = {
@@ -322,6 +324,7 @@ class AsyncBolt:
             AsyncBolt5x4.PROTOCOL_VERSION: AsyncBolt5x4,
             AsyncBolt5x5.PROTOCOL_VERSION: AsyncBolt5x5,
             AsyncBolt5x6.PROTOCOL_VERSION: AsyncBolt5x6,
+            AsyncBolt5x7.PROTOCOL_VERSION: AsyncBolt5x7,
         }
 
         if protocol_version is None:
@@ -509,6 +512,7 @@ class AsyncBolt:
             await AsyncBoltSocket.close_socket(s)
 
             supported_versions = cls.protocol_handlers().keys()
+            # TODO: 6.0 - raise public DriverError subclass instead
             raise BoltHandshakeError(
                 "The neo4j server does not support communication with this "
                 "driver. This driver has support for Bolt protocols "

--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -916,6 +916,16 @@ class AsyncBolt:
     def new_hydration_scope(self):
         return self.hydration_handler.new_hydration_scope()
 
+    def _default_hydration_hooks(self, dehydration_hooks, hydration_hooks):
+        if dehydration_hooks is not None and hydration_hooks is not None:
+            return dehydration_hooks, hydration_hooks
+        hydration_scope = self.new_hydration_scope()
+        if dehydration_hooks is None:
+            dehydration_hooks = hydration_scope.dehydration_hooks
+        if hydration_hooks is None:
+            hydration_hooks = hydration_scope.hydration_hooks
+        return dehydration_hooks, hydration_hooks
+
     def _append(
         self, signature, fields=(), response=None, dehydration_hooks=None
     ):

--- a/src/neo4j/_async/io/_bolt3.py
+++ b/src/neo4j/_async/io/_bolt3.py
@@ -215,6 +215,9 @@ class AsyncBolt3(AsyncBolt):
             or self.notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         headers = self.get_base_headers()
         headers.update(self.auth_dict)
         logged_headers = dict(headers)
@@ -275,6 +278,9 @@ class AsyncBolt3(AsyncBolt):
                 f"{self.PROTOCOL_VERSION!r}. Trying to impersonate "
                 f"{imp_user!r}."
             )
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
 
         metadata = {}
         records = []
@@ -337,6 +343,9 @@ class AsyncBolt3(AsyncBolt):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         if not parameters:
             parameters = {}
         extra = {}
@@ -379,6 +388,9 @@ class AsyncBolt3(AsyncBolt):
         **handlers,
     ):
         # Just ignore n and qid, it is not supported in the Bolt 3 Protocol.
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: DISCARD_ALL", self.local_port)
         self._append(
             b"\x2f",
@@ -396,6 +408,9 @@ class AsyncBolt3(AsyncBolt):
         **handlers,
     ):
         # Just ignore n and qid, it is not supported in the Bolt 3 Protocol.
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: PULL_ALL", self.local_port)
         self._append(
             b"\x3f",
@@ -435,6 +450,9 @@ class AsyncBolt3(AsyncBolt):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {}
         if mode in {READ_ACCESS, "r"}:
             # It will default to mode "w" if nothing is specified
@@ -464,6 +482,9 @@ class AsyncBolt3(AsyncBolt):
         )
 
     def commit(self, dehydration_hooks=None, hydration_hooks=None, **handlers):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: COMMIT", self.local_port)
         self._append(
             b"\x12",
@@ -475,6 +496,9 @@ class AsyncBolt3(AsyncBolt):
     def rollback(
         self, dehydration_hooks=None, hydration_hooks=None, **handlers
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: ROLLBACK", self.local_port)
         self._append(
             b"\x13",
@@ -490,6 +514,9 @@ class AsyncBolt3(AsyncBolt):
         Add a RESET message to the outgoing queue, send it and consume all
         remaining messages.
         """
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: RESET", self.local_port)
         response = ResetResponse(self, "reset", hydration_hooks)
         self._append(
@@ -499,6 +526,9 @@ class AsyncBolt3(AsyncBolt):
         await self.fetch_all()
 
     def goodbye(self, dehydration_hooks=None, hydration_hooks=None):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: GOODBYE", self.local_port)
         self._append(b"\x02", (), dehydration_hooks=dehydration_hooks)
 

--- a/src/neo4j/_async/io/_bolt4.py
+++ b/src/neo4j/_async/io/_bolt4.py
@@ -131,6 +131,9 @@ class AsyncBolt4x0(AsyncBolt):
             or self.notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         headers = self.get_base_headers()
         headers.update(self.auth_dict)
         logged_headers = dict(headers)
@@ -184,6 +187,9 @@ class AsyncBolt4x0(AsyncBolt):
                 f"{self.PROTOCOL_VERSION!r}. Trying to impersonate "
                 f"{imp_user!r}."
             )
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         metadata = {}
         records = []
 
@@ -244,6 +250,9 @@ class AsyncBolt4x0(AsyncBolt):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         if not parameters:
             parameters = {}
         extra = {}
@@ -292,6 +301,9 @@ class AsyncBolt4x0(AsyncBolt):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {"n": n}
         if qid != -1:
             extra["qid"] = qid
@@ -311,6 +323,9 @@ class AsyncBolt4x0(AsyncBolt):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {"n": n}
         if qid != -1:
             extra["qid"] = qid
@@ -347,6 +362,9 @@ class AsyncBolt4x0(AsyncBolt):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {}
         if mode in {READ_ACCESS, "r"}:
             # It will default to mode "w" if nothing is specified
@@ -379,6 +397,9 @@ class AsyncBolt4x0(AsyncBolt):
         )
 
     def commit(self, dehydration_hooks=None, hydration_hooks=None, **handlers):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: COMMIT", self.local_port)
         self._append(
             b"\x12",
@@ -390,6 +411,9 @@ class AsyncBolt4x0(AsyncBolt):
     def rollback(
         self, dehydration_hooks=None, hydration_hooks=None, **handlers
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: ROLLBACK", self.local_port)
         self._append(
             b"\x13",
@@ -405,6 +429,9 @@ class AsyncBolt4x0(AsyncBolt):
         Add a RESET message to the outgoing queue, send it and consume all
         remaining messages.
         """
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: RESET", self.local_port)
         response = ResetResponse(self, "reset", hydration_hooks)
         self._append(
@@ -414,6 +441,9 @@ class AsyncBolt4x0(AsyncBolt):
         await self.fetch_all()
 
     def goodbye(self, dehydration_hooks=None, hydration_hooks=None):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: GOODBYE", self.local_port)
         self._append(b"\x02", (), dehydration_hooks=dehydration_hooks)
 
@@ -547,6 +577,9 @@ class AsyncBolt4x3(AsyncBolt4x2):
                 f"{self.PROTOCOL_VERSION!r}. Trying to impersonate "
                 f"{imp_user!r}."
             )
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
 
         routing_context = self.routing_context or {}
         log.debug(
@@ -576,6 +609,9 @@ class AsyncBolt4x3(AsyncBolt4x2):
             or self.notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
 
         def on_success(metadata):
             self.configuration_hints.update(metadata.pop("hints", {}))
@@ -635,6 +671,9 @@ class AsyncBolt4x4(AsyncBolt4x3):
         dehydration_hooks=None,
         hydration_hooks=None,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         routing_context = self.routing_context or {}
         db_context = {}
         if database is not None:
@@ -683,6 +722,9 @@ class AsyncBolt4x4(AsyncBolt4x3):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         if not parameters:
             parameters = {}
         extra = {}
@@ -744,6 +786,9 @@ class AsyncBolt4x4(AsyncBolt4x3):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {}
         if mode in {READ_ACCESS, "r"}:
             # It will default to mode "w" if nothing is specified

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -1094,9 +1094,9 @@ class AsyncBolt5x7(AsyncBolt5x6):
                 self.local_port,
                 diag_record,
             )
-            return
-        for key, value in self.DEFAULT_ERROR_DIAGNOSTIC_RECORD:
-            diag_record.setdefault(key, value)
+        else:
+            for key, value in self.DEFAULT_ERROR_DIAGNOSTIC_RECORD:
+                diag_record.setdefault(key, value)
         self._enrich_error_diagnostic_record(metadata.get("cause"))
 
     async def _process_message(self, tag, fields):

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -982,7 +982,7 @@ class AsyncBolt5x5(AsyncBolt5x4):
             dehydration_hooks=dehydration_hooks,
         )
 
-    DEFAULT_DIAGNOSTIC_RECORD = (
+    DEFAULT_STATUS_DIAGNOSTIC_RECORD = (
         ("OPERATION", ""),
         ("OPERATION_CODE", "0"),
         ("CURRENT_SCHEMA", "/"),
@@ -1062,15 +1062,107 @@ class AsyncBolt5x6(AsyncBolt5x5):
                     if not isinstance(diag_record, dict):
                         log.info(
                             "[#%04X]  _: <CONNECTION> Server supplied an "
-                            "invalid diagnostic record (%r).",
+                            "invalid status diagnostic record (%r).",
                             self.local_port,
                             diag_record,
                         )
                         continue
-                    for key, value in self.DEFAULT_DIAGNOSTIC_RECORD:
+                    for key, value in self.DEFAULT_STATUS_DIAGNOSTIC_RECORD:
                         diag_record.setdefault(key, value)
 
             enrich(metadata)
             await AsyncUtil.callback(wrapped_handler, metadata)
 
         return handler
+
+
+class AsyncBolt5x7(AsyncBolt5x6):
+    PROTOCOL_VERSION = Version(5, 7)
+
+    DEFAULT_ERROR_DIAGNOSTIC_RECORD = (
+        AsyncBolt5x5.DEFAULT_STATUS_DIAGNOSTIC_RECORD
+    )
+
+    def _enrich_error_diagnostic_record(self, metadata):
+        if not isinstance(metadata, dict):
+            return
+        diag_record = metadata.setdefault("diagnostic_record", {})
+        if not isinstance(diag_record, dict):
+            log.info(
+                "[#%04X]  _: <CONNECTION> Server supplied an "
+                "invalid error diagnostic record (%r).",
+                self.local_port,
+                diag_record,
+            )
+            return
+        for key, value in self.DEFAULT_ERROR_DIAGNOSTIC_RECORD:
+            diag_record.setdefault(key, value)
+
+    async def _process_message(self, tag, fields):
+        """Process at most one message from the server, if available.
+
+        :returns: 2-tuple of number of detail messages and number of summary
+                 messages fetched
+        """
+        details = []
+        summary_signature = summary_metadata = None
+        if tag == b"\x71":  # RECORD
+            details = fields
+        elif fields:
+            summary_signature = tag
+            summary_metadata = fields[0]
+        else:
+            summary_signature = tag
+
+        if details:
+            # Do not log any data
+            log.debug("[#%04X]  S: RECORD * %d", self.local_port, len(details))
+            await self.responses[0].on_records(details)
+
+        if summary_signature is None:
+            return len(details), 0
+
+        response = self.responses.popleft()
+        response.complete = True
+        if summary_signature == b"\x70":
+            log.debug(
+                "[#%04X]  S: SUCCESS %r", self.local_port, summary_metadata
+            )
+            self._server_state_manager.transition(
+                response.message, summary_metadata
+            )
+            await response.on_success(summary_metadata or {})
+        elif summary_signature == b"\x7e":
+            log.debug("[#%04X]  S: IGNORED", self.local_port)
+            await response.on_ignored(summary_metadata or {})
+        elif summary_signature == b"\x7f":
+            log.debug(
+                "[#%04X]  S: FAILURE %r", self.local_port, summary_metadata
+            )
+            self._server_state_manager.state = self.bolt_states.FAILED
+            self._enrich_error_diagnostic_record(summary_metadata)
+            try:
+                await response.on_failure(summary_metadata or {})
+            except (ServiceUnavailable, DatabaseUnavailable):
+                if self.pool:
+                    await self.pool.deactivate(address=self.unresolved_address)
+                raise
+            except (NotALeader, ForbiddenOnReadOnlyDatabase):
+                if self.pool:
+                    await self.pool.on_write_failure(
+                        address=self.unresolved_address,
+                        database=self.last_database,
+                    )
+                raise
+            except Neo4jError as e:
+                if self.pool:
+                    await self.pool.on_neo4j_error(e, self)
+                raise
+        else:
+            sig_int = ord(summary_signature)
+            raise BoltProtocolError(
+                f"Unexpected response message with signature {sig_int:02X}",
+                self.unresolved_address,
+            )
+
+        return len(details), 1

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -1009,7 +1009,7 @@ class AsyncBolt5x5(AsyncBolt5x4):
                             diag_record,
                         )
                         continue
-                    for key, value in self.DEFAULT_DIAGNOSTIC_RECORD:
+                    for key, value in self.DEFAULT_STATUS_DIAGNOSTIC_RECORD:
                         diag_record.setdefault(key, value)
 
             enrich(metadata)
@@ -1097,6 +1097,7 @@ class AsyncBolt5x7(AsyncBolt5x6):
             return
         for key, value in self.DEFAULT_ERROR_DIAGNOSTIC_RECORD:
             diag_record.setdefault(key, value)
+        self._enrich_error_diagnostic_record(metadata.get("cause"))
 
     async def _process_message(self, tag, fields):
         """Process at most one message from the server, if available.

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -227,7 +227,7 @@ class AsyncBolt5x0(AsyncBolt):
             response=Response(
                 self, "route", hydration_hooks, on_success=metadata.update
             ),
-            dehydration_hooks=hydration_hooks,
+            dehydration_hooks=dehydration_hooks,
         )
         await self.send_all()
         await self.fetch_all()

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -136,6 +136,9 @@ class AsyncBolt5x0(AsyncBolt):
             or self.notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
 
         def on_success(metadata):
             self.configuration_hints.update(metadata.pop("hints", {}))
@@ -200,6 +203,9 @@ class AsyncBolt5x0(AsyncBolt):
         dehydration_hooks=None,
         hydration_hooks=None,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         routing_context = self.routing_context or {}
         db_context = {}
         if database is not None:
@@ -248,6 +254,9 @@ class AsyncBolt5x0(AsyncBolt):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         if not parameters:
             parameters = {}
         extra = {}
@@ -298,6 +307,9 @@ class AsyncBolt5x0(AsyncBolt):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {"n": n}
         if qid != -1:
             extra["qid"] = qid
@@ -317,6 +329,9 @@ class AsyncBolt5x0(AsyncBolt):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {"n": n}
         if qid != -1:
             extra["qid"] = qid
@@ -347,6 +362,9 @@ class AsyncBolt5x0(AsyncBolt):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {}
         if mode in {READ_ACCESS, "r"}:
             # It will default to mode "w" if nothing is specified
@@ -381,6 +399,9 @@ class AsyncBolt5x0(AsyncBolt):
         )
 
     def commit(self, dehydration_hooks=None, hydration_hooks=None, **handlers):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: COMMIT", self.local_port)
         self._append(
             b"\x12",
@@ -392,6 +413,9 @@ class AsyncBolt5x0(AsyncBolt):
     def rollback(
         self, dehydration_hooks=None, hydration_hooks=None, **handlers
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: ROLLBACK", self.local_port)
         self._append(
             b"\x13",
@@ -407,6 +431,9 @@ class AsyncBolt5x0(AsyncBolt):
         Add a RESET message to the outgoing queue, send it and consume all
         remaining messages.
         """
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: RESET", self.local_port)
         response = ResetResponse(self, "reset", hydration_hooks)
         self._append(
@@ -416,6 +443,9 @@ class AsyncBolt5x0(AsyncBolt):
         await self.fetch_all()
 
     def goodbye(self, dehydration_hooks=None, hydration_hooks=None):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: GOODBYE", self.local_port)
         self._append(b"\x02", (), dehydration_hooks=dehydration_hooks)
 
@@ -580,6 +610,9 @@ class AsyncBolt5x1(AsyncBolt5x0):
             or self.notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
 
         def on_success(metadata):
             self.configuration_hints.update(metadata.pop("hints", {}))
@@ -620,6 +653,9 @@ class AsyncBolt5x1(AsyncBolt5x0):
         check_supported_server_product(self.server_info.agent)
 
     def logon(self, dehydration_hooks=None, hydration_hooks=None):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         logged_auth_dict = dict(self.auth_dict)
         if "credentials" in logged_auth_dict:
             logged_auth_dict["credentials"] = "*******"
@@ -632,6 +668,9 @@ class AsyncBolt5x1(AsyncBolt5x0):
         )
 
     def logoff(self, dehydration_hooks=None, hydration_hooks=None):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: LOGOFF", self.local_port)
         self._append(
             b"\x6b",
@@ -658,6 +697,10 @@ class AsyncBolt5x2(AsyncBolt5x1):
         return headers
 
     async def hello(self, dehydration_hooks=None, hydration_hooks=None):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
+
         def on_success(metadata):
             self.configuration_hints.update(metadata.pop("hints", {}))
             self.server_info.update(metadata)
@@ -709,6 +752,9 @@ class AsyncBolt5x2(AsyncBolt5x1):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         if not parameters:
             parameters = {}
         extra = {}
@@ -773,6 +819,9 @@ class AsyncBolt5x2(AsyncBolt5x1):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {}
         if mode in {READ_ACCESS, "r"}:
             # It will default to mode "w" if nothing is specified
@@ -838,6 +887,9 @@ class AsyncBolt5x4(AsyncBolt5x3):
             "telemetry.enabled", False
         ):
             return
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         api_raw = int(api)
         log.debug(
             "[#%04X]  C: TELEMETRY %i  # (%r)", self.local_port, api_raw, api
@@ -877,6 +929,9 @@ class AsyncBolt5x5(AsyncBolt5x4):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         if not parameters:
             parameters = {}
         extra = {}
@@ -941,6 +996,9 @@ class AsyncBolt5x5(AsyncBolt5x4):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {}
         if mode in {READ_ACCESS, "r"}:
             # It will default to mode "w" if nothing is specified

--- a/src/neo4j/_async/io/_common.py
+++ b/src/neo4j/_async/io/_common.py
@@ -264,7 +264,7 @@ class Response:
         if self.connection.PROTOCOL_VERSION >= GQL_ERROR_AWARE_PROTOCOL:
             return Neo4jError._hydrate_gql(**metadata)
         else:
-            return Neo4jError.hydrate(**metadata)
+            return Neo4jError._hydrate_neo4j(**metadata)
 
 
 class InitResponse(Response):

--- a/src/neo4j/_async/io/_common.py
+++ b/src/neo4j/_async/io/_common.py
@@ -21,6 +21,7 @@ from struct import pack as struct_pack
 
 from ..._async_compat.util import AsyncUtil
 from ..._exceptions import SocketDeadlineExceededError
+from ...api import Version
 from ...exceptions import (
     Neo4jError,
     ServiceUnavailable,
@@ -28,6 +29,8 @@ from ...exceptions import (
     UnsupportedServerProduct,
 )
 
+
+GQL_ERROR_AWARE_PROTOCOL = Version(5, 7)
 
 log = logging.getLogger("neo4j.io")
 
@@ -248,7 +251,7 @@ class Response:
         await AsyncUtil.callback(handler, metadata)
         handler = self.handlers.get("on_summary")
         await AsyncUtil.callback(handler)
-        raise Neo4jError.hydrate(**metadata)
+        raise self._hydrate_error(metadata)
 
     async def on_ignored(self, metadata=None):
         """Handle an IGNORED message been received."""
@@ -256,6 +259,12 @@ class Response:
         await AsyncUtil.callback(handler, metadata)
         handler = self.handlers.get("on_summary")
         await AsyncUtil.callback(handler)
+
+    def _hydrate_error(self, metadata):
+        if self.connection.PROTOCOL_VERSION >= GQL_ERROR_AWARE_PROTOCOL:
+            return Neo4jError._hydrate_gql(**metadata)
+        else:
+            return Neo4jError.hydrate(**metadata)
 
 
 class InitResponse(Response):
@@ -271,7 +280,7 @@ class InitResponse(Response):
             "message",
             "Connection initialisation failed due to an unknown error",
         )
-        raise Neo4jError.hydrate(**metadata)
+        raise self._hydrate_error(metadata)
 
 
 class LogonResponse(InitResponse):
@@ -283,7 +292,7 @@ class LogonResponse(InitResponse):
         await AsyncUtil.callback(handler, metadata)
         handler = self.handlers.get("on_summary")
         await AsyncUtil.callback(handler)
-        raise Neo4jError.hydrate(**metadata)
+        raise self._hydrate_error(metadata)
 
 
 class ResetResponse(Response):

--- a/src/neo4j/_async/io/_pool.py
+++ b/src/neo4j/_async/io/_pool.py
@@ -341,6 +341,7 @@ class AsyncIOPool(abc.ABC):
                     or not await self.cond.wait(timeout)
                 ):
                     log.debug("[#0000]  _: <POOL> acquisition timed out")
+                    # TODO: 6.0 - change this to be a DriverError (or subclass)
                     raise ClientError(
                         "failed to obtain a connection from the pool within "
                         f"{deadline.original_timeout!r}s (timeout)"
@@ -1055,8 +1056,10 @@ class AsyncNeo4jPool(AsyncIOPool):
         liveness_check_timeout,
     ):
         if access_mode not in {WRITE_ACCESS, READ_ACCESS}:
+            # TODO: 6.0 - change this to be a ValueError
             raise ClientError(f"Non valid 'access_mode'; {access_mode}")
         if not timeout:
+            # TODO: 6.0 - change this to be a ValueError
             raise ClientError(
                 f"'timeout' must be a float larger than 0; {timeout}"
             )

--- a/src/neo4j/_async/work/session.py
+++ b/src/neo4j/_async/work/session.py
@@ -294,6 +294,7 @@ class AsyncSession(AsyncWorkspace):
             raise TypeError("query must be a string or a Query instance")
 
         if self._transaction:
+            # TODO: 6.0 - change this to be a TransactionError
             raise ClientError(
                 "Explicit Transaction must be handled explicitly"
             )

--- a/src/neo4j/_codec/hydration/v1/hydration_handler.py
+++ b/src/neo4j/_codec/hydration/v1/hydration_handler.py
@@ -154,7 +154,6 @@ class _GraphHydrator(GraphHydrator):
 class HydrationHandler(HydrationHandlerABC):
     def __init__(self):
         super().__init__()
-        self._created_scope = False
         self.struct_hydration_functions = {
             **self.struct_hydration_functions,
             b"X": spatial.hydrate_point,
@@ -201,8 +200,6 @@ class HydrationHandler(HydrationHandlerABC):
     def patch_utc(self):
         from ..v2 import temporal as temporal_v2
 
-        assert not self._created_scope
-
         del self.struct_hydration_functions[b"F"]
         del self.struct_hydration_functions[b"f"]
         self.struct_hydration_functions.update(
@@ -226,5 +223,4 @@ class HydrationHandler(HydrationHandlerABC):
             )
 
     def new_hydration_scope(self):
-        self._created_scope = True
         return HydrationScope(self, _GraphHydrator())

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -916,6 +916,16 @@ class Bolt:
     def new_hydration_scope(self):
         return self.hydration_handler.new_hydration_scope()
 
+    def _default_hydration_hooks(self, dehydration_hooks, hydration_hooks):
+        if dehydration_hooks is not None and hydration_hooks is not None:
+            return dehydration_hooks, hydration_hooks
+        hydration_scope = self.new_hydration_scope()
+        if dehydration_hooks is None:
+            dehydration_hooks = hydration_scope.dehydration_hooks
+        if hydration_hooks is None:
+            hydration_hooks = hydration_scope.hydration_hooks
+        return dehydration_hooks, hydration_hooks
+
     def _append(
         self, signature, fields=(), response=None, dehydration_hooks=None
     ):

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -458,7 +458,10 @@ class Bolt:
 
         # avoid new lines after imports for better readability and conciseness
         # fmt: off
-        if protocol_version == (5, 6):
+        if protocol_version == (5, 7):
+            from ._bolt5 import Bolt5x7
+            bolt_cls = Bolt5x7
+        elif protocol_version == (5, 6):
             from ._bolt5 import Bolt5x6
             bolt_cls = Bolt5x6
         elif protocol_version == (5, 5):

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -217,6 +217,7 @@ class Bolt:
             try:
                 return vars(auth)
             except (KeyError, TypeError) as e:
+                # TODO: 6.0 - change this to be a DriverError (or subclass)
                 raise AuthError(
                     f"Cannot determine auth details from {auth!r}"
                 ) from e
@@ -306,6 +307,7 @@ class Bolt:
             Bolt5x4,
             Bolt5x5,
             Bolt5x6,
+            Bolt5x7,
         )
 
         handlers = {
@@ -322,6 +324,7 @@ class Bolt:
             Bolt5x4.PROTOCOL_VERSION: Bolt5x4,
             Bolt5x5.PROTOCOL_VERSION: Bolt5x5,
             Bolt5x6.PROTOCOL_VERSION: Bolt5x6,
+            Bolt5x7.PROTOCOL_VERSION: Bolt5x7,
         }
 
         if protocol_version is None:
@@ -509,6 +512,7 @@ class Bolt:
             BoltSocket.close_socket(s)
 
             supported_versions = cls.protocol_handlers().keys()
+            # TODO: 6.0 - raise public DriverError subclass instead
             raise BoltHandshakeError(
                 "The neo4j server does not support communication with this "
                 "driver. This driver has support for Bolt protocols "

--- a/src/neo4j/_sync/io/_bolt3.py
+++ b/src/neo4j/_sync/io/_bolt3.py
@@ -215,6 +215,9 @@ class Bolt3(Bolt):
             or self.notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         headers = self.get_base_headers()
         headers.update(self.auth_dict)
         logged_headers = dict(headers)
@@ -275,6 +278,9 @@ class Bolt3(Bolt):
                 f"{self.PROTOCOL_VERSION!r}. Trying to impersonate "
                 f"{imp_user!r}."
             )
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
 
         metadata = {}
         records = []
@@ -337,6 +343,9 @@ class Bolt3(Bolt):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         if not parameters:
             parameters = {}
         extra = {}
@@ -379,6 +388,9 @@ class Bolt3(Bolt):
         **handlers,
     ):
         # Just ignore n and qid, it is not supported in the Bolt 3 Protocol.
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: DISCARD_ALL", self.local_port)
         self._append(
             b"\x2f",
@@ -396,6 +408,9 @@ class Bolt3(Bolt):
         **handlers,
     ):
         # Just ignore n and qid, it is not supported in the Bolt 3 Protocol.
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: PULL_ALL", self.local_port)
         self._append(
             b"\x3f",
@@ -435,6 +450,9 @@ class Bolt3(Bolt):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {}
         if mode in {READ_ACCESS, "r"}:
             # It will default to mode "w" if nothing is specified
@@ -464,6 +482,9 @@ class Bolt3(Bolt):
         )
 
     def commit(self, dehydration_hooks=None, hydration_hooks=None, **handlers):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: COMMIT", self.local_port)
         self._append(
             b"\x12",
@@ -475,6 +496,9 @@ class Bolt3(Bolt):
     def rollback(
         self, dehydration_hooks=None, hydration_hooks=None, **handlers
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: ROLLBACK", self.local_port)
         self._append(
             b"\x13",
@@ -490,6 +514,9 @@ class Bolt3(Bolt):
         Add a RESET message to the outgoing queue, send it and consume all
         remaining messages.
         """
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: RESET", self.local_port)
         response = ResetResponse(self, "reset", hydration_hooks)
         self._append(
@@ -499,6 +526,9 @@ class Bolt3(Bolt):
         self.fetch_all()
 
     def goodbye(self, dehydration_hooks=None, hydration_hooks=None):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: GOODBYE", self.local_port)
         self._append(b"\x02", (), dehydration_hooks=dehydration_hooks)
 

--- a/src/neo4j/_sync/io/_bolt4.py
+++ b/src/neo4j/_sync/io/_bolt4.py
@@ -131,6 +131,9 @@ class Bolt4x0(Bolt):
             or self.notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         headers = self.get_base_headers()
         headers.update(self.auth_dict)
         logged_headers = dict(headers)
@@ -184,6 +187,9 @@ class Bolt4x0(Bolt):
                 f"{self.PROTOCOL_VERSION!r}. Trying to impersonate "
                 f"{imp_user!r}."
             )
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         metadata = {}
         records = []
 
@@ -244,6 +250,9 @@ class Bolt4x0(Bolt):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         if not parameters:
             parameters = {}
         extra = {}
@@ -292,6 +301,9 @@ class Bolt4x0(Bolt):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {"n": n}
         if qid != -1:
             extra["qid"] = qid
@@ -311,6 +323,9 @@ class Bolt4x0(Bolt):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {"n": n}
         if qid != -1:
             extra["qid"] = qid
@@ -347,6 +362,9 @@ class Bolt4x0(Bolt):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {}
         if mode in {READ_ACCESS, "r"}:
             # It will default to mode "w" if nothing is specified
@@ -379,6 +397,9 @@ class Bolt4x0(Bolt):
         )
 
     def commit(self, dehydration_hooks=None, hydration_hooks=None, **handlers):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: COMMIT", self.local_port)
         self._append(
             b"\x12",
@@ -390,6 +411,9 @@ class Bolt4x0(Bolt):
     def rollback(
         self, dehydration_hooks=None, hydration_hooks=None, **handlers
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: ROLLBACK", self.local_port)
         self._append(
             b"\x13",
@@ -405,6 +429,9 @@ class Bolt4x0(Bolt):
         Add a RESET message to the outgoing queue, send it and consume all
         remaining messages.
         """
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: RESET", self.local_port)
         response = ResetResponse(self, "reset", hydration_hooks)
         self._append(
@@ -414,6 +441,9 @@ class Bolt4x0(Bolt):
         self.fetch_all()
 
     def goodbye(self, dehydration_hooks=None, hydration_hooks=None):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: GOODBYE", self.local_port)
         self._append(b"\x02", (), dehydration_hooks=dehydration_hooks)
 
@@ -547,6 +577,9 @@ class Bolt4x3(Bolt4x2):
                 f"{self.PROTOCOL_VERSION!r}. Trying to impersonate "
                 f"{imp_user!r}."
             )
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
 
         routing_context = self.routing_context or {}
         log.debug(
@@ -576,6 +609,9 @@ class Bolt4x3(Bolt4x2):
             or self.notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
 
         def on_success(metadata):
             self.configuration_hints.update(metadata.pop("hints", {}))
@@ -635,6 +671,9 @@ class Bolt4x4(Bolt4x3):
         dehydration_hooks=None,
         hydration_hooks=None,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         routing_context = self.routing_context or {}
         db_context = {}
         if database is not None:
@@ -683,6 +722,9 @@ class Bolt4x4(Bolt4x3):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         if not parameters:
             parameters = {}
         extra = {}
@@ -744,6 +786,9 @@ class Bolt4x4(Bolt4x3):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {}
         if mode in {READ_ACCESS, "r"}:
             # It will default to mode "w" if nothing is specified

--- a/src/neo4j/_sync/io/_bolt5.py
+++ b/src/neo4j/_sync/io/_bolt5.py
@@ -1009,7 +1009,7 @@ class Bolt5x5(Bolt5x4):
                             diag_record,
                         )
                         continue
-                    for key, value in self.DEFAULT_DIAGNOSTIC_RECORD:
+                    for key, value in self.DEFAULT_STATUS_DIAGNOSTIC_RECORD:
                         diag_record.setdefault(key, value)
 
             enrich(metadata)
@@ -1097,6 +1097,7 @@ class Bolt5x7(Bolt5x6):
             return
         for key, value in self.DEFAULT_ERROR_DIAGNOSTIC_RECORD:
             diag_record.setdefault(key, value)
+        self._enrich_error_diagnostic_record(metadata.get("cause"))
 
     def _process_message(self, tag, fields):
         """Process at most one message from the server, if available.

--- a/src/neo4j/_sync/io/_bolt5.py
+++ b/src/neo4j/_sync/io/_bolt5.py
@@ -227,7 +227,7 @@ class Bolt5x0(Bolt):
             response=Response(
                 self, "route", hydration_hooks, on_success=metadata.update
             ),
-            dehydration_hooks=hydration_hooks,
+            dehydration_hooks=dehydration_hooks,
         )
         self.send_all()
         self.fetch_all()

--- a/src/neo4j/_sync/io/_bolt5.py
+++ b/src/neo4j/_sync/io/_bolt5.py
@@ -136,6 +136,9 @@ class Bolt5x0(Bolt):
             or self.notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
 
         def on_success(metadata):
             self.configuration_hints.update(metadata.pop("hints", {}))
@@ -200,6 +203,9 @@ class Bolt5x0(Bolt):
         dehydration_hooks=None,
         hydration_hooks=None,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         routing_context = self.routing_context or {}
         db_context = {}
         if database is not None:
@@ -248,6 +254,9 @@ class Bolt5x0(Bolt):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         if not parameters:
             parameters = {}
         extra = {}
@@ -298,6 +307,9 @@ class Bolt5x0(Bolt):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {"n": n}
         if qid != -1:
             extra["qid"] = qid
@@ -317,6 +329,9 @@ class Bolt5x0(Bolt):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {"n": n}
         if qid != -1:
             extra["qid"] = qid
@@ -347,6 +362,9 @@ class Bolt5x0(Bolt):
             or notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {}
         if mode in {READ_ACCESS, "r"}:
             # It will default to mode "w" if nothing is specified
@@ -381,6 +399,9 @@ class Bolt5x0(Bolt):
         )
 
     def commit(self, dehydration_hooks=None, hydration_hooks=None, **handlers):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: COMMIT", self.local_port)
         self._append(
             b"\x12",
@@ -392,6 +413,9 @@ class Bolt5x0(Bolt):
     def rollback(
         self, dehydration_hooks=None, hydration_hooks=None, **handlers
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: ROLLBACK", self.local_port)
         self._append(
             b"\x13",
@@ -407,6 +431,9 @@ class Bolt5x0(Bolt):
         Add a RESET message to the outgoing queue, send it and consume all
         remaining messages.
         """
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: RESET", self.local_port)
         response = ResetResponse(self, "reset", hydration_hooks)
         self._append(
@@ -416,6 +443,9 @@ class Bolt5x0(Bolt):
         self.fetch_all()
 
     def goodbye(self, dehydration_hooks=None, hydration_hooks=None):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: GOODBYE", self.local_port)
         self._append(b"\x02", (), dehydration_hooks=dehydration_hooks)
 
@@ -580,6 +610,9 @@ class Bolt5x1(Bolt5x0):
             or self.notifications_disabled_classifications is not None
         ):
             self.assert_notification_filtering_support()
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
 
         def on_success(metadata):
             self.configuration_hints.update(metadata.pop("hints", {}))
@@ -620,6 +653,9 @@ class Bolt5x1(Bolt5x0):
         check_supported_server_product(self.server_info.agent)
 
     def logon(self, dehydration_hooks=None, hydration_hooks=None):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         logged_auth_dict = dict(self.auth_dict)
         if "credentials" in logged_auth_dict:
             logged_auth_dict["credentials"] = "*******"
@@ -632,6 +668,9 @@ class Bolt5x1(Bolt5x0):
         )
 
     def logoff(self, dehydration_hooks=None, hydration_hooks=None):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         log.debug("[#%04X]  C: LOGOFF", self.local_port)
         self._append(
             b"\x6b",
@@ -658,6 +697,10 @@ class Bolt5x2(Bolt5x1):
         return headers
 
     def hello(self, dehydration_hooks=None, hydration_hooks=None):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
+
         def on_success(metadata):
             self.configuration_hints.update(metadata.pop("hints", {}))
             self.server_info.update(metadata)
@@ -709,6 +752,9 @@ class Bolt5x2(Bolt5x1):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         if not parameters:
             parameters = {}
         extra = {}
@@ -773,6 +819,9 @@ class Bolt5x2(Bolt5x1):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {}
         if mode in {READ_ACCESS, "r"}:
             # It will default to mode "w" if nothing is specified
@@ -838,6 +887,9 @@ class Bolt5x4(Bolt5x3):
             "telemetry.enabled", False
         ):
             return
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         api_raw = int(api)
         log.debug(
             "[#%04X]  C: TELEMETRY %i  # (%r)", self.local_port, api_raw, api
@@ -877,6 +929,9 @@ class Bolt5x5(Bolt5x4):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         if not parameters:
             parameters = {}
         extra = {}
@@ -941,6 +996,9 @@ class Bolt5x5(Bolt5x4):
         hydration_hooks=None,
         **handlers,
     ):
+        dehydration_hooks, hydration_hooks = self._default_hydration_hooks(
+            dehydration_hooks, hydration_hooks
+        )
         extra = {}
         if mode in {READ_ACCESS, "r"}:
             # It will default to mode "w" if nothing is specified

--- a/src/neo4j/_sync/io/_bolt5.py
+++ b/src/neo4j/_sync/io/_bolt5.py
@@ -1094,9 +1094,9 @@ class Bolt5x7(Bolt5x6):
                 self.local_port,
                 diag_record,
             )
-            return
-        for key, value in self.DEFAULT_ERROR_DIAGNOSTIC_RECORD:
-            diag_record.setdefault(key, value)
+        else:
+            for key, value in self.DEFAULT_ERROR_DIAGNOSTIC_RECORD:
+                diag_record.setdefault(key, value)
         self._enrich_error_diagnostic_record(metadata.get("cause"))
 
     def _process_message(self, tag, fields):

--- a/src/neo4j/_sync/io/_common.py
+++ b/src/neo4j/_sync/io/_common.py
@@ -264,7 +264,7 @@ class Response:
         if self.connection.PROTOCOL_VERSION >= GQL_ERROR_AWARE_PROTOCOL:
             return Neo4jError._hydrate_gql(**metadata)
         else:
-            return Neo4jError.hydrate(**metadata)
+            return Neo4jError._hydrate_neo4j(**metadata)
 
 
 class InitResponse(Response):

--- a/src/neo4j/_sync/io/_pool.py
+++ b/src/neo4j/_sync/io/_pool.py
@@ -338,6 +338,7 @@ class IOPool(abc.ABC):
                     or not self.cond.wait(timeout)
                 ):
                     log.debug("[#0000]  _: <POOL> acquisition timed out")
+                    # TODO: 6.0 - change this to be a DriverError (or subclass)
                     raise ClientError(
                         "failed to obtain a connection from the pool within "
                         f"{deadline.original_timeout!r}s (timeout)"
@@ -1052,8 +1053,10 @@ class Neo4jPool(IOPool):
         liveness_check_timeout,
     ):
         if access_mode not in {WRITE_ACCESS, READ_ACCESS}:
+            # TODO: 6.0 - change this to be a ValueError
             raise ClientError(f"Non valid 'access_mode'; {access_mode}")
         if not timeout:
+            # TODO: 6.0 - change this to be a ValueError
             raise ClientError(
                 f"'timeout' must be a float larger than 0; {timeout}"
             )

--- a/src/neo4j/_sync/work/session.py
+++ b/src/neo4j/_sync/work/session.py
@@ -294,6 +294,7 @@ class Session(Workspace):
             raise TypeError("query must be a string or a Query instance")
 
         if self._transaction:
+            # TODO: 6.0 - change this to be a TransactionError
             raise ClientError(
                 "Explicit Transaction must be handled explicitly"
             )

--- a/src/neo4j/_work/summary.py
+++ b/src/neo4j/_work/summary.py
@@ -767,7 +767,7 @@ class GqlStatusObject:
 
         .. note::
             This means these codes are not guaranteed to be stable and may
-            change in future versions.
+            change in future versions of the driver or the server.
         """
         if hasattr(self, "_gql_status"):
             return self._gql_status

--- a/src/neo4j/exceptions.py
+++ b/src/neo4j/exceptions.py
@@ -253,7 +253,7 @@ class GqlErrorClassification(str, _Enum):
 
     .. seealso:: :attr:`.GqlError.gql_classification`
 
-    .. versionadded:: 5.xx
+    .. versionadded:: 5.26
     """
 
     CLIENT_ERROR = "CLIENT_ERROR"
@@ -279,7 +279,7 @@ class GqlError(Exception):
     See also
     https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
 
-    .. versionadded: 5.xx
+    .. versionadded: 5.26
     """
 
     _gql_status: str

--- a/src/neo4j/exceptions.py
+++ b/src/neo4j/exceptions.py
@@ -59,9 +59,50 @@ Driver API Errors
 
 from __future__ import annotations
 
+import sys
 import typing as t
+from copy import deepcopy
 
-from ._meta import deprecated
+from ._meta import (
+    deprecated,
+    preview,
+)
+
+
+__all__ = [
+    "AuthConfigurationError",
+    "AuthError",
+    "BrokenRecordError",
+    "CertificateConfigurationError",
+    "ClientError",
+    "ConfigurationError",
+    "ConstraintError",
+    "CypherSyntaxError",
+    "CypherTypeError",
+    "DatabaseError",
+    "DatabaseUnavailable",
+    "DriverError",
+    "Forbidden",
+    "ForbiddenOnReadOnlyDatabase",
+    "IncompleteCommit",
+    "Neo4jError",
+    "NotALeader",
+    "ReadServiceUnavailable",
+    "ResultConsumedError",
+    "ResultError",
+    "ResultFailedError",
+    "ResultNotSingleError",
+    "RoutingServiceUnavailable",
+    "ServiceUnavailable",
+    "SessionError",
+    "SessionExpired",
+    "TokenExpired",
+    "TransactionError",
+    "TransactionNestingError",
+    "TransientError",
+    "UnsupportedServerProduct",
+    "WriteServiceUnavailable",
+]
 
 
 if t.TYPE_CHECKING:
@@ -168,57 +209,107 @@ ERROR_REWRITE_MAP: dict[str, tuple[str, str | None]] = {
 }
 
 
+_UNKNOWN_GQL_STATUS = "50N42"
+_UNKNOWN_GQL_EXPLANATION = "general processing exception - unknown error"
+_UNKNOWN_GQL_CLASSIFICATION = "UNKNOWN"  # TODO: define final value
+_UNKNOWN_GQL_DIAGNOSTIC_RECORD = (
+    (
+        "OPERATION",
+        "",
+    ),
+    (
+        "OPERATION_CODE",
+        "0",
+    ),
+    ("CURRENT_SCHEMA", "/"),
+)
+
+
+def _make_gql_description(explanation: str, message: str | None = None) -> str:
+    if message is None:
+        return f"error: {explanation}"
+
+    return f"error: {explanation}. {message}"
+
+
 # Neo4jError
 class Neo4jError(Exception):
     """Raised when the Cypher engine returns an error to the client."""
 
-    #: (str or None) The error message returned by the server.
-    message = None
-    #: (str or None) The error code returned by the server.
-    #: There are many Neo4j status codes, see
-    #: `status codes <https://neo4j.com/docs/status-codes/current/>`_.
-    code = None
-    classification = None
-    category = None
-    title = None
+    _neo4j_code: str
+    _message: str
+    _classification: str
+    _category: str
+    _title: str
     #: (dict) Any additional information returned by the server.
-    metadata = None
+    _metadata: dict[str, t.Any]
+
+    _gql_status: str
+    _gql_explanation: str  # internal use only
+    _gql_description: str
+    _gql_status_description: str
+    _gql_classification: str
+    _status_diagnostic_record: dict[str, t.Any]  # original, internal only
+    _diagnostic_record: dict[str, t.Any]  # copy to be used externally
 
     _retryable = False
 
     @classmethod
-    def hydrate(
+    def _hydrate(
         cls,
+        *,
+        neo4j_code: str | None = None,
         message: str | None = None,
-        code: str | None = None,
-        **metadata: t.Any,
-    ) -> Neo4jError:
+        gql_status: str | None = None,
+        explanation: str | None = None,
+        diagnostic_record: dict[str, t.Any] | None = None,
+        cause: Neo4jError | None = None,
+    ) -> te.Self:
+        neo4j_code = neo4j_code or "Neo.DatabaseError.General.UnknownError"
         message = message or "An unknown error occurred"
-        code = code or "Neo.DatabaseError.General.UnknownError"
+
         try:
-            _, classification, category, title = code.split(".")
+            _, classification, category, title = neo4j_code.split(".")
         except ValueError:
             classification = CLASSIFICATION_DATABASE
             category = "General"
             title = "UnknownError"
         else:
             classification_override, code_override = ERROR_REWRITE_MAP.get(
-                code, (None, None)
+                neo4j_code, (None, None)
             )
             if classification_override is not None:
                 classification = classification_override
             if code_override is not None:
-                code = code_override
+                neo4j_code = code_override
 
-        error_class = cls._extract_error_class(classification, code)
+        error_class = cls._extract_error_class(classification, neo4j_code)
 
-        inst = error_class(message)
-        inst.message = message
-        inst.code = code
-        inst.classification = classification
-        inst.category = category
-        inst.title = title
-        inst.metadata = metadata
+        if explanation is not None:
+            gql_description = _make_gql_description(explanation, message)
+            inst = error_class(gql_description)
+            inst._gql_description = gql_description
+        else:
+            inst = error_class(message)
+
+        inst._neo4j_code = neo4j_code
+        inst._message = message
+        inst._classification = classification
+        inst._category = category
+        inst._title = title
+        if gql_status:
+            inst._gql_status = gql_status
+        if explanation:
+            inst._gql_explanation = explanation
+        if diagnostic_record is not None:
+            inst._status_diagnostic_record = diagnostic_record
+        if cause:
+            inst.__cause__ = cause
+        else:
+            current_exc = sys.exc_info()[1]
+            if current_exc is not None:
+                inst.__context__ = current_exc
+
         return inst
 
     @classmethod
@@ -240,6 +331,257 @@ class Neo4jError(Exception):
 
         else:
             return cls
+
+    @classmethod
+    def hydrate(
+        cls,
+        code: str | None = None,
+        message: str | None = None,
+        **metadata: t.Any,
+    ) -> te.Self:
+        inst = cls._hydrate(neo4j_code=code, message=message)
+        inst._metadata = metadata
+        return inst
+
+    @classmethod
+    def _hydrate_gql(cls, **metadata: t.Any) -> te.Self:
+        gql_status = metadata.pop("gql_status", None)
+        if not isinstance(gql_status, str):
+            gql_status = None
+        status_explanation = metadata.pop("status_explanation", None)
+        if not isinstance(status_explanation, str):
+            status_explanation = None
+        message = metadata.pop("status_message", None)
+        if not isinstance(message, str):
+            message = None
+        neo4j_code = metadata.pop("neo4j_code", None)
+        if not isinstance(neo4j_code, str):
+            neo4j_code = None
+        diagnostic_record = metadata.pop("diagnostic_record", None)
+        if not isinstance(diagnostic_record, dict):
+            diagnostic_record = None
+        cause = metadata.pop("cause", None)
+        if not isinstance(cause, dict):
+            cause = None
+        else:
+            cause = cls._hydrate_gql(**cause)
+
+        inst = cls._hydrate(
+            neo4j_code=neo4j_code,
+            message=message,
+            gql_status=gql_status,
+            explanation=status_explanation,
+            diagnostic_record=diagnostic_record,
+            cause=cause,
+        )
+        inst._metadata = metadata
+
+        return inst
+
+    @property
+    def message(self) -> str:
+        """
+        TODO.
+
+        #: (str or None) The error message returned by the server.
+        """
+        return self._message
+
+    @message.setter
+    @deprecated("Altering the message of a Neo4jError is deprecated.")
+    def message(self, value: str) -> None:
+        self._message = value
+
+    # TODO: 6.0 - Remove this alias
+    @property
+    @deprecated(
+        "The code of a Neo4jError is deprecated. Use neo4j_code instead."
+    )
+    def code(self) -> str:
+        """
+        The neo4j error code returned by the server.
+
+        .. deprecated:: 5.xx
+            Use :attr:`.neo4j_code` instead.
+        """
+        return self._neo4j_code
+
+    # TODO: 6.0 - Remove this and all other deprecated setters
+    @code.setter
+    @deprecated("Altering the code of a Neo4jError is deprecated.")
+    def code(self, value: str) -> None:
+        self._neo4j_code = value
+
+    @property
+    def neo4j_code(self) -> str:
+        """
+        The error code returned by the server.
+
+        There are many Neo4j status codes, see
+        `status codes <https://neo4j.com/docs/status-codes/current/>`_.
+
+        .. versionadded: 5.xx
+        """
+        return self._neo4j_code
+
+    @property
+    @deprecated("classification of Neo4jError is deprecated.")
+    def classification(self) -> str:
+        # Undocumented, has been there before
+        # TODO 6.0: Remove this property
+        return self._classification
+
+    @classification.setter
+    @deprecated("classification of Neo4jError is deprecated.")
+    def classification(self, value: str) -> None:
+        self._classification = value
+
+    @property
+    @deprecated("category of Neo4jError is deprecated.")
+    def category(self) -> str:
+        # Undocumented, has been there before
+        # TODO 6.0: Remove this property
+        return self._category
+
+    @category.setter
+    @deprecated("category of Neo4jError is deprecated.")
+    def category(self, value: str) -> None:
+        self._category = value
+
+    @property
+    @deprecated("title of Neo4jError is deprecated.")
+    def title(self) -> str:
+        # Undocumented, has been there before
+        # TODO 6.0: Remove this property
+        return self._title
+
+    @title.setter
+    @deprecated("title of Neo4jError is deprecated.")
+    def title(self, value: str) -> None:
+        self._title = value
+
+    @property
+    def metadata(self) -> dict[str, t.Any]:
+        # Undocumented, might be useful for debugging
+        return self._metadata
+
+    @metadata.setter
+    @deprecated("Altering the metadata of Neo4jError is deprecated.")
+    def metadata(self, value: dict[str, t.Any]) -> None:
+        # TODO 6.0: Remove this property
+        self._metadata = value
+
+    @property
+    @preview("GQLSTATUS support is a preview feature.")
+    def gql_status(self) -> str:
+        """
+        The GQLSTATUS returned from the server.
+
+        The status code ``50N42`` (unknown error) is a special code that the
+        driver will use for polyfilling (when connected to an old,
+        non-GQL-aware server).
+        Further, it may be used by servers during the transition-phase to
+        GQLSTATUS-awareness.
+
+        This means this code is not guaranteed to be stable and may change in
+        future versions.
+
+        **This is a preview**.
+        It might be changed without following the deprecation policy.
+        See also
+        https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
+
+        .. versionadded: 5.xx
+        """
+        if hasattr(self, "_gql_status"):
+            return self._gql_status
+
+        self._gql_status = _UNKNOWN_GQL_STATUS
+        return self._gql_status
+
+    def _get_explanation(self) -> str:
+        if hasattr(self, "_gql_explanation"):
+            return self._gql_explanation
+
+        self._gql_explanation = _UNKNOWN_GQL_EXPLANATION
+        return self._gql_explanation
+
+    @property
+    @preview("GQLSTATUS support is a preview feature.")
+    def gql_status_description(self) -> str:
+        """
+        A description of the GQLSTATUS returned from the server.
+
+        This description is meant for human consumption and debugging purposes.
+        Don't rely on it in a programmatic way.
+
+        **This is a preview**.
+        It might be changed without following the deprecation policy.
+        See also
+        https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
+
+        .. versionadded: 5.xx
+        """
+        if hasattr(self, "_gql_status_description"):
+            return self._gql_status_description
+
+        self._gql_status_description = _make_gql_description(
+            self._get_explanation(), self._message
+        )
+        return self._gql_status_description
+
+    @property
+    @preview("GQLSTATUS support is a preview feature.")
+    def gql_classification(self) -> str:
+        """
+        TODO.
+
+        **This is a preview**.
+        It might be changed without following the deprecation policy.
+        See also
+        https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
+
+        .. versionadded: 5.xx
+        """
+        # TODO
+        if hasattr(self, "_gql_classification"):
+            return self._gql_classification
+
+        diag_record = self._get_status_diagnostic_record()
+        classification = diag_record.get("_classification")
+        if not isinstance(classification, str):
+            self._classification = _UNKNOWN_GQL_CLASSIFICATION
+        else:
+            self._classification = classification
+        return self._classification
+
+    def _get_status_diagnostic_record(self) -> dict[str, t.Any]:
+        if hasattr(self, "_status_diagnostic_record"):
+            return self._status_diagnostic_record
+
+        self._status_diagnostic_record = dict(_UNKNOWN_GQL_DIAGNOSTIC_RECORD)
+        return self._status_diagnostic_record
+
+    @property
+    @preview("GQLSTATUS support is a preview feature.")
+    def diagnostic_record(self) -> dict[str, t.Any]:
+        """
+        Further information about the GQLSTATUS for diagnostic purposes.
+
+        **This is a preview**.
+        It might be changed without following the deprecation policy.
+        See also
+        https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
+
+        .. versionadded: 5.xx
+        """
+        if hasattr(self, "_diagnostic_record"):
+            return self._diagnostic_record
+
+        self._diagnostic_record = deepcopy(
+            self._get_status_diagnostic_record()
+        )
+        return self._diagnostic_record
 
     # TODO: 6.0 - Remove this alias
     @deprecated(
@@ -277,7 +619,9 @@ class Neo4jError(Exception):
         return self._retryable
 
     def _unauthenticates_all_connections(self) -> bool:
-        return self.code == "Neo.ClientError.Security.AuthorizationExpired"
+        return (
+            self._neo4j_code == "Neo.ClientError.Security.AuthorizationExpired"
+        )
 
     # TODO: 6.0 - Remove this alias
     invalidates_all_connections = deprecated(
@@ -289,9 +633,10 @@ class Neo4jError(Exception):
     def _is_fatal_during_discovery(self) -> bool:
         # checks if the code is an error that is caused by the client. In this
         # case the driver should fail fast during discovery.
-        if not isinstance(self.code, str):
+        code = self._neo4j_code
+        if not isinstance(code, str):
             return False
-        if self.code in {
+        if code in {
             "Neo.ClientError.Database.DatabaseNotFound",
             "Neo.ClientError.Transaction.InvalidBookmark",
             "Neo.ClientError.Transaction.InvalidBookmarkMixture",
@@ -301,14 +646,14 @@ class Neo4jError(Exception):
         }:
             return True
         return (
-            self.code.startswith("Neo.ClientError.Security.")
-            and self.code != "Neo.ClientError.Security.AuthorizationExpired"
+            code.startswith("Neo.ClientError.Security.")
+            and code != "Neo.ClientError.Security.AuthorizationExpired"
         )
 
     def _has_security_code(self) -> bool:
-        if self.code is None:
+        if self._neo4j_code is None:
             return False
-        return self.code.startswith("Neo.ClientError.Security.")
+        return self._neo4j_code.startswith("Neo.ClientError.Security.")
 
     # TODO: 6.0 - Remove this alias
     is_fatal_during_discovery = deprecated(
@@ -318,8 +663,18 @@ class Neo4jError(Exception):
     )(_is_fatal_during_discovery)
 
     def __str__(self):
-        if self.code or self.message:
-            return f"{{code: {self.code}}} {{message: {self.message}}}"
+        code = self._neo4j_code
+        message = self._message
+        if code or message:
+            return f"{{neo4j_code: {code}}} {{message: {message}}}"
+            # TODO: 6.0 - User gql status and status_description instead
+            # something like:
+            # return (
+            #     f"{{gql_status: {self.gql_status}}} "
+            #     f"{{neo4j_code: {self.neo4j_code}}} "
+            #     f"{{gql_status_description: {self.gql_status_description}}} "
+            #     f"{{diagnostic_record: {self.diagnostic_record}}}"
+            # )
         return super().__str__()
 
 
@@ -436,6 +791,9 @@ transient_errors: dict[str, type[Neo4jError]] = {
 class DriverError(Exception):
     """Raised when the Driver raises an error."""
 
+    _diagnostic_record: dict[str, t.Any]
+    _gql_description: str
+
     def is_retryable(self) -> bool:
         """
         Whether the error is retryable.
@@ -450,6 +808,79 @@ class DriverError(Exception):
         .. versionadded:: 5.0
         """
         return False
+
+    @property
+    @preview("GQLSTATUS support is a preview feature.")
+    def gql_status(self) -> str:
+        """
+        The GQLSTATUS of this error.
+
+        .. seealso:: :attr:`.Neo4jError.gql_status`
+
+        **This is a preview**.
+        It might be changed without following the deprecation policy.
+        See also
+        https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
+
+        .. versionadded: 5.xx
+        """
+        return _UNKNOWN_GQL_STATUS
+
+    @property
+    @preview("GQLSTATUS support is a preview feature.")
+    def gql_status_description(self) -> str:
+        """
+        A description of the GQLSTATUS.
+
+        This description is meant for human consumption and debugging purposes.
+        Don't rely on it in a programmatic way.
+
+        **This is a preview**.
+        It might be changed without following the deprecation policy.
+        See also
+        https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
+
+        .. versionadded: 5.xx
+        """
+        if hasattr(self, "_gql_description"):
+            return self._gql_description
+
+        self._gql_description = _make_gql_description(_UNKNOWN_GQL_EXPLANATION)
+        return self._gql_description
+
+    @property
+    @preview("GQLSTATUS support is a preview feature.")
+    def gql_classification(self) -> str:
+        """
+        TODO.
+
+        **This is a preview**.
+        It might be changed without following the deprecation policy.
+        See also
+        https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
+
+        .. versionadded: 5.xx
+        """
+        return _UNKNOWN_GQL_CLASSIFICATION
+
+    @property
+    @preview("GQLSTATUS support is a preview feature.")
+    def diagnostic_record(self) -> dict[str, t.Any]:
+        """
+        Further information about the GQLSTATUS for diagnostic purposes.
+
+        **This is a preview**.
+        It might be changed without following the deprecation policy.
+        See also
+        https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
+
+        .. versionadded: 5.xx
+        """
+        if hasattr(self, "_diagnostic_record"):
+            return self._diagnostic_record
+
+        self._diagnostic_record = dict(_UNKNOWN_GQL_DIAGNOSTIC_RECORD)
+        return self._diagnostic_record
 
 
 # DriverError > SessionError

--- a/src/neo4j/exceptions.py
+++ b/src/neo4j/exceptions.py
@@ -292,9 +292,6 @@ class GqlError(Exception):
     _diagnostic_record: dict[str, t.Any]  # copy to be used externally
     _gql_cause: GqlError | None
 
-    def __init__(self, *args):
-        super().__init__(*args)
-
     @staticmethod
     def _hydrate_cause(**metadata: t.Any) -> GqlError:
         meta_extractor = _MetaExtractor(metadata)

--- a/testkitbackend/_async/backend.py
+++ b/testkitbackend/_async/backend.py
@@ -125,6 +125,17 @@ class AsyncBackend:
 
     @staticmethod
     def _exc_stems_from_driver(exc):
+        if isinstance(
+            exc,
+            (
+                Neo4jError,
+                DriverError,
+                UnsupportedServerProduct,
+                BoltError,
+                MarkdAsDriverError,
+            ),
+        ):
+            return True
         stack = traceback.extract_tb(exc.__traceback__)
         for frame in stack[-1:1:-1]:
             p = Path(frame.filename)
@@ -134,16 +145,30 @@ class AsyncBackend:
                 return True
         return None
 
-    async def write_driver_exc(self, exc):
+    def _serialize_driver_exc(self, exc):
         log.debug(exc.args)
         log.debug("".join(traceback.format_exception(exc)))
 
         key = self.next_key()
         self.errors[key] = exc
 
-        data = totestkit.driver_exc(exc, id_=key)
+        return totestkit.driver_exc(exc, id_=key)
 
-        await self.send_response(data["name"], data["data"])
+    @staticmethod
+    def _serialize_backend_error(exc):
+        tb = "".join(traceback.format_exception(exc))
+        log.error(tb)
+        return {"name": "BackendError", "data": {"msg": tb}}
+
+    def _serialize_exc(self, exc):
+        try:
+            if isinstance(exc, requests.FrontendError):
+                return {"name": "FrontendError", "data": {"msg": str(exc)}}
+            if self._exc_stems_from_driver(exc):
+                return self._serialize_driver_exc(exc)
+        except Exception as e:
+            return self._serialize_backend_error(e)
+        return self._serialize_backend_error(exc)
 
     async def _process(self, request):
         # Process a received request.
@@ -164,23 +189,9 @@ class AsyncBackend:
                     f"Backend does not support some properties of the {name} "
                     f"request: {', '.join(unused_keys)}"
                 )
-        except (
-            Neo4jError,
-            DriverError,
-            UnsupportedServerProduct,
-            BoltError,
-            MarkdAsDriverError,
-        ) as e:
-            await self.write_driver_exc(e)
-        except requests.FrontendError as e:
-            await self.send_response("FrontendError", {"msg": str(e)})
         except Exception as e:
-            if self._exc_stems_from_driver(e):
-                await self.write_driver_exc(e)
-            else:
-                tb = traceback.format_exc()
-                log.error(tb)
-                await self.send_response("BackendError", {"msg": tb})
+            data = self._serialize_exc(e)
+            await self.send_response(data["name"], data["data"])
 
     async def send_response(self, name, data):
         """Send a response to backend."""

--- a/testkitbackend/_async/backend.py
+++ b/testkitbackend/_async/backend.py
@@ -145,9 +145,17 @@ class AsyncBackend:
                 return True
         return None
 
+    @staticmethod
+    def _get_tb(exc):
+        return "".join(
+            traceback.format_exception(
+                type(exc), exc, getattr(exc, "__traceback__", None)
+            )
+        )
+
     def _serialize_driver_exc(self, exc):
         log.debug(exc.args)
-        log.debug("".join(traceback.format_exception(exc)))
+        log.debug(self._get_tb(exc))
 
         key = self.next_key()
         self.errors[key] = exc
@@ -156,7 +164,7 @@ class AsyncBackend:
 
     @staticmethod
     def _serialize_backend_error(exc):
-        tb = "".join(traceback.format_exception(exc))
+        tb = AsyncBackend._get_tb(exc)
         log.error(tb)
         return {"name": "BackendError", "data": {"msg": tb}}
 

--- a/testkitbackend/_sync/backend.py
+++ b/testkitbackend/_sync/backend.py
@@ -145,9 +145,17 @@ class Backend:
                 return True
         return None
 
+    @staticmethod
+    def _get_tb(exc):
+        return "".join(
+            traceback.format_exception(
+                type(exc), exc, getattr(exc, "__traceback__", None)
+            )
+        )
+
     def _serialize_driver_exc(self, exc):
         log.debug(exc.args)
-        log.debug("".join(traceback.format_exception(exc)))
+        log.debug(self._get_tb(exc))
 
         key = self.next_key()
         self.errors[key] = exc
@@ -156,7 +164,7 @@ class Backend:
 
     @staticmethod
     def _serialize_backend_error(exc):
-        tb = "".join(traceback.format_exception(exc))
+        tb = Backend._get_tb(exc)
         log.error(tb)
         return {"name": "BackendError", "data": {"msg": tb}}
 

--- a/testkitbackend/_sync/backend.py
+++ b/testkitbackend/_sync/backend.py
@@ -34,6 +34,7 @@ from neo4j.exceptions import (
     UnsupportedServerProduct,
 )
 
+from .. import totestkit
 from .._driver_logger import (
     buffer_handler,
     log,
@@ -133,43 +134,16 @@ class Backend:
                 return True
         return None
 
-    @staticmethod
-    def _exc_msg(exc, max_depth=10):
-        if isinstance(exc, Neo4jError) and exc.message is not None:
-            return str(exc.message)
-
-        depth = 0
-        res = str(exc)
-        while getattr(exc, "__cause__", None) is not None:
-            depth += 1
-            if depth >= max_depth:
-                break
-            res += f"\nCaused by: {exc.__cause__!r}"
-            exc = exc.__cause__
-        return res
-
     def write_driver_exc(self, exc):
-        log.debug(traceback.format_exc())
+        log.debug(exc.args)
+        log.debug("".join(traceback.format_exception(exc)))
 
         key = self.next_key()
         self.errors[key] = exc
 
-        payload = {"id": key, "msg": ""}
+        data = totestkit.driver_exc(exc, id_=key)
 
-        if isinstance(exc, MarkdAsDriverError):
-            wrapped_exc = exc.wrapped_exc
-            payload["errorType"] = str(type(wrapped_exc))
-            if wrapped_exc.args:
-                payload["msg"] = self._exc_msg(wrapped_exc.args[0])
-            payload["retryable"] = False
-        else:
-            payload["errorType"] = str(type(exc))
-            payload["msg"] = self._exc_msg(exc)
-            if isinstance(exc, Neo4jError):
-                payload["code"] = exc.code
-            payload["retryable"] = getattr(exc, "is_retryable", bool)()
-
-        self.send_response("DriverError", payload)
+        self.send_response(data["name"], data["data"])
 
     def _process(self, request):
         # Process a received request.

--- a/testkitbackend/test_config.json
+++ b/testkitbackend/test_config.json
@@ -58,6 +58,7 @@
     "Feature:Bolt:5.4": true,
     "Feature:Bolt:5.5": true,
     "Feature:Bolt:5.6": true,
+    "Feature:Bolt:5.7": true,
     "Feature:Bolt:Patch:UTC": true,
     "Feature:Impersonation": true,
     "Feature:TLS:1.1": "Driver blocks TLS 1.1 for security reasons.",

--- a/testkitbackend/totestkit.py
+++ b/testkitbackend/totestkit.py
@@ -345,7 +345,9 @@ def _exc_msg(exc, max_depth=10):
             res = str(exc.message) if exc.message is not None else str(exc)
         else:
             with warning_check(neo4j.PreviewWarning, r".*\bGQLSTATUS\b.*"):
-                res = exc.message
+                msg = exc.message
+            if exc.args:
+                res = f"{msg} - {exc!s}"
     else:
         res = str(exc)
     while getattr(exc, "__cause__", None) is not None:

--- a/testkitbackend/totestkit.py
+++ b/testkitbackend/totestkit.py
@@ -20,7 +20,7 @@ import math
 
 import neo4j
 from neo4j.exceptions import (
-    GQLError,
+    GqlError,
     Neo4jError,
 )
 from neo4j.graph import (
@@ -315,7 +315,7 @@ def driver_exc(exc, id_=None):
         payload["msg"] = _exc_msg(exc)
         if isinstance(exc, Neo4jError):
             payload["code"] = exc.code
-        if isinstance(exc, GQLError):
+        if isinstance(exc, GqlError):
             with warning_check(neo4j.PreviewWarning, r".*\bGQLSTATUS\b.*"):
                 payload["gqlStatus"] = exc.gql_status
             with warning_check(neo4j.PreviewWarning, r".*\bGQLSTATUS\b.*"):
@@ -334,21 +334,6 @@ def driver_exc(exc, id_=None):
     return {"name": "DriverError", "data": payload}
 
 
-# def _exc_msg(exc, max_depth=10):
-#     if isinstance(exc, Neo4jError) and exc.message is not None:
-#         return str(exc.message)
-#
-#     depth = 0
-#     res = str(exc)
-#     while getattr(exc, "__cause__", None) is not None:
-#         depth += 1
-#         if depth >= max_depth:
-#             break
-#         res += f"\n  Caused by: {exc.__cause__!r}"
-#         exc = exc.__cause__
-#     return res
-
-
 def _exc_msg(exc):
     if isinstance(exc, Neo4jError) and exc.message is not None:
         return str(exc.message)
@@ -356,8 +341,8 @@ def _exc_msg(exc):
 
 
 def driver_exc_cause(exc):
-    if not isinstance(exc, GQLError):
-        raise TypeError("Expected GQLError as cause")
+    if not isinstance(exc, GqlError):
+        raise TypeError("Expected GqlError as cause")
     payload = {}
     with warning_check(neo4j.PreviewWarning, r".*\bGQLSTATUS\b.*"):
         payload["msg"] = exc.message

--- a/testkitbackend/totestkit.py
+++ b/testkitbackend/totestkit.py
@@ -20,7 +20,6 @@ import math
 
 import neo4j
 from neo4j.exceptions import (
-    DriverError,
     GqlError,
     Neo4jError,
 )
@@ -342,10 +341,8 @@ def _exc_msg(exc, max_depth=10):
 
     depth = 0
     if isinstance(exc, GqlError):
-        if isinstance(exc, Neo4jError) and exc.message is not None:
-            res = str(exc.message)
-        elif isinstance(exc, DriverError):
-            res = str(exc)
+        if isinstance(exc, Neo4jError):
+            res = str(exc.message) if exc.message is not None else str(exc)
         else:
             with warning_check(neo4j.PreviewWarning, r".*\bGQLSTATUS\b.*"):
                 res = exc.message

--- a/testkitbackend/totestkit.py
+++ b/testkitbackend/totestkit.py
@@ -347,7 +347,10 @@ def driver_exc_cause(exc):
     if not isinstance(exc, GqlError):
         return driver_exc_cause(getattr(exc, "__cause__", None))
     payload = {}
-    with warning_check(neo4j.PreviewWarning, r".*\bGQLSTATUS\b.*"):
+    if not isinstance(exc, Neo4jError):
+        with warning_check(neo4j.PreviewWarning, r".*\bGQLSTATUS\b.*"):
+            payload["msg"] = exc.message
+    else:
         payload["msg"] = exc.message
     with warning_check(neo4j.PreviewWarning, r".*\bGQLSTATUS\b.*"):
         payload["gqlStatus"] = exc.gql_status

--- a/testkitbackend/totestkit.py
+++ b/testkitbackend/totestkit.py
@@ -346,8 +346,7 @@ def _exc_msg(exc, max_depth=10):
         else:
             with warning_check(neo4j.PreviewWarning, r".*\bGQLSTATUS\b.*"):
                 msg = exc.message
-            if exc.args:
-                res = f"{msg} - {exc!s}"
+            res = f"{msg} - {exc!s}" if exc.args else msg
     else:
         res = str(exc)
     while getattr(exc, "__cause__", None) is not None:

--- a/testkitbackend/totestkit.py
+++ b/testkitbackend/totestkit.py
@@ -328,7 +328,7 @@ def driver_exc(exc, id_=None):
                 payload["diagnosticRecord"] = {
                     k: field(v) for k, v in exc.diagnostic_record.items()
                 }
-            cause = exc, "__cause__", None
+            cause = getattr(exc, "__cause__", None)
             if isinstance(cause, GqlError):
                 payload["cause"] = driver_exc_cause(cause)
 

--- a/testkitbackend/totestkit.py
+++ b/testkitbackend/totestkit.py
@@ -328,8 +328,9 @@ def driver_exc(exc, id_=None):
                 payload["diagnosticRecord"] = {
                     k: field(v) for k, v in exc.diagnostic_record.items()
                 }
-            if exc.__cause__ is not None:
-                payload["cause"] = driver_exc_cause(exc.__cause__)
+            cause = exc, "__cause__", None
+            if isinstance(cause, GqlError):
+                payload["cause"] = driver_exc_cause(cause)
 
     return {"name": "DriverError", "data": payload}
 

--- a/testkitbackend/totestkit.py
+++ b/testkitbackend/totestkit.py
@@ -20,6 +20,7 @@ import math
 
 import neo4j
 from neo4j.exceptions import (
+    DriverError,
     GqlError,
     Neo4jError,
 )
@@ -341,8 +342,13 @@ def _exc_msg(exc, max_depth=10):
 
     depth = 0
     if isinstance(exc, GqlError):
-        with warning_check(neo4j.PreviewWarning, r".*\bGQLSTATUS\b.*"):
-            res = exc.message
+        if isinstance(exc, Neo4jError) and exc.message is not None:
+            res = str(exc.message)
+        elif isinstance(exc, DriverError):
+            res = str(exc)
+        else:
+            with warning_check(neo4j.PreviewWarning, r".*\bGQLSTATUS\b.*"):
+                res = exc.message
     else:
         res = str(exc)
     while getattr(exc, "__cause__", None) is not None:

--- a/tests/iter_util.py
+++ b/tests/iter_util.py
@@ -29,7 +29,8 @@ if t.TYPE_CHECKING:
 
 def powerset(
     iterable: t.Iterable[_T],
-    limit: int | None = None,
+    lower_limit: int | None = None,
+    upper_limit: int | None = None,
 ) -> t.Iterable[tuple[_T, ...]]:
     """
     Build the powerset of an iterable.
@@ -39,12 +40,19 @@ def powerset(
         >>> tuple(powerset([1, 2, 3]))
         ((), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3))
 
-        >>> tuple(powerset([1, 2, 3], limit=2))
+        >>> tuple(powerset([1, 2, 3], upper_limit=2))
         ((), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3))
+
+        >>> tuple(powerset([1, 2, 3], lower_limit=2))
+        ((1, 2), (1, 3), (2, 3), (1, 2, 3))
 
     :return: The powerset of the iterable.
     """
     s = list(iterable)
-    if limit is None:
-        limit = len(s)
-    return chain.from_iterable(combinations(s, r) for r in range(limit + 1))
+    if upper_limit is None:
+        upper_limit = len(s)
+    if lower_limit is None:
+        lower_limit = 0
+    return chain.from_iterable(
+        combinations(s, r) for r in range(lower_limit, upper_limit + 1)
+    )

--- a/tests/unit/async_/fixtures/fake_connection.py
+++ b/tests/unit/async_/fixtures/fake_connection.py
@@ -206,7 +206,7 @@ def async_scripted_connection_generator(async_fake_connection_generator):
                                 cb_args = default_cb_args
                             res = cb(*cb_args)
                             if cb_name == "on_failure":
-                                error = Neo4jError.hydrate(**cb_args[0])
+                                error = Neo4jError._hydrate_gql(**cb_args[0])
                             # suppress in case the callback is not async
                             with suppress(TypeError):
                                 await res

--- a/tests/unit/async_/io/test_class_bolt.py
+++ b/tests/unit/async_/io/test_class_bolt.py
@@ -38,7 +38,7 @@ def test_class_method_protocol_handlers():
     expected_handlers = {
         (3, 0),
         (4, 1), (4, 2), (4, 3), (4, 4),
-        (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (5, 6),
+        (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (5, 6), (5, 7),
     }
     # fmt: on
 
@@ -68,7 +68,8 @@ def test_class_method_protocol_handlers():
         ((5, 4), 1),
         ((5, 5), 1),
         ((5, 6), 1),
-        ((5, 7), 0),
+        ((5, 7), 1),
+        ((5, 8), 0),
         ((6, 0), 0),
     ],
 )
@@ -91,7 +92,7 @@ def test_class_method_get_handshake():
     handshake = AsyncBolt.get_handshake()
     assert (
         handshake
-        == b"\x00\x06\x06\x05\x00\x02\x04\x04\x00\x00\x01\x04\x00\x00\x00\x03"
+        == b"\x00\x07\x07\x05\x00\x02\x04\x04\x00\x00\x01\x04\x00\x00\x00\x03"
     )
 
 
@@ -141,6 +142,7 @@ async def test_cancel_hello_in_open(mocker, none_auth):
         ((5, 4), "neo4j._async.io._bolt5.AsyncBolt5x4"),
         ((5, 5), "neo4j._async.io._bolt5.AsyncBolt5x5"),
         ((5, 6), "neo4j._async.io._bolt5.AsyncBolt5x6"),
+        ((5, 7), "neo4j._async.io._bolt5.AsyncBolt5x7"),
     ),
 )
 @mark_async_test
@@ -179,7 +181,7 @@ async def test_version_negotiation(
         (2, 0),
         (4, 0),
         (3, 1),
-        (5, 7),
+        (5, 8),
         (6, 0),
     ),
 )
@@ -187,7 +189,7 @@ async def test_version_negotiation(
 async def test_failing_version_negotiation(mocker, bolt_version, none_auth):
     supported_protocols = (
         "('3.0', '4.1', '4.2', '4.3', '4.4', "
-        "'5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6')"
+        "'5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7')"
     )
 
     address = ("localhost", 7687)

--- a/tests/unit/async_/io/test_class_bolt3.py
+++ b/tests/unit/async_/io/test_class_bolt3.py
@@ -532,7 +532,7 @@ def raises_if_db(db):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x0.py
+++ b/tests/unit/async_/io/test_class_bolt4x0.py
@@ -623,7 +623,7 @@ async def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x1.py
+++ b/tests/unit/async_/io/test_class_bolt4x1.py
@@ -645,7 +645,7 @@ async def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x2.py
+++ b/tests/unit/async_/io/test_class_bolt4x2.py
@@ -645,7 +645,7 @@ async def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x3.py
+++ b/tests/unit/async_/io/test_class_bolt4x3.py
@@ -674,7 +674,7 @@ async def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x4.py
+++ b/tests/unit/async_/io/test_class_bolt4x4.py
@@ -634,7 +634,7 @@ async def test_tx_timeout(
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x0.py
+++ b/tests/unit/async_/io/test_class_bolt5x0.py
@@ -698,7 +698,7 @@ async def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x2.py
+++ b/tests/unit/async_/io/test_class_bolt5x2.py
@@ -789,7 +789,7 @@ async def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x3.py
+++ b/tests/unit/async_/io/test_class_bolt5x3.py
@@ -676,7 +676,7 @@ async def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x4.py
+++ b/tests/unit/async_/io/test_class_bolt5x4.py
@@ -681,7 +681,7 @@ async def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x5.py
+++ b/tests/unit/async_/io/test_class_bolt5x5.py
@@ -690,7 +690,7 @@ DEFAULT_DIAG_REC_PAIRS = (
             {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
             {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x6.py
+++ b/tests/unit/async_/io/test_class_bolt5x6.py
@@ -690,7 +690,7 @@ DEFAULT_DIAG_REC_PAIRS = (
             {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
             {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x7.py
+++ b/tests/unit/async_/io/test_class_bolt5x7.py
@@ -841,11 +841,10 @@ def _build_error_hierarchy_metadata(diag_records_metadata):
     current_root = metadata
     for i, r in enumerate(diag_records_metadata[1:]):
         current_root["cause"] = {
-            "gql_status": f"BAR{i + 1:02}",
             "description": f"error cause nr. {i + 1}",
             "message": f"cause message {i + 1}",
         }
-        if r is not ...:
-            metadata["diagnostic_record"] = r
         current_root = current_root["cause"]
+        if r is not ...:
+            current_root["diagnostic_record"] = r
     return metadata

--- a/tests/unit/async_/io/test_class_bolt5x7.py
+++ b/tests/unit/async_/io/test_class_bolt5x7.py
@@ -20,12 +20,14 @@ import logging
 import pytest
 
 import neo4j
-import neo4j.exceptions
 from neo4j._api import TelemetryAPI
 from neo4j._async.config import AsyncPoolConfig
-from neo4j._async.io._bolt5 import AsyncBolt5x1
-from neo4j._meta import USER_AGENT
-from neo4j.exceptions import ConfigurationError
+from neo4j._async.io._bolt5 import AsyncBolt5x7
+from neo4j._meta import (
+    BOLT_AGENT_DICT,
+    USER_AGENT,
+)
+from neo4j.exceptions import Neo4jError
 
 from ...._async_compat import mark_async_test
 from ....iter_util import powerset
@@ -35,7 +37,7 @@ from ....iter_util import powerset
 def test_conn_is_stale(fake_socket, set_stale):
     address = neo4j.Address(("127.0.0.1", 7687))
     max_connection_lifetime = 0
-    connection = AsyncBolt5x1(
+    connection = AsyncBolt5x7(
         address, fake_socket(address), max_connection_lifetime
     )
     if set_stale:
@@ -47,7 +49,7 @@ def test_conn_is_stale(fake_socket, set_stale):
 def test_conn_is_not_stale_if_not_enabled(fake_socket, set_stale):
     address = neo4j.Address(("127.0.0.1", 7687))
     max_connection_lifetime = -1
-    connection = AsyncBolt5x1(
+    connection = AsyncBolt5x7(
         address, fake_socket(address), max_connection_lifetime
     )
     if set_stale:
@@ -59,7 +61,7 @@ def test_conn_is_not_stale_if_not_enabled(fake_socket, set_stale):
 def test_conn_is_not_stale(fake_socket, set_stale):
     address = neo4j.Address(("127.0.0.1", 7687))
     max_connection_lifetime = 999999999
-    connection = AsyncBolt5x1(
+    connection = AsyncBolt5x7(
         address, fake_socket(address), max_connection_lifetime
     )
     if set_stale:
@@ -82,8 +84,8 @@ def test_conn_is_not_stale(fake_socket, set_stale):
 @mark_async_test
 async def test_extra_in_begin(fake_socket, args, kwargs, expected_fields):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x1.UNPACKER_CLS)
-    connection = AsyncBolt5x1(
+    socket = fake_socket(address, AsyncBolt5x7.UNPACKER_CLS)
+    connection = AsyncBolt5x7(
         address, socket, AsyncPoolConfig.max_connection_lifetime
     )
     connection.begin(*args, **kwargs)
@@ -112,8 +114,8 @@ async def test_extra_in_begin(fake_socket, args, kwargs, expected_fields):
 @mark_async_test
 async def test_extra_in_run(fake_socket, args, kwargs, expected_fields):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x1.UNPACKER_CLS)
-    connection = AsyncBolt5x1(
+    socket = fake_socket(address, AsyncBolt5x7.UNPACKER_CLS)
+    connection = AsyncBolt5x7(
         address, socket, AsyncPoolConfig.max_connection_lifetime
     )
     connection.run(*args, **kwargs)
@@ -126,8 +128,8 @@ async def test_extra_in_run(fake_socket, args, kwargs, expected_fields):
 @mark_async_test
 async def test_n_extra_in_discard(fake_socket):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x1.UNPACKER_CLS)
-    connection = AsyncBolt5x1(
+    socket = fake_socket(address, AsyncBolt5x7.UNPACKER_CLS)
+    connection = AsyncBolt5x7(
         address, socket, AsyncPoolConfig.max_connection_lifetime
     )
     connection.discard(n=666)
@@ -148,8 +150,8 @@ async def test_n_extra_in_discard(fake_socket):
 @mark_async_test
 async def test_qid_extra_in_discard(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x1.UNPACKER_CLS)
-    connection = AsyncBolt5x1(
+    socket = fake_socket(address, AsyncBolt5x7.UNPACKER_CLS)
+    connection = AsyncBolt5x7(
         address, socket, AsyncPoolConfig.max_connection_lifetime
     )
     connection.discard(qid=test_input)
@@ -170,8 +172,8 @@ async def test_qid_extra_in_discard(fake_socket, test_input, expected):
 @mark_async_test
 async def test_n_and_qid_extras_in_discard(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x1.UNPACKER_CLS)
-    connection = AsyncBolt5x1(
+    socket = fake_socket(address, AsyncBolt5x7.UNPACKER_CLS)
+    connection = AsyncBolt5x7(
         address, socket, AsyncPoolConfig.max_connection_lifetime
     )
     connection.discard(n=666, qid=test_input)
@@ -192,8 +194,8 @@ async def test_n_and_qid_extras_in_discard(fake_socket, test_input, expected):
 @mark_async_test
 async def test_n_extra_in_pull(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x1.UNPACKER_CLS)
-    connection = AsyncBolt5x1(
+    socket = fake_socket(address, AsyncBolt5x7.UNPACKER_CLS)
+    connection = AsyncBolt5x7(
         address, socket, AsyncPoolConfig.max_connection_lifetime
     )
     connection.pull(n=test_input)
@@ -214,8 +216,8 @@ async def test_n_extra_in_pull(fake_socket, test_input, expected):
 @mark_async_test
 async def test_qid_extra_in_pull(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x1.UNPACKER_CLS)
-    connection = AsyncBolt5x1(
+    socket = fake_socket(address, AsyncBolt5x7.UNPACKER_CLS)
+    connection = AsyncBolt5x7(
         address, socket, AsyncPoolConfig.max_connection_lifetime
     )
     connection.pull(qid=test_input)
@@ -229,8 +231,8 @@ async def test_qid_extra_in_pull(fake_socket, test_input, expected):
 @mark_async_test
 async def test_n_and_qid_extras_in_pull(fake_socket):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x1.UNPACKER_CLS)
-    connection = AsyncBolt5x1(
+    socket = fake_socket(address, AsyncBolt5x7.UNPACKER_CLS)
+    connection = AsyncBolt5x7(
         address, socket, AsyncPoolConfig.max_connection_lifetime
     )
     connection.pull(n=666, qid=777)
@@ -246,12 +248,12 @@ async def test_hello_passes_routing_metadata(fake_socket_pair):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=AsyncBolt5x1.PACKER_CLS,
-        unpacker_cls=AsyncBolt5x1.UNPACKER_CLS,
+        packer_cls=AsyncBolt5x7.PACKER_CLS,
+        unpacker_cls=AsyncBolt5x7.UNPACKER_CLS,
     )
     await sockets.server.send_message(b"\x70", {"server": "Neo4j/4.4.0"})
     await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x1(
+    connection = AsyncBolt5x7(
         address,
         sockets.client,
         AsyncPoolConfig.max_connection_lifetime,
@@ -272,8 +274,8 @@ async def test_telemetry_message(
     fake_socket, api, serv_enabled, driver_disabled
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x1.UNPACKER_CLS)
-    connection = AsyncBolt5x1(
+    socket = fake_socket(address, AsyncBolt5x7.UNPACKER_CLS)
+    connection = AsyncBolt5x7(
         address,
         socket,
         AsyncPoolConfig.max_connection_lifetime,
@@ -284,124 +286,13 @@ async def test_telemetry_message(
     connection.telemetry(api)
     await connection.send_all()
 
-    with pytest.raises(OSError):
-        await socket.pop_message()
-
-
-async def _assert_logon_message(sockets, auth):
-    tag, fields = await sockets.server.pop_message()
-    assert tag == b"\x6a"  # LOGON
-    assert len(fields) == 1
-    keys = ["scheme", "principal", "credentials"]
-    assert list(fields[0].keys()) == keys
-    for key in keys:
-        assert fields[0][key] == getattr(auth, key)
-
-
-@mark_async_test
-async def test_hello_pipelines_logon(fake_socket_pair):
-    auth = neo4j.Auth("basic", "alice123", "supersecret123")
-    address = neo4j.Address(("127.0.0.1", 7687))
-    sockets = fake_socket_pair(
-        address,
-        packer_cls=AsyncBolt5x1.PACKER_CLS,
-        unpacker_cls=AsyncBolt5x1.UNPACKER_CLS,
-    )
-    await sockets.server.send_message(
-        b"\x7f",
-        {
-            "code": "Neo.DatabaseError.General.MadeUpError",
-            "message": "kthxbye",
-        },
-    )
-    connection = AsyncBolt5x1(
-        address,
-        sockets.client,
-        AsyncPoolConfig.max_connection_lifetime,
-        auth=auth,
-    )
-    with pytest.raises(neo4j.exceptions.Neo4jError):
-        await connection.hello()
-    tag, fields = await sockets.server.pop_message()
-    assert tag == b"\x01"  # HELLO
-    assert len(fields) == 1
-    assert list(fields[0].keys()) == ["user_agent"]
-    assert auth.credentials not in repr(fields)
-    await _assert_logon_message(sockets, auth)
-
-
-@mark_async_test
-async def test_logon(fake_socket_pair):
-    auth = neo4j.Auth("basic", "alice123", "supersecret123")
-    address = neo4j.Address(("127.0.0.1", 7687))
-    sockets = fake_socket_pair(
-        address,
-        packer_cls=AsyncBolt5x1.PACKER_CLS,
-        unpacker_cls=AsyncBolt5x1.UNPACKER_CLS,
-    )
-    connection = AsyncBolt5x1(
-        address,
-        sockets.client,
-        AsyncPoolConfig.max_connection_lifetime,
-        auth=auth,
-    )
-    connection.logon()
-    await connection.send_all()
-    await _assert_logon_message(sockets, auth)
-
-
-@mark_async_test
-async def test_re_auth(fake_socket_pair, mocker, static_auth):
-    auth = neo4j.Auth("basic", "alice123", "supersecret123")
-    auth_manager = static_auth(auth)
-    address = neo4j.Address(("127.0.0.1", 7687))
-    sockets = fake_socket_pair(
-        address,
-        packer_cls=AsyncBolt5x1.PACKER_CLS,
-        unpacker_cls=AsyncBolt5x1.UNPACKER_CLS,
-    )
-    await sockets.server.send_message(
-        b"\x7f",
-        {
-            "code": "Neo.DatabaseError.General.MadeUpError",
-            "message": "kthxbye",
-        },
-    )
-    connection = AsyncBolt5x1(
-        address, sockets.client, AsyncPoolConfig.max_connection_lifetime
-    )
-    connection.pool = mocker.AsyncMock()
-    connection.re_auth(auth, auth_manager)
-    await connection.send_all()
-    with pytest.raises(neo4j.exceptions.Neo4jError):
-        await connection.fetch_all()
-    tag, fields = await sockets.server.pop_message()
-    assert tag == b"\x6b"  # LOGOFF
-    assert len(fields) == 0
-    await _assert_logon_message(sockets, auth)
-    assert connection.auth is auth
-    assert connection.auth_manager is auth_manager
-
-
-@mark_async_test
-async def test_logoff(fake_socket_pair):
-    address = neo4j.Address(("127.0.0.1", 7687))
-    sockets = fake_socket_pair(
-        address,
-        packer_cls=AsyncBolt5x1.PACKER_CLS,
-        unpacker_cls=AsyncBolt5x1.UNPACKER_CLS,
-    )
-    await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x1(
-        address, sockets.client, AsyncPoolConfig.max_connection_lifetime
-    )
-    connection.logoff()
-    assert not sockets.server.recv_buffer  # pipelined, so no response yet
-    await connection.send_all()
-    assert sockets.server.recv_buffer  # now!
-    tag, fields = await sockets.server.pop_message()
-    assert tag == b"\x6b"  # LOGOFF
-    assert len(fields) == 0
+    if serv_enabled and not driver_disabled:
+        tag, fields = await socket.pop_message()
+        assert tag == b"\x54"
+        assert fields == [int(api)]
+    else:
+        with pytest.raises(OSError):
+            await socket.pop_message()
 
 
 @pytest.mark.parametrize(
@@ -426,15 +317,15 @@ async def test_hint_recv_timeout_seconds(
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=AsyncBolt5x1.PACKER_CLS,
-        unpacker_cls=AsyncBolt5x1.UNPACKER_CLS,
+        packer_cls=AsyncBolt5x7.PACKER_CLS,
+        unpacker_cls=AsyncBolt5x7.UNPACKER_CLS,
     )
     sockets.client.settimeout = mocker.Mock()
     await sockets.server.send_message(
         b"\x70", {"server": "Neo4j/4.3.4", "hints": hints}
     )
     await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x1(
+    connection = AsyncBolt5x7(
         address, sockets.client, AsyncPoolConfig.max_connection_lifetime
     )
     with caplog.at_level(logging.INFO):
@@ -479,12 +370,12 @@ async def test_credentials_are_not_logged(auth, fake_socket_pair, caplog):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=AsyncBolt5x1.PACKER_CLS,
-        unpacker_cls=AsyncBolt5x1.UNPACKER_CLS,
+        packer_cls=AsyncBolt5x7.PACKER_CLS,
+        unpacker_cls=AsyncBolt5x7.UNPACKER_CLS,
     )
     await sockets.server.send_message(b"\x70", {"server": "Neo4j/4.3.4"})
     await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x1(
+    connection = AsyncBolt5x7(
         address,
         sockets.client,
         AsyncPoolConfig.max_connection_lifetime,
@@ -502,61 +393,100 @@ async def test_credentials_are_not_logged(auth, fake_socket_pair, caplog):
     assert CREDENTIALS not in caplog.text
 
 
+def _assert_notifications_in_extra(extra, expected):
+    for key in expected:
+        assert key in extra
+        assert extra[key] == expected[key]
+
+
 @pytest.mark.parametrize(
-    ("method", "args"),
+    ("method", "args", "extra_idx"),
     (
-        ("run", ("RETURN 1",)),
-        ("begin", ()),
+        ("run", ("RETURN 1",), 2),
+        ("begin", (), 0),
     ),
 )
 @pytest.mark.parametrize(
-    "kwargs",
-    (
-        {"notifications_min_severity": "WARNING"},
-        {"notifications_disabled_classifications": ["HINT"]},
-        {"notifications_disabled_classifications": []},
-        {
-            "notifications_min_severity": "WARNING",
-            "notifications_disabled_classifications": ["HINT"],
-        },
-    ),
+    ("cls_min_sev", "method_min_sev"),
+    itertools.product((None, "WARNING", "OFF"), repeat=2),
 )
-def test_does_not_support_notification_filters(
-    fake_socket, method, args, kwargs
+@pytest.mark.parametrize(
+    ("cls_dis_clss", "method_dis_clss"),
+    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+)
+@mark_async_test
+async def test_supports_notification_filters(
+    fake_socket,
+    method,
+    args,
+    extra_idx,
+    cls_min_sev,
+    method_min_sev,
+    cls_dis_clss,
+    method_dis_clss,
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x1.UNPACKER_CLS)
-    connection = AsyncBolt5x1(
-        address, socket, AsyncPoolConfig.max_connection_lifetime
+    socket = fake_socket(address, AsyncBolt5x7.UNPACKER_CLS)
+    connection = AsyncBolt5x7(
+        address,
+        socket,
+        AsyncPoolConfig.max_connection_lifetime,
+        notifications_min_severity=cls_min_sev,
+        notifications_disabled_classifications=cls_dis_clss,
     )
     method = getattr(connection, method)
-    with pytest.raises(ConfigurationError, match="Notification filtering"):
-        method(*args, **kwargs)
+
+    method(
+        *args,
+        notifications_min_severity=method_min_sev,
+        notifications_disabled_classifications=method_dis_clss,
+    )
+    await connection.send_all()
+
+    _, fields = await socket.pop_message()
+    extra = fields[extra_idx]
+    expected = {}
+    if method_min_sev is not None:
+        expected["notifications_minimum_severity"] = method_min_sev
+    if method_dis_clss is not None:
+        expected["notifications_disabled_classifications"] = method_dis_clss
+    _assert_notifications_in_extra(extra, expected)
 
 
-@mark_async_test
+@pytest.mark.parametrize("min_sev", (None, "WARNING", "OFF"))
 @pytest.mark.parametrize(
-    "kwargs",
-    (
-        {"notifications_min_severity": "WARNING"},
-        {"notifications_disabled_classifications": ["HINT"]},
-        {"notifications_disabled_classifications": []},
-        {
-            "notifications_min_severity": "WARNING",
-            "notifications_disabled_classifications": ["HINT"],
-        },
-    ),
+    "dis_clss", (None, [], ["HINT"], ["HINT", "DEPRECATION"])
 )
-async def test_hello_does_not_support_notification_filters(
-    fake_socket, kwargs
+@mark_async_test
+async def test_hello_supports_notification_filters(
+    fake_socket_pair, min_sev, dis_clss
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, AsyncBolt5x1.UNPACKER_CLS)
-    connection = AsyncBolt5x1(
-        address, socket, AsyncPoolConfig.max_connection_lifetime, **kwargs
+    sockets = fake_socket_pair(
+        address,
+        packer_cls=AsyncBolt5x7.PACKER_CLS,
+        unpacker_cls=AsyncBolt5x7.UNPACKER_CLS,
     )
-    with pytest.raises(ConfigurationError, match="Notification filtering"):
-        await connection.hello()
+    await sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
+    await sockets.server.send_message(b"\x70", {})
+    connection = AsyncBolt5x7(
+        address,
+        sockets.client,
+        AsyncPoolConfig.max_connection_lifetime,
+        notifications_min_severity=min_sev,
+        notifications_disabled_classifications=dis_clss,
+    )
+
+    await connection.hello()
+
+    _tag, fields = await sockets.server.pop_message()
+    extra = fields[0]
+    expected = {}
+    if min_sev is not None:
+        expected["notifications_minimum_severity"] = min_sev
+    if dis_clss is not None:
+        expected["notifications_disabled_classifications"] = dis_clss
+    _assert_notifications_in_extra(extra, expected)
 
 
 @mark_async_test
@@ -567,13 +497,13 @@ async def test_user_agent(fake_socket_pair, user_agent):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=AsyncBolt5x1.PACKER_CLS,
-        unpacker_cls=AsyncBolt5x1.UNPACKER_CLS,
+        packer_cls=AsyncBolt5x7.PACKER_CLS,
+        unpacker_cls=AsyncBolt5x7.UNPACKER_CLS,
     )
     await sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
     await sockets.server.send_message(b"\x70", {})
     max_connection_lifetime = 0
-    connection = AsyncBolt5x1(
+    connection = AsyncBolt5x7(
         address, sockets.client, max_connection_lifetime, user_agent=user_agent
     )
     await connection.hello()
@@ -590,24 +520,24 @@ async def test_user_agent(fake_socket_pair, user_agent):
 @pytest.mark.parametrize(
     "user_agent", (None, "test user agent", "", USER_AGENT)
 )
-async def test_does_not_send_bolt_agent(fake_socket_pair, user_agent):
+async def test_sends_bolt_agent(fake_socket_pair, user_agent):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=AsyncBolt5x1.PACKER_CLS,
-        unpacker_cls=AsyncBolt5x1.UNPACKER_CLS,
+        packer_cls=AsyncBolt5x7.PACKER_CLS,
+        unpacker_cls=AsyncBolt5x7.UNPACKER_CLS,
     )
     await sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
     await sockets.server.send_message(b"\x70", {})
     max_connection_lifetime = 0
-    connection = AsyncBolt5x1(
+    connection = AsyncBolt5x7(
         address, sockets.client, max_connection_lifetime, user_agent=user_agent
     )
     await connection.hello()
 
     _tag, fields = await sockets.server.pop_message()
     extra = fields[0]
-    assert "bolt_agent" not in extra
+    assert extra["bolt_agent"] == BOLT_AGENT_DICT
 
 
 @mark_async_test
@@ -654,11 +584,11 @@ async def test_tx_timeout(
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=AsyncBolt5x1.PACKER_CLS,
-        unpacker_cls=AsyncBolt5x1.UNPACKER_CLS,
+        packer_cls=AsyncBolt5x7.PACKER_CLS,
+        unpacker_cls=AsyncBolt5x7.UNPACKER_CLS,
     )
     await sockets.server.send_message(b"\x70", {})
-    connection = AsyncBolt5x1(address, sockets.client, 0)
+    connection = AsyncBolt5x7(address, sockets.client, 0)
     func = getattr(connection, func)
     if isinstance(res, Exception):
         with pytest.raises(type(res), match=str(res)):
@@ -690,10 +620,10 @@ async def test_tracks_last_database(fake_socket_pair, actions):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=AsyncBolt5x1.PACKER_CLS,
-        unpacker_cls=AsyncBolt5x1.UNPACKER_CLS,
+        packer_cls=AsyncBolt5x7.PACKER_CLS,
+        unpacker_cls=AsyncBolt5x7.UNPACKER_CLS,
     )
-    connection = AsyncBolt5x1(address, sockets.client, 0)
+    connection = AsyncBolt5x7(address, sockets.client, 0)
     await sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
     await sockets.server.send_message(b"\x70", {})
     await connection.hello()
@@ -739,6 +669,13 @@ async def test_tracks_last_database(fake_socket_pair, actions):
         assert connection.last_database == db
 
 
+DEFAULT_DIAG_REC_PAIRS = (
+    ("OPERATION", ""),
+    ("OPERATION_CODE", "0"),
+    ("CURRENT_SCHEMA", "/"),
+)
+
+
 @pytest.mark.parametrize(
     "sent_diag_records",
     powerset(
@@ -751,13 +688,15 @@ async def test_tracks_last_database(fake_socket_pair, actions):
             1,
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
+            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
+            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
         ),
         upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))
 @mark_async_test
-async def test_does_not_enrich_diagnostic_record(
+async def test_enriches_statuses(
     sent_diag_records,
     method,
     fake_socket_pair,
@@ -765,14 +704,23 @@ async def test_does_not_enrich_diagnostic_record(
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=AsyncBolt5x1.PACKER_CLS,
-        unpacker_cls=AsyncBolt5x1.UNPACKER_CLS,
+        packer_cls=AsyncBolt5x7.PACKER_CLS,
+        unpacker_cls=AsyncBolt5x7.UNPACKER_CLS,
     )
-    connection = AsyncBolt5x1(address, sockets.client, 0)
+    connection = AsyncBolt5x7(address, sockets.client, 0)
 
     sent_metadata = {
         "statuses": [
-            {"diagnostic_record": r} if r is not ... else {}
+            {
+                "status_description": "the status description",
+                "description": "description",
+                "diagnostic_record": r,
+            }
+            if r is not ...
+            else {
+                "status_description": "the status description",
+                "description": "description",
+            }
             for r in sent_diag_records
         ]
     }
@@ -788,4 +736,116 @@ async def test_does_not_enrich_diagnostic_record(
     await connection.send_all()
     await connection.fetch_all()
 
-    assert received_metadata == sent_metadata
+    def extend_diag_record(r):
+        if r is ...:
+            return dict(DEFAULT_DIAG_REC_PAIRS)
+        if isinstance(r, dict):
+            return dict((*DEFAULT_DIAG_REC_PAIRS, *r.items()))
+        return r
+
+    expected_diag_records = [extend_diag_record(r) for r in sent_diag_records]
+    expected_metadata = {
+        "statuses": [
+            {
+                "status_description": "the status description",
+                "description": "description",
+                "diagnostic_record": r,
+            }
+            if r is not ...
+            else {
+                "status_description": "the status description",
+                "description": "description",
+            }
+            for r in expected_diag_records
+        ]
+    }
+
+    assert received_metadata == expected_metadata
+
+
+@pytest.mark.parametrize(
+    "sent_diag_records",
+    powerset(
+        (
+            ...,
+            None,
+            {},
+            [],
+            "1",
+            1,
+            {"OPERATION_CODE": "0"},
+            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
+            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
+            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+        ),
+        lower_limit=1,
+        upper_limit=3,
+    ),
+)
+@mark_async_test
+async def test_enriches_error_statuses(
+    sent_diag_records,
+    fake_socket_pair,
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(
+        address,
+        packer_cls=AsyncBolt5x7.PACKER_CLS,
+        unpacker_cls=AsyncBolt5x7.UNPACKER_CLS,
+    )
+    connection = AsyncBolt5x7(address, sockets.client, 0)
+    sent_diag_records = [
+        {**r, "_classification": "CLIENT_ERROR", "_status_parameters": {}}
+        if isinstance(r, dict)
+        else r
+        for r in sent_diag_records
+    ]
+
+    sent_metadata = _build_error_hierarchy_metadata(sent_diag_records)
+
+    await sockets.server.send_message(b"\x7f", sent_metadata)
+
+    received_metadata = None
+
+    def on_failure(metadata):
+        nonlocal received_metadata
+        received_metadata = metadata
+
+    connection.run("RETURN 1", on_failure=on_failure)
+    await connection.send_all()
+    with pytest.raises(Neo4jError):
+        await connection.fetch_all()
+
+    def extend_diag_record(r):
+        if r is ...:
+            return dict(DEFAULT_DIAG_REC_PAIRS)
+        if isinstance(r, dict):
+            return dict((*DEFAULT_DIAG_REC_PAIRS, *r.items()))
+        return r
+
+    expected_diag_records = [extend_diag_record(r) for r in sent_diag_records]
+    expected_metadata = _build_error_hierarchy_metadata(expected_diag_records)
+
+    assert received_metadata == expected_metadata
+
+
+def _build_error_hierarchy_metadata(diag_records_metadata):
+    metadata = {
+        "gql_status": "FOO12",
+        "description": "but have you tried not doing that?!",
+        "message": "some people just can't be helped",
+        "neo4j_code": "Neo.ClientError.Generic.YouSuck",
+    }
+    if diag_records_metadata[0] is not ...:
+        metadata["diagnostic_record"] = diag_records_metadata[0]
+    current_root = metadata
+    for i, r in enumerate(diag_records_metadata[1:]):
+        current_root["cause"] = {
+            "gql_status": f"BAR{i + 1:02}",
+            "description": f"error cause nr. {i + 1}",
+            "message": f"cause message {i + 1}",
+        }
+        if r is not ...:
+            metadata["diagnostic_record"] = r
+        current_root = current_root["cause"]
+    return metadata

--- a/tests/unit/async_/io/test_neo4j_pool.py
+++ b/tests/unit/async_/io/test_neo4j_pool.py
@@ -535,11 +535,13 @@ async def test_passes_pool_config_to_connection(mocker):
     "error",
     (
         ServiceUnavailable(),
-        Neo4jError.hydrate(
-            "message", "Neo.ClientError.Statement.EntityNotFound"
+        Neo4jError._hydrate_neo4j(
+            code="Neo.ClientError.Statement.EntityNotFound",
+            message="message",
         ),
-        Neo4jError.hydrate(
-            "message", "Neo.ClientError.Security.AuthorizationExpired"
+        Neo4jError._hydrate_neo4j(
+            code="Neo.ClientError.Security.AuthorizationExpired",
+            message="message",
         ),
     ),
 )
@@ -578,20 +580,20 @@ async def test_discovery_is_retried(custom_routing_opener, error):
 @pytest.mark.parametrize(
     "error",
     map(
-        lambda args: Neo4jError.hydrate(*args),
+        lambda args: Neo4jError._hydrate_neo4j(code=args[0], message=args[1]),
         (
-            ("message", "Neo.ClientError.Database.DatabaseNotFound"),
-            ("message", "Neo.ClientError.Transaction.InvalidBookmark"),
-            ("message", "Neo.ClientError.Transaction.InvalidBookmarkMixture"),
-            ("message", "Neo.ClientError.Statement.TypeError"),
-            ("message", "Neo.ClientError.Statement.ArgumentError"),
-            ("message", "Neo.ClientError.Request.Invalid"),
-            ("message", "Neo.ClientError.Security.AuthenticationRateLimit"),
-            ("message", "Neo.ClientError.Security.CredentialsExpired"),
-            ("message", "Neo.ClientError.Security.Forbidden"),
-            ("message", "Neo.ClientError.Security.TokenExpired"),
-            ("message", "Neo.ClientError.Security.Unauthorized"),
-            ("message", "Neo.ClientError.Security.MadeUpError"),
+            ("Neo.ClientError.Database.DatabaseNotFound", "message"),
+            ("Neo.ClientError.Transaction.InvalidBookmark", "message"),
+            ("Neo.ClientError.Transaction.InvalidBookmarkMixture", "message"),
+            ("Neo.ClientError.Statement.TypeError", "message"),
+            ("Neo.ClientError.Statement.ArgumentError", "message"),
+            ("Neo.ClientError.Request.Invalid", "message"),
+            ("Neo.ClientError.Security.AuthenticationRateLimit", "message"),
+            ("Neo.ClientError.Security.CredentialsExpired", "message"),
+            ("Neo.ClientError.Security.Forbidden", "message"),
+            ("Neo.ClientError.Security.TokenExpired", "message"),
+            ("Neo.ClientError.Security.Unauthorized", "message"),
+            ("Neo.ClientError.Security.MadeUpError", "message"),
         ),
     ),
 )
@@ -627,7 +629,7 @@ async def test_fast_failing_discovery(custom_routing_opener, error):
 @pytest.mark.parametrize(
     ("error", "marks_unauthenticated", "fetches_new"),
     (
-        (Neo4jError.hydrate("message", args[0]), *args[1:])
+        (Neo4jError._hydrate_neo4j(code=args[0], message="message"), *args[1:])
         for args in (
             ("Neo.ClientError.Database.DatabaseNotFound", False, False),
             ("Neo.ClientError.Statement.TypeError", False, False),

--- a/tests/unit/async_/test_auth_management.py
+++ b/tests/unit/async_/test_auth_management.py
@@ -59,7 +59,7 @@ CODES_HANDLED_BY_BEARER_MANAGER = {
     "Neo.ClientError.Security.Unauthorized",
 }
 SAMPLE_ERRORS = [
-    Neo4jError.hydrate(code=code)
+    Neo4jError._hydrate_neo4j(code=code)
     for code in {
         "Neo.ClientError.Security.AuthenticationRateLimit",
         "Neo.ClientError.Security.AuthorizationExpired",

--- a/tests/unit/async_/work/test_transaction.py
+++ b/tests/unit/async_/work/test_transaction.py
@@ -315,7 +315,12 @@ async def test_server_error_propagates(async_scripted_connection, error):
             (
                 "pull",
                 {
-                    "on_failure": ({"code": "Neo.ClientError.Made.Up"},),
+                    "on_failure": (
+                        {
+                            "neo4j_code": "Neo.ClientError.Made.Up",
+                            "gql_status": "50N42",
+                        },
+                    ),
                     "on_summary": None,
                 },
             )

--- a/tests/unit/common/test_exceptions.py
+++ b/tests/unit/common/test_exceptions.py
@@ -149,7 +149,7 @@ def test_serviceunavailable_raised_from_bolt_protocol_error_with_explicit_style(
 
 
 def test_neo4jerror_hydrate_with_no_args():
-    error = Neo4jError.hydrate()
+    error = Neo4jError._hydrate_neo4j()
 
     assert isinstance(error, DatabaseError)
     assert error.classification == CLASSIFICATION_DATABASE
@@ -160,8 +160,10 @@ def test_neo4jerror_hydrate_with_no_args():
     assert error.code == "Neo.DatabaseError.General.UnknownError"
 
 
-def test_neo4jerror_hydrate_with_message_and_code_rubish():
-    error = Neo4jError.hydrate(message="Test error message", code="ASDF_asdf")
+def test_neo4jerror_hydrate_with_message_and_code_rubbish():
+    error = Neo4jError._hydrate_neo4j(
+        message="Test error message", code="ASDF_asdf"
+    )
 
     assert isinstance(error, DatabaseError)
     assert error.classification == CLASSIFICATION_DATABASE
@@ -173,7 +175,7 @@ def test_neo4jerror_hydrate_with_message_and_code_rubish():
 
 
 def test_neo4jerror_hydrate_with_message_and_code_database():
-    error = Neo4jError.hydrate(
+    error = Neo4jError._hydrate_neo4j(
         message="Test error message",
         code="Neo.DatabaseError.General.UnknownError",
     )
@@ -188,7 +190,7 @@ def test_neo4jerror_hydrate_with_message_and_code_database():
 
 
 def test_neo4jerror_hydrate_with_message_and_code_transient():
-    error = Neo4jError.hydrate(
+    error = Neo4jError._hydrate_neo4j(
         message="Test error message",
         code="Neo.TransientError.General.TestError",
     )
@@ -203,7 +205,7 @@ def test_neo4jerror_hydrate_with_message_and_code_transient():
 
 
 def test_neo4jerror_hydrate_with_message_and_code_client():
-    error = Neo4jError.hydrate(
+    error = Neo4jError._hydrate_neo4j(
         message="Test error message",
         code=f"Neo.{CLASSIFICATION_CLIENT}.General.TestError",
     )
@@ -254,7 +256,7 @@ def test_neo4jerror_hydrate_with_message_and_code_client():
 )
 def test_error_rewrite(code, expected_cls, expected_code):
     message = "Test error message"
-    error = Neo4jError.hydrate(message=message, code=code)
+    error = Neo4jError._hydrate_neo4j(message=message, code=code)
 
     expected_retryable = expected_cls is TransientError
     assert error.__class__ is expected_cls
@@ -303,12 +305,12 @@ def test_error_rewrite(code, expected_cls, expected_code):
             "{code: Neo.ClientError.General.UnknownError} "
             "{message: An unknown error occurred}",
         ),
-    ),
+    )[1:2],
 )
 def test_neo4j_error_from_server_as_str(
     code, message, expected_cls, expected_str
 ):
-    error = Neo4jError.hydrate(code=code, message=message)
+    error = Neo4jError._hydrate_neo4j(code=code, message=message)
 
     assert type(error) is expected_cls
     assert str(error) == expected_str

--- a/tests/unit/common/test_record.py
+++ b/tests/unit/common/test_record.py
@@ -591,5 +591,6 @@ def test_record_with_error(accessor, should_raise) -> None:
     with pytest.raises(BrokenRecordError) as raised:
         accessor(r)
     exc_value = raised.value
+    assert exc_value.__cause__ is not None
     assert exc_value.__cause__ is exc
     assert list(traceback.walk_tb(exc_value.__cause__.__traceback__)) == frames

--- a/tests/unit/common/work/test_summary.py
+++ b/tests/unit/common/work/test_summary.py
@@ -889,6 +889,7 @@ def test_summary_result_counters(summary_args_kwargs, counters_set) -> None:
         ((5, 4), "t_first"),
         ((5, 5), "t_first"),
         ((5, 6), "t_first"),
+        ((5, 7), "t_first"),
     ),
 )
 def test_summary_result_available_after(
@@ -925,6 +926,7 @@ def test_summary_result_available_after(
         ((5, 4), "t_last"),
         ((5, 5), "t_last"),
         ((5, 6), "t_last"),
+        ((5, 7), "t_last"),
     ),
 )
 def test_summary_result_consumed_after(

--- a/tests/unit/sync/fixtures/fake_connection.py
+++ b/tests/unit/sync/fixtures/fake_connection.py
@@ -206,7 +206,7 @@ def scripted_connection_generator(fake_connection_generator):
                                 cb_args = default_cb_args
                             res = cb(*cb_args)
                             if cb_name == "on_failure":
-                                error = Neo4jError.hydrate(**cb_args[0])
+                                error = Neo4jError._hydrate_gql(**cb_args[0])
                             # suppress in case the callback is not async
                             with suppress(TypeError):
                                 res

--- a/tests/unit/sync/io/test_class_bolt.py
+++ b/tests/unit/sync/io/test_class_bolt.py
@@ -38,7 +38,7 @@ def test_class_method_protocol_handlers():
     expected_handlers = {
         (3, 0),
         (4, 1), (4, 2), (4, 3), (4, 4),
-        (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (5, 6),
+        (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (5, 6), (5, 7),
     }
     # fmt: on
 
@@ -68,7 +68,8 @@ def test_class_method_protocol_handlers():
         ((5, 4), 1),
         ((5, 5), 1),
         ((5, 6), 1),
-        ((5, 7), 0),
+        ((5, 7), 1),
+        ((5, 8), 0),
         ((6, 0), 0),
     ],
 )
@@ -91,7 +92,7 @@ def test_class_method_get_handshake():
     handshake = Bolt.get_handshake()
     assert (
         handshake
-        == b"\x00\x06\x06\x05\x00\x02\x04\x04\x00\x00\x01\x04\x00\x00\x00\x03"
+        == b"\x00\x07\x07\x05\x00\x02\x04\x04\x00\x00\x01\x04\x00\x00\x00\x03"
     )
 
 
@@ -141,6 +142,7 @@ def test_cancel_hello_in_open(mocker, none_auth):
         ((5, 4), "neo4j._sync.io._bolt5.Bolt5x4"),
         ((5, 5), "neo4j._sync.io._bolt5.Bolt5x5"),
         ((5, 6), "neo4j._sync.io._bolt5.Bolt5x6"),
+        ((5, 7), "neo4j._sync.io._bolt5.Bolt5x7"),
     ),
 )
 @mark_sync_test
@@ -179,7 +181,7 @@ def test_version_negotiation(
         (2, 0),
         (4, 0),
         (3, 1),
-        (5, 7),
+        (5, 8),
         (6, 0),
     ),
 )
@@ -187,7 +189,7 @@ def test_version_negotiation(
 def test_failing_version_negotiation(mocker, bolt_version, none_auth):
     supported_protocols = (
         "('3.0', '4.1', '4.2', '4.3', '4.4', "
-        "'5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6')"
+        "'5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7')"
     )
 
     address = ("localhost", 7687)

--- a/tests/unit/sync/io/test_class_bolt3.py
+++ b/tests/unit/sync/io/test_class_bolt3.py
@@ -532,7 +532,7 @@ def raises_if_db(db):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x0.py
+++ b/tests/unit/sync/io/test_class_bolt4x0.py
@@ -623,7 +623,7 @@ def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x1.py
+++ b/tests/unit/sync/io/test_class_bolt4x1.py
@@ -645,7 +645,7 @@ def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x2.py
+++ b/tests/unit/sync/io/test_class_bolt4x2.py
@@ -645,7 +645,7 @@ def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x3.py
+++ b/tests/unit/sync/io/test_class_bolt4x3.py
@@ -674,7 +674,7 @@ def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x4.py
+++ b/tests/unit/sync/io/test_class_bolt4x4.py
@@ -634,7 +634,7 @@ def test_tx_timeout(
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x0.py
+++ b/tests/unit/sync/io/test_class_bolt5x0.py
@@ -698,7 +698,7 @@ def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x1.py
+++ b/tests/unit/sync/io/test_class_bolt5x1.py
@@ -752,7 +752,7 @@ def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x2.py
+++ b/tests/unit/sync/io/test_class_bolt5x2.py
@@ -789,7 +789,7 @@ def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x3.py
+++ b/tests/unit/sync/io/test_class_bolt5x3.py
@@ -676,7 +676,7 @@ def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x4.py
+++ b/tests/unit/sync/io/test_class_bolt5x4.py
@@ -681,7 +681,7 @@ def test_tracks_last_database(fake_socket_pair, actions):
             {"OPERATION_CODE": "0"},
             {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x5.py
+++ b/tests/unit/sync/io/test_class_bolt5x5.py
@@ -690,7 +690,7 @@ DEFAULT_DIAG_REC_PAIRS = (
             {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
             {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
         ),
-        limit=3,
+        upper_limit=3,
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x7.py
+++ b/tests/unit/sync/io/test_class_bolt5x7.py
@@ -841,11 +841,10 @@ def _build_error_hierarchy_metadata(diag_records_metadata):
     current_root = metadata
     for i, r in enumerate(diag_records_metadata[1:]):
         current_root["cause"] = {
-            "gql_status": f"BAR{i + 1:02}",
             "description": f"error cause nr. {i + 1}",
             "message": f"cause message {i + 1}",
         }
-        if r is not ...:
-            metadata["diagnostic_record"] = r
         current_root = current_root["cause"]
+        if r is not ...:
+            current_root["diagnostic_record"] = r
     return metadata

--- a/tests/unit/sync/io/test_class_bolt5x7.py
+++ b/tests/unit/sync/io/test_class_bolt5x7.py
@@ -26,7 +26,8 @@ from neo4j._meta import (
     USER_AGENT,
 )
 from neo4j._sync.config import PoolConfig
-from neo4j._sync.io._bolt5 import Bolt5x6
+from neo4j._sync.io._bolt5 import Bolt5x7
+from neo4j.exceptions import Neo4jError
 
 from ...._async_compat import mark_sync_test
 from ....iter_util import powerset
@@ -36,7 +37,7 @@ from ....iter_util import powerset
 def test_conn_is_stale(fake_socket, set_stale):
     address = neo4j.Address(("127.0.0.1", 7687))
     max_connection_lifetime = 0
-    connection = Bolt5x6(
+    connection = Bolt5x7(
         address, fake_socket(address), max_connection_lifetime
     )
     if set_stale:
@@ -48,7 +49,7 @@ def test_conn_is_stale(fake_socket, set_stale):
 def test_conn_is_not_stale_if_not_enabled(fake_socket, set_stale):
     address = neo4j.Address(("127.0.0.1", 7687))
     max_connection_lifetime = -1
-    connection = Bolt5x6(
+    connection = Bolt5x7(
         address, fake_socket(address), max_connection_lifetime
     )
     if set_stale:
@@ -60,7 +61,7 @@ def test_conn_is_not_stale_if_not_enabled(fake_socket, set_stale):
 def test_conn_is_not_stale(fake_socket, set_stale):
     address = neo4j.Address(("127.0.0.1", 7687))
     max_connection_lifetime = 999999999
-    connection = Bolt5x6(
+    connection = Bolt5x7(
         address, fake_socket(address), max_connection_lifetime
     )
     if set_stale:
@@ -83,8 +84,8 @@ def test_conn_is_not_stale(fake_socket, set_stale):
 @mark_sync_test
 def test_extra_in_begin(fake_socket, args, kwargs, expected_fields):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
-    connection = Bolt5x6(
+    socket = fake_socket(address, Bolt5x7.UNPACKER_CLS)
+    connection = Bolt5x7(
         address, socket, PoolConfig.max_connection_lifetime
     )
     connection.begin(*args, **kwargs)
@@ -113,8 +114,8 @@ def test_extra_in_begin(fake_socket, args, kwargs, expected_fields):
 @mark_sync_test
 def test_extra_in_run(fake_socket, args, kwargs, expected_fields):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
-    connection = Bolt5x6(
+    socket = fake_socket(address, Bolt5x7.UNPACKER_CLS)
+    connection = Bolt5x7(
         address, socket, PoolConfig.max_connection_lifetime
     )
     connection.run(*args, **kwargs)
@@ -127,8 +128,8 @@ def test_extra_in_run(fake_socket, args, kwargs, expected_fields):
 @mark_sync_test
 def test_n_extra_in_discard(fake_socket):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
-    connection = Bolt5x6(
+    socket = fake_socket(address, Bolt5x7.UNPACKER_CLS)
+    connection = Bolt5x7(
         address, socket, PoolConfig.max_connection_lifetime
     )
     connection.discard(n=666)
@@ -149,8 +150,8 @@ def test_n_extra_in_discard(fake_socket):
 @mark_sync_test
 def test_qid_extra_in_discard(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
-    connection = Bolt5x6(
+    socket = fake_socket(address, Bolt5x7.UNPACKER_CLS)
+    connection = Bolt5x7(
         address, socket, PoolConfig.max_connection_lifetime
     )
     connection.discard(qid=test_input)
@@ -171,8 +172,8 @@ def test_qid_extra_in_discard(fake_socket, test_input, expected):
 @mark_sync_test
 def test_n_and_qid_extras_in_discard(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
-    connection = Bolt5x6(
+    socket = fake_socket(address, Bolt5x7.UNPACKER_CLS)
+    connection = Bolt5x7(
         address, socket, PoolConfig.max_connection_lifetime
     )
     connection.discard(n=666, qid=test_input)
@@ -193,8 +194,8 @@ def test_n_and_qid_extras_in_discard(fake_socket, test_input, expected):
 @mark_sync_test
 def test_n_extra_in_pull(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
-    connection = Bolt5x6(
+    socket = fake_socket(address, Bolt5x7.UNPACKER_CLS)
+    connection = Bolt5x7(
         address, socket, PoolConfig.max_connection_lifetime
     )
     connection.pull(n=test_input)
@@ -215,8 +216,8 @@ def test_n_extra_in_pull(fake_socket, test_input, expected):
 @mark_sync_test
 def test_qid_extra_in_pull(fake_socket, test_input, expected):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
-    connection = Bolt5x6(
+    socket = fake_socket(address, Bolt5x7.UNPACKER_CLS)
+    connection = Bolt5x7(
         address, socket, PoolConfig.max_connection_lifetime
     )
     connection.pull(qid=test_input)
@@ -230,8 +231,8 @@ def test_qid_extra_in_pull(fake_socket, test_input, expected):
 @mark_sync_test
 def test_n_and_qid_extras_in_pull(fake_socket):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
-    connection = Bolt5x6(
+    socket = fake_socket(address, Bolt5x7.UNPACKER_CLS)
+    connection = Bolt5x7(
         address, socket, PoolConfig.max_connection_lifetime
     )
     connection.pull(n=666, qid=777)
@@ -247,12 +248,12 @@ def test_hello_passes_routing_metadata(fake_socket_pair):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=Bolt5x6.PACKER_CLS,
-        unpacker_cls=Bolt5x6.UNPACKER_CLS,
+        packer_cls=Bolt5x7.PACKER_CLS,
+        unpacker_cls=Bolt5x7.UNPACKER_CLS,
     )
     sockets.server.send_message(b"\x70", {"server": "Neo4j/4.4.0"})
     sockets.server.send_message(b"\x70", {})
-    connection = Bolt5x6(
+    connection = Bolt5x7(
         address,
         sockets.client,
         PoolConfig.max_connection_lifetime,
@@ -273,8 +274,8 @@ def test_telemetry_message(
     fake_socket, api, serv_enabled, driver_disabled
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
-    connection = Bolt5x6(
+    socket = fake_socket(address, Bolt5x7.UNPACKER_CLS)
+    connection = Bolt5x7(
         address,
         socket,
         PoolConfig.max_connection_lifetime,
@@ -316,15 +317,15 @@ def test_hint_recv_timeout_seconds(
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=Bolt5x6.PACKER_CLS,
-        unpacker_cls=Bolt5x6.UNPACKER_CLS,
+        packer_cls=Bolt5x7.PACKER_CLS,
+        unpacker_cls=Bolt5x7.UNPACKER_CLS,
     )
     sockets.client.settimeout = mocker.Mock()
     sockets.server.send_message(
         b"\x70", {"server": "Neo4j/4.3.4", "hints": hints}
     )
     sockets.server.send_message(b"\x70", {})
-    connection = Bolt5x6(
+    connection = Bolt5x7(
         address, sockets.client, PoolConfig.max_connection_lifetime
     )
     with caplog.at_level(logging.INFO):
@@ -369,12 +370,12 @@ def test_credentials_are_not_logged(auth, fake_socket_pair, caplog):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=Bolt5x6.PACKER_CLS,
-        unpacker_cls=Bolt5x6.UNPACKER_CLS,
+        packer_cls=Bolt5x7.PACKER_CLS,
+        unpacker_cls=Bolt5x7.UNPACKER_CLS,
     )
     sockets.server.send_message(b"\x70", {"server": "Neo4j/4.3.4"})
     sockets.server.send_message(b"\x70", {})
-    connection = Bolt5x6(
+    connection = Bolt5x7(
         address,
         sockets.client,
         PoolConfig.max_connection_lifetime,
@@ -425,8 +426,8 @@ def test_supports_notification_filters(
     method_dis_clss,
 ):
     address = neo4j.Address(("127.0.0.1", 7687))
-    socket = fake_socket(address, Bolt5x6.UNPACKER_CLS)
-    connection = Bolt5x6(
+    socket = fake_socket(address, Bolt5x7.UNPACKER_CLS)
+    connection = Bolt5x7(
         address,
         socket,
         PoolConfig.max_connection_lifetime,
@@ -463,12 +464,12 @@ def test_hello_supports_notification_filters(
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=Bolt5x6.PACKER_CLS,
-        unpacker_cls=Bolt5x6.UNPACKER_CLS,
+        packer_cls=Bolt5x7.PACKER_CLS,
+        unpacker_cls=Bolt5x7.UNPACKER_CLS,
     )
     sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
     sockets.server.send_message(b"\x70", {})
-    connection = Bolt5x6(
+    connection = Bolt5x7(
         address,
         sockets.client,
         PoolConfig.max_connection_lifetime,
@@ -496,13 +497,13 @@ def test_user_agent(fake_socket_pair, user_agent):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=Bolt5x6.PACKER_CLS,
-        unpacker_cls=Bolt5x6.UNPACKER_CLS,
+        packer_cls=Bolt5x7.PACKER_CLS,
+        unpacker_cls=Bolt5x7.UNPACKER_CLS,
     )
     sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
     sockets.server.send_message(b"\x70", {})
     max_connection_lifetime = 0
-    connection = Bolt5x6(
+    connection = Bolt5x7(
         address, sockets.client, max_connection_lifetime, user_agent=user_agent
     )
     connection.hello()
@@ -523,13 +524,13 @@ def test_sends_bolt_agent(fake_socket_pair, user_agent):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=Bolt5x6.PACKER_CLS,
-        unpacker_cls=Bolt5x6.UNPACKER_CLS,
+        packer_cls=Bolt5x7.PACKER_CLS,
+        unpacker_cls=Bolt5x7.UNPACKER_CLS,
     )
     sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
     sockets.server.send_message(b"\x70", {})
     max_connection_lifetime = 0
-    connection = Bolt5x6(
+    connection = Bolt5x7(
         address, sockets.client, max_connection_lifetime, user_agent=user_agent
     )
     connection.hello()
@@ -583,11 +584,11 @@ def test_tx_timeout(
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=Bolt5x6.PACKER_CLS,
-        unpacker_cls=Bolt5x6.UNPACKER_CLS,
+        packer_cls=Bolt5x7.PACKER_CLS,
+        unpacker_cls=Bolt5x7.UNPACKER_CLS,
     )
     sockets.server.send_message(b"\x70", {})
-    connection = Bolt5x6(address, sockets.client, 0)
+    connection = Bolt5x7(address, sockets.client, 0)
     func = getattr(connection, func)
     if isinstance(res, Exception):
         with pytest.raises(type(res), match=str(res)):
@@ -619,10 +620,10 @@ def test_tracks_last_database(fake_socket_pair, actions):
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=Bolt5x6.PACKER_CLS,
-        unpacker_cls=Bolt5x6.UNPACKER_CLS,
+        packer_cls=Bolt5x7.PACKER_CLS,
+        unpacker_cls=Bolt5x7.UNPACKER_CLS,
     )
-    connection = Bolt5x6(address, sockets.client, 0)
+    connection = Bolt5x7(address, sockets.client, 0)
     sockets.server.send_message(b"\x70", {"server": "Neo4j/1.2.3"})
     sockets.server.send_message(b"\x70", {})
     connection.hello()
@@ -703,10 +704,10 @@ def test_enriches_statuses(
     address = neo4j.Address(("127.0.0.1", 7687))
     sockets = fake_socket_pair(
         address,
-        packer_cls=Bolt5x6.PACKER_CLS,
-        unpacker_cls=Bolt5x6.UNPACKER_CLS,
+        packer_cls=Bolt5x7.PACKER_CLS,
+        unpacker_cls=Bolt5x7.UNPACKER_CLS,
     )
-    connection = Bolt5x6(address, sockets.client, 0)
+    connection = Bolt5x7(address, sockets.client, 0)
 
     sent_metadata = {
         "statuses": [
@@ -760,3 +761,91 @@ def test_enriches_statuses(
     }
 
     assert received_metadata == expected_metadata
+
+
+@pytest.mark.parametrize(
+    "sent_diag_records",
+    powerset(
+        (
+            ...,
+            None,
+            {},
+            [],
+            "1",
+            1,
+            {"OPERATION_CODE": "0"},
+            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
+            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
+            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+        ),
+        lower_limit=1,
+        upper_limit=3,
+    ),
+)
+@mark_sync_test
+def test_enriches_error_statuses(
+    sent_diag_records,
+    fake_socket_pair,
+):
+    address = neo4j.Address(("127.0.0.1", 7687))
+    sockets = fake_socket_pair(
+        address,
+        packer_cls=Bolt5x7.PACKER_CLS,
+        unpacker_cls=Bolt5x7.UNPACKER_CLS,
+    )
+    connection = Bolt5x7(address, sockets.client, 0)
+    sent_diag_records = [
+        {**r, "_classification": "CLIENT_ERROR", "_status_parameters": {}}
+        if isinstance(r, dict)
+        else r
+        for r in sent_diag_records
+    ]
+
+    sent_metadata = _build_error_hierarchy_metadata(sent_diag_records)
+
+    sockets.server.send_message(b"\x7f", sent_metadata)
+
+    received_metadata = None
+
+    def on_failure(metadata):
+        nonlocal received_metadata
+        received_metadata = metadata
+
+    connection.run("RETURN 1", on_failure=on_failure)
+    connection.send_all()
+    with pytest.raises(Neo4jError):
+        connection.fetch_all()
+
+    def extend_diag_record(r):
+        if r is ...:
+            return dict(DEFAULT_DIAG_REC_PAIRS)
+        if isinstance(r, dict):
+            return dict((*DEFAULT_DIAG_REC_PAIRS, *r.items()))
+        return r
+
+    expected_diag_records = [extend_diag_record(r) for r in sent_diag_records]
+    expected_metadata = _build_error_hierarchy_metadata(expected_diag_records)
+
+    assert received_metadata == expected_metadata
+
+
+def _build_error_hierarchy_metadata(diag_records_metadata):
+    metadata = {
+        "gql_status": "FOO12",
+        "description": "but have you tried not doing that?!",
+        "message": "some people just can't be helped",
+        "neo4j_code": "Neo.ClientError.Generic.YouSuck",
+    }
+    if diag_records_metadata[0] is not ...:
+        metadata["diagnostic_record"] = diag_records_metadata[0]
+    current_root = metadata
+    for i, r in enumerate(diag_records_metadata[1:]):
+        current_root["cause"] = {
+            "gql_status": f"BAR{i + 1:02}",
+            "description": f"error cause nr. {i + 1}",
+            "message": f"cause message {i + 1}",
+        }
+        if r is not ...:
+            metadata["diagnostic_record"] = r
+        current_root = current_root["cause"]
+    return metadata

--- a/tests/unit/sync/io/test_neo4j_pool.py
+++ b/tests/unit/sync/io/test_neo4j_pool.py
@@ -535,11 +535,13 @@ def test_passes_pool_config_to_connection(mocker):
     "error",
     (
         ServiceUnavailable(),
-        Neo4jError.hydrate(
-            "message", "Neo.ClientError.Statement.EntityNotFound"
+        Neo4jError._hydrate_neo4j(
+            code="Neo.ClientError.Statement.EntityNotFound",
+            message="message",
         ),
-        Neo4jError.hydrate(
-            "message", "Neo.ClientError.Security.AuthorizationExpired"
+        Neo4jError._hydrate_neo4j(
+            code="Neo.ClientError.Security.AuthorizationExpired",
+            message="message",
         ),
     ),
 )
@@ -578,20 +580,20 @@ def test_discovery_is_retried(custom_routing_opener, error):
 @pytest.mark.parametrize(
     "error",
     map(
-        lambda args: Neo4jError.hydrate(*args),
+        lambda args: Neo4jError._hydrate_neo4j(code=args[0], message=args[1]),
         (
-            ("message", "Neo.ClientError.Database.DatabaseNotFound"),
-            ("message", "Neo.ClientError.Transaction.InvalidBookmark"),
-            ("message", "Neo.ClientError.Transaction.InvalidBookmarkMixture"),
-            ("message", "Neo.ClientError.Statement.TypeError"),
-            ("message", "Neo.ClientError.Statement.ArgumentError"),
-            ("message", "Neo.ClientError.Request.Invalid"),
-            ("message", "Neo.ClientError.Security.AuthenticationRateLimit"),
-            ("message", "Neo.ClientError.Security.CredentialsExpired"),
-            ("message", "Neo.ClientError.Security.Forbidden"),
-            ("message", "Neo.ClientError.Security.TokenExpired"),
-            ("message", "Neo.ClientError.Security.Unauthorized"),
-            ("message", "Neo.ClientError.Security.MadeUpError"),
+            ("Neo.ClientError.Database.DatabaseNotFound", "message"),
+            ("Neo.ClientError.Transaction.InvalidBookmark", "message"),
+            ("Neo.ClientError.Transaction.InvalidBookmarkMixture", "message"),
+            ("Neo.ClientError.Statement.TypeError", "message"),
+            ("Neo.ClientError.Statement.ArgumentError", "message"),
+            ("Neo.ClientError.Request.Invalid", "message"),
+            ("Neo.ClientError.Security.AuthenticationRateLimit", "message"),
+            ("Neo.ClientError.Security.CredentialsExpired", "message"),
+            ("Neo.ClientError.Security.Forbidden", "message"),
+            ("Neo.ClientError.Security.TokenExpired", "message"),
+            ("Neo.ClientError.Security.Unauthorized", "message"),
+            ("Neo.ClientError.Security.MadeUpError", "message"),
         ),
     ),
 )
@@ -627,7 +629,7 @@ def test_fast_failing_discovery(custom_routing_opener, error):
 @pytest.mark.parametrize(
     ("error", "marks_unauthenticated", "fetches_new"),
     (
-        (Neo4jError.hydrate("message", args[0]), *args[1:])
+        (Neo4jError._hydrate_neo4j(code=args[0], message="message"), *args[1:])
         for args in (
             ("Neo.ClientError.Database.DatabaseNotFound", False, False),
             ("Neo.ClientError.Statement.TypeError", False, False),

--- a/tests/unit/sync/test_auth_management.py
+++ b/tests/unit/sync/test_auth_management.py
@@ -59,7 +59,7 @@ CODES_HANDLED_BY_BEARER_MANAGER = {
     "Neo.ClientError.Security.Unauthorized",
 }
 SAMPLE_ERRORS = [
-    Neo4jError.hydrate(code=code)
+    Neo4jError._hydrate_neo4j(code=code)
     for code in {
         "Neo.ClientError.Security.AuthenticationRateLimit",
         "Neo.ClientError.Security.AuthorizationExpired",

--- a/tests/unit/sync/work/test_transaction.py
+++ b/tests/unit/sync/work/test_transaction.py
@@ -315,7 +315,12 @@ def test_server_error_propagates(scripted_connection, error):
             (
                 "pull",
                 {
-                    "on_failure": ({"code": "Neo.ClientError.Made.Up"},),
+                    "on_failure": (
+                        {
+                            "neo4j_code": "Neo.ClientError.Made.Up",
+                            "gql_status": "50N42",
+                        },
+                    ),
                     "on_summary": None,
                 },
             )


### PR DESCRIPTION
:warning: This feature is still in **PREVIEW**.
It might be changed without following the deprecation policy.

This PR introduces a new base class for `Neo4jError` and `DriverError` called `GqlError`.
It contains fields to make the errors GQL compliant.
Moreover, does the PR introduce support for Bolt protocol version 5.7 in which such GQL error information can be transmitted over the wire.

Depends on:
 * https://github.com/neo4j-drivers/testkit/pull/629