### PR TITLE
Prefix AsyncNonConcurrentMethodChecker methods with underscore

### DIFF
--- a/src/neo4j/_async/_debug/_concurrency_check.py
+++ b/src/neo4j/_async/_debug/_concurrency_check.py
@@ -62,17 +62,17 @@ class AsyncNonConcurrentMethodChecker:
             return NonConcurrentMethodError(msg)
 
         @classmethod
-        def non_concurrent_method(cls, f: _TWrapped) -> _TWrapped:
+        def _non_concurrent_method(cls, f: _TWrapped) -> _TWrapped:
             if AsyncUtil.is_async_code:
                 if not inspect.iscoroutinefunction(f):
                     raise TypeError(
                         "cannot decorate non-coroutine function with "
-                        "AsyncNonConcurrentMethodChecked.non_concurrent_method"
+                        "AsyncNonConcurrentMethodChecked._non_concurrent_method"
                     )
             elif not callable(f):
                 raise TypeError(
                     "cannot decorate non-callable object with "
-                    "NonConcurrentMethodChecked.non_concurrent_method"
+                    "NonConcurrentMethodChecked._non_concurrent_method"
                 )
 
             @copy_signature(f)
@@ -100,17 +100,17 @@ class AsyncNonConcurrentMethodChecker:
             return inner
 
         @classmethod
-        def non_concurrent_iter(cls, f: _TWrappedIter) -> _TWrappedIter:
+        def _non_concurrent_iter(cls, f: _TWrappedIter) -> _TWrappedIter:
             if AsyncUtil.is_async_code:
                 if not inspect.isasyncgenfunction(f):
                     raise TypeError(
                         "cannot decorate non-async-generator function with "
-                        "AsyncNonConcurrentMethodChecked.non_concurrent_iter"
+                        "AsyncNonConcurrentMethodChecked._non_concurrent_iter"
                     )
             elif not inspect.isgeneratorfunction(f):
                 raise TypeError(
                     "cannot decorate non-generator function with "
-                    "NonConcurrentMethodChecked.non_concurrent_iter"
+                    "NonConcurrentMethodChecked._non_concurrent_iter"
                 )
 
             @copy_signature(f)
@@ -145,9 +145,9 @@ class AsyncNonConcurrentMethodChecker:
     else:
 
         @classmethod
-        def non_concurrent_method(cls, f: _TWrapped) -> _TWrapped:
+        def _non_concurrent_method(cls, f: _TWrapped) -> _TWrapped:
             return f
 
         @classmethod
-        def non_concurrent_iter(cls, f: _TWrappedIter) -> _TWrappedIter:
+        def _non_concurrent_iter(cls, f: _TWrappedIter) -> _TWrappedIter:
             return f

--- a/src/neo4j/_async/work/result.py
+++ b/src/neo4j/_async/work/result.py
@@ -375,7 +375,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
         assert self._creation_frame_cache is not None  # help mypy a little
         return self._creation_frame_cache
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_iter
+    @AsyncNonConcurrentMethodChecker._non_concurrent_iter
     async def __aiter__(self) -> t.AsyncIterator[Record]:
         """
         Create an iterator returning records.
@@ -408,7 +408,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
         if self._consumed:
             raise ResultConsumedError(self, _RESULT_CONSUMED_ERROR)
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def __anext__(self) -> Record:
         """
         Advance the result stream and return the record.
@@ -498,7 +498,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
         self._attached = False
         self._exception = exc
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def consume(self) -> ResultSummary:
         """
         Consume the remainder of this result and return the summary.
@@ -565,7 +565,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
     @t.overload
     async def single(self, strict: te.Literal[True]) -> Record: ...
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def single(self, strict: bool = False) -> Record | None:
         """
         Obtain the next and only remaining record or None.
