### PR TITLE
Fix bugs in neo4j.time.DateTime handling

### DIFF
--- a/src/neo4j/_async/work/result.py
+++ b/src/neo4j/_async/work/result.py
@@ -892,6 +892,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
             consumed.
         """
         import pandas as pd  # type: ignore[import]
+        import pytz
 
         if not expand:
             df = pd.DataFrame(await self.values(), columns=self._keys)
@@ -931,14 +932,19 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
                 ).all()
             )
         ]
+
+        def datetime_to_timestamp(x):
+            if not x:
+                return pd.NaT
+            tzinfo = getattr(x, "tzinfo", None)
+            if tzinfo is None:
+                return pd.Timestamp(x.iso_format())
+            return pd.Timestamp(
+                x.astimezone(pytz.UTC).iso_format()
+            ).astimezone(tzinfo)
+
         df[dt_columns] = df[dt_columns].apply(
-            lambda col: col.map(
-                lambda x: pd.Timestamp(x.iso_format()).replace(
-                    tzinfo=getattr(x, "tzinfo", None)
-                )
-                if x
-                else pd.NaT
-            )
+            lambda col: col.map(datetime_to_timestamp)
         )
         return df
 

--- a/src/neo4j/time/__init__.py
+++ b/src/neo4j/time/__init__.py
@@ -2560,7 +2560,7 @@ class DateTime(date_time_base_class, metaclass=DateTimeType):
 
         Accepts :class:`.DateTime` and :class:`datetime.datetime`.
         """
-        if not isinstance(other, (Date, date)):
+        if not isinstance(other, (DateTime, datetime)):
             return NotImplemented
         return not self.__eq__(other)
 
@@ -2641,7 +2641,9 @@ class DateTime(date_time_base_class, metaclass=DateTimeType):
     def __add__(self, other: timedelta | Duration) -> DateTime:
         """Add a :class:`datetime.timedelta`."""
         if isinstance(other, Duration):
-            t = self.to_clock_time() + ClockTime(
+            if other == (0, 0, 0, 0):
+                return self
+            t = self.time().to_clock_time() + ClockTime(
                 other.seconds, other.nanoseconds
             )
             days, seconds = symmetric_divmod(t.seconds, 86400)
@@ -2651,8 +2653,11 @@ class DateTime(date_time_base_class, metaclass=DateTimeType):
             time_ = Time.from_ticks(seconds * NANO_SECONDS + t.nanoseconds)
             return self.combine(date_, time_).replace(tzinfo=self.tzinfo)
         if isinstance(other, timedelta):
+            if other.total_seconds() == 0:
+                return self
             t = self.to_clock_time() + ClockTime(
-                86400 * other.days + other.seconds, other.microseconds * 1000
+                86400 * other.days + other.seconds,
+                other.microseconds * 1000,
             )
             days, seconds = symmetric_divmod(t.seconds, 86400)
             date_ = Date.from_ordinal(days + 1)

--- a/tests/unit/async_/work/test_result.py
+++ b/tests/unit/async_/work/test_result.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import datetime
 import logging
 import typing as t
 import uuid
@@ -1082,6 +1083,18 @@ async def test_to_df_expand(
     assert df.equals(expected_df)
 
 
+DTS_AROUND_SWEDISH_DST_CHANGE: tuple[datetime.datetime, ...] = (
+    datetime.datetime(2024, 3, 31, 0, 30, 0),
+    datetime.datetime(2024, 3, 31, 1, 30, 0),
+    datetime.datetime(2024, 3, 31, 2, 30, 0),
+    datetime.datetime(2024, 3, 31, 3, 30, 0),
+    datetime.datetime(2024, 10, 27, 0, 30, 0),
+    datetime.datetime(2024, 10, 27, 1, 30, 0),
+    datetime.datetime(2024, 10, 27, 2, 30, 0),
+    datetime.datetime(2024, 10, 27, 3, 30, 0),
+)
+
+
 @pytest.mark.parametrize(
     ("keys", "values", "expected_df"),
     (
@@ -1209,7 +1222,7 @@ async def test_to_df_expand(
                 columns=["mixed"],
             ),
         ),
-        # Column with only None (should not be transfomred to NaT)
+        # Column with only None (should not be transformed to NaT)
         (
             ["all_none"],
             [
@@ -1251,6 +1264,34 @@ async def test_to_df_expand(
                 ],
                 columns=["all_none", "mixed", "n"],
             ),
+        ),
+        # Difficult timezones
+        *(
+            (
+                ["dt_tz"],
+                [
+                    [
+                        pytz.UTC.localize(
+                            neo4j_time.DateTime.from_native(dt)
+                        ).astimezone(pytz.timezone("Europe/Stockholm"))
+                        + neo4j_time.Duration(nanoseconds=add_ns)
+                    ]
+                    for dt in DTS_AROUND_SWEDISH_DST_CHANGE
+                ],
+                pd.DataFrame(
+                    [
+                        [
+                            pytz.UTC.localize(pd.Timestamp(dt)).astimezone(
+                                pytz.timezone("Europe/Stockholm")
+                            )
+                            + pd.Timedelta(add_ns, unit="ns")
+                        ]
+                        for dt in DTS_AROUND_SWEDISH_DST_CHANGE
+                    ],
+                    columns=["dt_tz"],
+                ),
+            )
+            for add_ns in (0, 1)
         ),
     ),
 )


### PR DESCRIPTION
 * Fix `DateTime` +/- `Duration` computation being wildly off by considering the days of the `DateTime` since UNIX epoch twice.
 * Fix `Result.to_df` not correctly converting `DateTime`s with `tzinfo` if `parse_dates=True` is passed in.
 * Fix `DateTime.__ne__` (inequality operator) always falling back to `object.__ne__` (comparison by `id`).