### PR TITLE
Fix concurrent install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,8 @@ def change_project_name(new_name):
         fd.seek(0)
         pyproject = tomlkit.parse(fd.read())
         old_name = pyproject["project"]["name"]
+        if old_name == new_name:
+            return None
         pyproject["project"]["name"] = new_name
         fd.seek(0)
         fd.truncate()
@@ -82,7 +84,8 @@ def changed_package_name(new_name):
     try:
         yield
     finally:
-        change_project_name(old_name)
+        if old_name is not None:
+            change_project_name(old_name)
 
 
 with changed_package_name(package):


### PR DESCRIPTION
There's some file manipulation going on during installation of the package. Since we've shifted CI to run unit tests in parallel, and therefore install the package in parallel, we've seen flakiness stemming from this race condition.