@@ -631,7 +631,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
                 )
         return buffer.popleft()
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def fetch(self, n: int) -> list[Record]:
         """
         Obtain up to n records from this result.
@@ -655,7 +655,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
             for _ in range(min(n, len(self._record_buffer)))
         ]
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def peek(self) -> Record | None:
         """
         Obtain the next record from this result without consuming it.
@@ -677,7 +677,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
             return self._record_buffer[0]
         return None
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def graph(self) -> Graph:
         """
         Turn the result into a :class:`.Graph`.
@@ -701,7 +701,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
         await self._buffer_all()
         return self._hydration_scope.get_graph()
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def value(
         self, key: _TResultKey = 0, default: object = None
     ) -> list[t.Any]:
@@ -725,7 +725,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
         """
         return [record.value(key, default) async for record in self]
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def values(self, *keys: _TResultKey) -> list[list[t.Any]]:
         """
         Return the remainder of the result as a list of values lists.
@@ -746,7 +746,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
         """
         return [record.values(*keys) async for record in self]
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def data(self, *keys: _TResultKey) -> list[dict[str, t.Any]]:
         """
         Return the remainder of the result as a list of dictionaries.
@@ -776,7 +776,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
         """
         return [record.data(*keys) async for record in self]
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def to_eager_result(self) -> EagerResult:
         """
         Convert this result to an :class:`.EagerResult`.
@@ -801,7 +801,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
             summary=await self.consume(),
         )
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def to_df(
         self, expand: bool = False, parse_dates: bool = False
     ) -> pandas.DataFrame:

--- a/src/neo4j/_async/work/session.py
+++ b/src/neo4j/_async/work/session.py
@@ -184,7 +184,7 @@ class AsyncSession(AsyncWorkspace):
         await self._connect(READ_ACCESS, force_auth=True)
         await self._disconnect()
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def close(self) -> None:
         """
         Close the session.
@@ -253,7 +253,7 @@ class AsyncSession(AsyncWorkspace):
             """
             self._handle_cancellation(message="manual cancel")
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def run(
         self,
         query: te.LiteralString | Query,
@@ -334,7 +334,7 @@ class AsyncSession(AsyncWorkspace):
         "`last_bookmark` has been deprecated in favor of `last_bookmarks`. "
         "This method can lead to unexpected behaviour."
     )
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def last_bookmark(self) -> str | None:
         """
         Get the bookmark received following the last completed transaction.
