### PR TITLE
API docs: elaborate on Result.to_df options

### DIFF
--- a/src/neo4j/_async/work/result.py
+++ b/src/neo4j/_async/work/result.py
@@ -885,6 +885,8 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
             If :data:`True`, columns that exclusively contain
             :class:`time.DateTime` objects, :class:`time.Date` objects, or
             :data:`None`, will be converted to :class:`pandas.Timestamp`.
+            If :data:`False`, columns of the above types will be left as is
+            (dtype ``object``).
 
         :raises ImportError: if `pandas` library is not available.
         :raises ResultConsumedError: if the transaction from which this result

--- a/src/neo4j/_async/work/result.py
+++ b/src/neo4j/_async/work/result.py
@@ -885,8 +885,8 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
             If :data:`True`, columns that exclusively contain
             :class:`time.DateTime` objects, :class:`time.Date` objects, or
             :data:`None`, will be converted to :class:`pandas.Timestamp`.
-            If :data:`False`, columns of the above types will be left as is
-            (dtype ``object``).
+            If :data:`False`, columns of the above types will be left as driver
+            types (dtype ``object``).
 
         :raises ImportError: if `pandas` library is not available.
         :raises ResultConsumedError: if the transaction from which this result

--- a/src/neo4j/_sync/work/result.py
+++ b/src/neo4j/_sync/work/result.py
@@ -885,6 +885,8 @@ class Result(NonConcurrentMethodChecker):
             If :data:`True`, columns that exclusively contain
             :class:`time.DateTime` objects, :class:`time.Date` objects, or
             :data:`None`, will be converted to :class:`pandas.Timestamp`.
+            If :data:`False`, columns of the above types will be left as is
+            (dtype ``object``).
 
         :raises ImportError: if `pandas` library is not available.
         :raises ResultConsumedError: if the transaction from which this result

--- a/src/neo4j/_sync/work/result.py
+++ b/src/neo4j/_sync/work/result.py
@@ -885,8 +885,8 @@ class Result(NonConcurrentMethodChecker):
             If :data:`True`, columns that exclusively contain
             :class:`time.DateTime` objects, :class:`time.Date` objects, or
             :data:`None`, will be converted to :class:`pandas.Timestamp`.
-            If :data:`False`, columns of the above types will be left as is
-            (dtype ``object``).
+            If :data:`False`, columns of the above types will be left as driver
+            types (dtype ``object``).
 
         :raises ImportError: if `pandas` library is not available.
         :raises ResultConsumedError: if the transaction from which this result


### PR DESCRIPTION
Explain what passing `parse_dates=False` to `Result.to_df` does.