### PR TITLE
API docs: fix `AsyncAuthManagers.basic` example

### DIFF
--- a/src/neo4j/_async/auth_management.py
+++ b/src/neo4j/_async/auth_management.py
@@ -273,12 +273,12 @@ class AsyncAuthManagers:
                 # assume we know our tokens expire every 60 seconds
                 expires_in = 60
 
-                return ExpiringAuth(
-                    auth=neo4j.bearer_auth(sso_token),
-                    # Include a little buffer so that we fetch a new token
-                    # *before* the old one expires
-                    expires_in=expires_in - 10
-                )
+                # Include a little buffer so that we fetch a new token
+                # *before* the old one expires
+                expires_in -= 10
+
+                auth = neo4j.bearer_auth(sso_token)
+                return ExpiringAuth(auth=auth).expires_in(expires_in)
 
 
             with neo4j.GraphDatabase.driver(

--- a/src/neo4j/_sync/auth_management.py
+++ b/src/neo4j/_sync/auth_management.py
@@ -273,12 +273,12 @@ class AuthManagers:
                 # assume we know our tokens expire every 60 seconds
                 expires_in = 60
 
-                return ExpiringAuth(
-                    auth=neo4j.bearer_auth(sso_token),
-                    # Include a little buffer so that we fetch a new token
-                    # *before* the old one expires
-                    expires_in=expires_in - 10
-                )
+                # Include a little buffer so that we fetch a new token
+                # *before* the old one expires
+                expires_in -= 10
+
+                auth = neo4j.bearer_auth(sso_token)
+                return ExpiringAuth(auth=auth).expires_in(expires_in)
 
 
             with neo4j.GraphDatabase.driver(


### PR DESCRIPTION
The example used an old version of `ExpiringAuth`. Before version 5.9, `ExpiringAuth` accepted an `expires_in` parameter, which then was changed to `expires_at` while `expires_in` was moved to be a convenience method on `ExpiringAuth` instances.

However, the example code in `AsyncAuthManagers.basic` was not adjusted.