@@ -365,7 +365,7 @@ class AsyncSession(AsyncWorkspace):
             return self._bookmarks[-1]
         return None
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def last_bookmarks(self) -> Bookmarks:
         """
         Return most recent bookmarks of the session.
@@ -455,7 +455,7 @@ class AsyncSession(AsyncWorkspace):
             pipelined=self._pipelined_begin,
         )
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def begin_transaction(
         self,
         metadata: dict[str, t.Any] | None = None,
@@ -614,7 +614,7 @@ class AsyncSession(AsyncWorkspace):
         else:
             raise ServiceUnavailable("Transaction failed")
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def execute_read(
         self,
         transaction_function: t.Callable[
@@ -695,7 +695,7 @@ class AsyncSession(AsyncWorkspace):
 
     # TODO: 6.0 - Remove this method
     @deprecated("read_transaction has been renamed to execute_read")
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def read_transaction(
         self,
         transaction_function: t.Callable[
@@ -738,7 +738,7 @@ class AsyncSession(AsyncWorkspace):
             kwargs,
         )
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def execute_write(
         self,
         transaction_function: t.Callable[
@@ -801,7 +801,7 @@ class AsyncSession(AsyncWorkspace):
 
     # TODO: 6.0 - Remove this method
     @deprecated("write_transaction has been renamed to execute_write")
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def write_transaction(
         self,
         transaction_function: t.Callable[

--- a/src/neo4j/_async/work/transaction.py
+++ b/src/neo4j/_async/work/transaction.py
@@ -67,7 +67,7 @@ class AsyncTransactionBase(AsyncNonConcurrentMethodChecker):
     async def _enter(self) -> te.Self:
         return self
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def _exit(self, exception_type, exception_value, traceback):
         if self._closed_flag:
             return
@@ -79,7 +79,7 @@ class AsyncTransactionBase(AsyncNonConcurrentMethodChecker):
             return
         await self._close()
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def _begin(
         self,
         database,
@@ -124,7 +124,7 @@ class AsyncTransactionBase(AsyncNonConcurrentMethodChecker):
             await result._tx_end()
         self._results = []
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def run(
         self,
         query: te.LiteralString,
@@ -196,7 +196,7 @@ class AsyncTransactionBase(AsyncNonConcurrentMethodChecker):
 
         return result
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def _commit(self):
         if self._closed_flag:
             raise TransactionError(self, "Transaction closed")
@@ -223,7 +223,7 @@ class AsyncTransactionBase(AsyncNonConcurrentMethodChecker):
 
         return self._bookmark
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def _rollback(self):
         if self._closed_flag:
             raise TransactionError(self, "Transaction closed")
@@ -247,7 +247,7 @@ class AsyncTransactionBase(AsyncNonConcurrentMethodChecker):
             self._closed_flag = True
             await AsyncUtil.callback(self._on_closed)
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def _close(self):
         if self._closed_flag:
             return

--- a/src/neo4j/_async/work/workspace.py
+++ b/src/neo4j/_async/work/workspace.py
@@ -197,7 +197,7 @@ class AsyncWorkspace(AsyncNonConcurrentMethodChecker):
                 self._connection = None
             self._connection_access_mode = None
 
-    @AsyncNonConcurrentMethodChecker.non_concurrent_method
+    @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def close(self) -> None:
         if self._closed:
             return

--- a/src/neo4j/_sync/_debug/_concurrency_check.py
+++ b/src/neo4j/_sync/_debug/_concurrency_check.py
@@ -62,17 +62,17 @@ class NonConcurrentMethodChecker:
             return NonConcurrentMethodError(msg)
 
         @classmethod
-        def non_concurrent_method(cls, f: _TWrapped) -> _TWrapped:
+        def _non_concurrent_method(cls, f: _TWrapped) -> _TWrapped:
             if Util.is_async_code:
                 if not inspect.iscoroutinefunction(f):
                     raise TypeError(
                         "cannot decorate non-coroutine function with "
-                        "NonConcurrentMethodChecked.non_concurrent_method"
+                        "NonConcurrentMethodChecked._non_concurrent_method"
                     )
             elif not callable(f):
                 raise TypeError(
                     "cannot decorate non-callable object with "
-                    "NonConcurrentMethodChecked.non_concurrent_method"
+                    "NonConcurrentMethodChecked._non_concurrent_method"
                 )
 
             @copy_signature(f)
@@ -100,17 +100,17 @@ class NonConcurrentMethodChecker:
             return inner
 
         @classmethod
-        def non_concurrent_iter(cls, f: _TWrappedIter) -> _TWrappedIter:
+        def _non_concurrent_iter(cls, f: _TWrappedIter) -> _TWrappedIter:
             if Util.is_async_code:
                 if not inspect.isasyncgenfunction(f):
                     raise TypeError(
                         "cannot decorate non-async-generator function with "
-                        "NonConcurrentMethodChecked.non_concurrent_iter"
+                        "NonConcurrentMethodChecked._non_concurrent_iter"
                     )
             elif not inspect.isgeneratorfunction(f):
                 raise TypeError(
                     "cannot decorate non-generator function with "
-                    "NonConcurrentMethodChecked.non_concurrent_iter"
+                    "NonConcurrentMethodChecked._non_concurrent_iter"
                 )
 
             @copy_signature(f)
@@ -145,9 +145,9 @@ class NonConcurrentMethodChecker:
     else:
 
         @classmethod
-        def non_concurrent_method(cls, f: _TWrapped) -> _TWrapped:
+        def _non_concurrent_method(cls, f: _TWrapped) -> _TWrapped:
             return f
 
         @classmethod
-        def non_concurrent_iter(cls, f: _TWrappedIter) -> _TWrappedIter:
+        def _non_concurrent_iter(cls, f: _TWrappedIter) -> _TWrappedIter:
             return f

--- a/src/neo4j/_sync/work/result.py
+++ b/src/neo4j/_sync/work/result.py
@@ -375,7 +375,7 @@ class Result(NonConcurrentMethodChecker):
         assert self._creation_frame_cache is not None  # help mypy a little
         return self._creation_frame_cache
 
-    @NonConcurrentMethodChecker.non_concurrent_iter
+    @NonConcurrentMethodChecker._non_concurrent_iter
     def __iter__(self) -> t.Iterator[Record]:
         """
         Create an iterator returning records.
