### PR TITLE
Typing: fix auth token shorthand

### DIFF
--- a/src/neo4j/_async/driver.py
+++ b/src/neo4j/_async/driver.py
@@ -1026,7 +1026,7 @@ class AsyncDriver:
             bookmark_manager: (
                 AsyncBookmarkManager | BookmarkManager | None
             ) = ...,
-            auth: Auth | tuple[t.Any, t.Any] = ...,
+            auth: Auth | tuple[str, str] = ...,
             notifications_min_severity: (
                 T_NotificationMinimumSeverity | None
             ) = ...,
@@ -1101,7 +1101,7 @@ class AsyncDriver:
             bookmark_manager: (
                 AsyncBookmarkManager | BookmarkManager | None
             ) = ...,
-            auth: Auth | tuple[t.Any, t.Any] = ...,
+            auth: Auth | tuple[str, str] = ...,
             notifications_min_severity: (
                 T_NotificationMinimumSeverity | None
             ) = ...,
@@ -1184,7 +1184,7 @@ class AsyncDriver:
 
         async def verify_authentication(
             self,
-            auth: Auth | tuple[t.Any, t.Any] | None = None,
+            auth: Auth | tuple[str, str] | None = None,
             # all other arguments are experimental
             # they may be change or removed any time without prior notice
             session_connection_timeout: float = ...,
@@ -1208,7 +1208,7 @@ class AsyncDriver:
 
         async def verify_authentication(
             self,
-            auth: Auth | tuple[t.Any, t.Any] | None = None,
+            auth: Auth | tuple[str, str] | None = None,
             **config,
         ) -> bool:
             """

--- a/src/neo4j/_sync/driver.py
+++ b/src/neo4j/_sync/driver.py
@@ -1025,7 +1025,7 @@ class Driver:
             bookmark_manager: (
                 BookmarkManager | BookmarkManager | None
             ) = ...,
-            auth: Auth | tuple[t.Any, t.Any] = ...,
+            auth: Auth | tuple[str, str] = ...,
             notifications_min_severity: (
                 T_NotificationMinimumSeverity | None
             ) = ...,
@@ -1100,7 +1100,7 @@ class Driver:
             bookmark_manager: (
                 BookmarkManager | BookmarkManager | None
             ) = ...,
-            auth: Auth | tuple[t.Any, t.Any] = ...,
+            auth: Auth | tuple[str, str] = ...,
             notifications_min_severity: (
                 T_NotificationMinimumSeverity | None
             ) = ...,
@@ -1183,7 +1183,7 @@ class Driver:
 
         def verify_authentication(
             self,
-            auth: Auth | tuple[t.Any, t.Any] | None = None,
+            auth: Auth | tuple[str, str] | None = None,
             # all other arguments are experimental
             # they may be change or removed any time without prior notice
             session_connection_timeout: float = ...,
@@ -1207,7 +1207,7 @@ class Driver:
 
         def verify_authentication(
             self,
-            auth: Auth | tuple[t.Any, t.Any] | None = None,
+            auth: Auth | tuple[str, str] | None = None,
             **config,
         ) -> bool:
             """

--- a/src/neo4j/api.py
+++ b/src/neo4j/api.py
@@ -163,7 +163,7 @@ class Auth:
 AuthToken = Auth
 
 if t.TYPE_CHECKING:
-    _TAuth = t.Union[t.Tuple[t.Any, t.Any], Auth, None]
+    _TAuth = t.Union[t.Tuple[str, str], Auth, None]
 
 
 def basic_auth(user: str, password: str, realm: str | None = None) -> Auth:


### PR DESCRIPTION
The driver accepts a tuple `("user", "password")` for the auth argument. This is shorthand for a `basic` auth token. It was typed to expect `tuple[Any, Any]`, which is inconsistent with `neo4j.basic(str, str, ...)`.