@@ -408,7 +408,7 @@ class Result(NonConcurrentMethodChecker):
         if self._consumed:
             raise ResultConsumedError(self, _RESULT_CONSUMED_ERROR)
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def __next__(self) -> Record:
         """
         Advance the result stream and return the record.
@@ -498,7 +498,7 @@ class Result(NonConcurrentMethodChecker):
         self._attached = False
         self._exception = exc
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def consume(self) -> ResultSummary:
         """
         Consume the remainder of this result and return the summary.
@@ -565,7 +565,7 @@ class Result(NonConcurrentMethodChecker):
     @t.overload
     def single(self, strict: te.Literal[True]) -> Record: ...
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def single(self, strict: bool = False) -> Record | None:
         """
         Obtain the next and only remaining record or None.
@@ -631,7 +631,7 @@ class Result(NonConcurrentMethodChecker):
                 )
         return buffer.popleft()
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def fetch(self, n: int) -> list[Record]:
         """
         Obtain up to n records from this result.
@@ -655,7 +655,7 @@ class Result(NonConcurrentMethodChecker):
             for _ in range(min(n, len(self._record_buffer)))
         ]
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def peek(self) -> Record | None:
         """
         Obtain the next record from this result without consuming it.
@@ -677,7 +677,7 @@ class Result(NonConcurrentMethodChecker):
             return self._record_buffer[0]
         return None
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def graph(self) -> Graph:
         """
         Turn the result into a :class:`.Graph`.
@@ -701,7 +701,7 @@ class Result(NonConcurrentMethodChecker):
         self._buffer_all()
         return self._hydration_scope.get_graph()
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def value(
         self, key: _TResultKey = 0, default: object = None
     ) -> list[t.Any]:
@@ -725,7 +725,7 @@ class Result(NonConcurrentMethodChecker):
         """
         return [record.value(key, default) for record in self]
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def values(self, *keys: _TResultKey) -> list[list[t.Any]]:
         """
         Return the remainder of the result as a list of values lists.
@@ -746,7 +746,7 @@ class Result(NonConcurrentMethodChecker):
         """
         return [record.values(*keys) for record in self]
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def data(self, *keys: _TResultKey) -> list[dict[str, t.Any]]:
         """
         Return the remainder of the result as a list of dictionaries.
@@ -776,7 +776,7 @@ class Result(NonConcurrentMethodChecker):
         """
         return [record.data(*keys) for record in self]
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def to_eager_result(self) -> EagerResult:
         """
         Convert this result to an :class:`.EagerResult`.
@@ -801,7 +801,7 @@ class Result(NonConcurrentMethodChecker):
             summary=self.consume(),
         )
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def to_df(
         self, expand: bool = False, parse_dates: bool = False
     ) -> pandas.DataFrame:

--- a/src/neo4j/_sync/work/session.py
+++ b/src/neo4j/_sync/work/session.py
@@ -184,7 +184,7 @@ class Session(Workspace):
         self._connect(READ_ACCESS, force_auth=True)
         self._disconnect()
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def close(self) -> None:
         """
         Close the session.
@@ -253,7 +253,7 @@ class Session(Workspace):
             """
             self._handle_cancellation(message="manual cancel")
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def run(
         self,
         query: te.LiteralString | Query,
@@ -334,7 +334,7 @@ class Session(Workspace):
         "`last_bookmark` has been deprecated in favor of `last_bookmarks`. "
         "This method can lead to unexpected behaviour."
     )
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def last_bookmark(self) -> str | None:
         """
         Get the bookmark received following the last completed transaction.
@@ -365,7 +365,7 @@ class Session(Workspace):
             return self._bookmarks[-1]
         return None
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def last_bookmarks(self) -> Bookmarks:
         """
         Return most recent bookmarks of the session.
@@ -455,7 +455,7 @@ class Session(Workspace):
             pipelined=self._pipelined_begin,
         )
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def begin_transaction(
         self,
         metadata: dict[str, t.Any] | None = None,
@@ -614,7 +614,7 @@ class Session(Workspace):
         else:
             raise ServiceUnavailable("Transaction failed")
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def execute_read(
         self,
         transaction_function: t.Callable[
@@ -695,7 +695,7 @@ class Session(Workspace):
 
     # TODO: 6.0 - Remove this method
     @deprecated("read_transaction has been renamed to execute_read")
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def read_transaction(
         self,
         transaction_function: t.Callable[
@@ -738,7 +738,7 @@ class Session(Workspace):
             kwargs,
         )
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def execute_write(
         self,
         transaction_function: t.Callable[
@@ -801,7 +801,7 @@ class Session(Workspace):
 
     # TODO: 6.0 - Remove this method
     @deprecated("write_transaction has been renamed to execute_write")
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def write_transaction(
         self,
         transaction_function: t.Callable[

--- a/src/neo4j/_sync/work/transaction.py
+++ b/src/neo4j/_sync/work/transaction.py
@@ -67,7 +67,7 @@ class TransactionBase(NonConcurrentMethodChecker):
     def _enter(self) -> te.Self:
         return self
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def _exit(self, exception_type, exception_value, traceback):
         if self._closed_flag:
             return
@@ -79,7 +79,7 @@ class TransactionBase(NonConcurrentMethodChecker):
             return
         self._close()
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def _begin(
         self,
         database,
@@ -124,7 +124,7 @@ class TransactionBase(NonConcurrentMethodChecker):
             result._tx_end()
         self._results = []
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def run(
         self,
         query: te.LiteralString,
@@ -196,7 +196,7 @@ class TransactionBase(NonConcurrentMethodChecker):
 
         return result
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def _commit(self):
         if self._closed_flag:
             raise TransactionError(self, "Transaction closed")
@@ -223,7 +223,7 @@ class TransactionBase(NonConcurrentMethodChecker):
 
         return self._bookmark
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def _rollback(self):
         if self._closed_flag:
             raise TransactionError(self, "Transaction closed")
@@ -247,7 +247,7 @@ class TransactionBase(NonConcurrentMethodChecker):
             self._closed_flag = True
             Util.callback(self._on_closed)
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def _close(self):
         if self._closed_flag:
             return

--- a/src/neo4j/_sync/work/workspace.py
+++ b/src/neo4j/_sync/work/workspace.py
@@ -197,7 +197,7 @@ class Workspace(NonConcurrentMethodChecker):
                 self._connection = None
             self._connection_access_mode = None
 
-    @NonConcurrentMethodChecker.non_concurrent_method
+    @NonConcurrentMethodChecker._non_concurrent_method
     def close(self) -> None:
         if self._closed:
             return


### PR DESCRIPTION
The concurrency check introduced in
https://github.com/neo4j/neo4j-python-driver/pull/989 introduced classmethods to several driver primitives that had the check added. These class methods are only meant for internal use and are undocumented. Therefore, they should be marked private.