### PR TITLE
Set TCP_NODELAY

### DIFF
--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import logging
 import struct
 import typing as t
@@ -29,10 +30,12 @@ from contextlib import suppress
 from socket import (
     AF_INET,
     AF_INET6,
+    IPPROTO_TCP,
     SHUT_RDWR,
     SO_KEEPALIVE,
     socket,
     SOL_SOCKET,
+    TCP_NODELAY,
     timeout as SocketTimeout,  # noqa: N812 (it is a class)
 )
 # isort: on
@@ -548,6 +551,12 @@ class BoltSocket:
                 s = socket(AF_INET6)
             else:
                 raise ValueError(f"Unsupported address {resolved_address!r}")
+            try:
+                s.setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
+            except OSError as e:
+                # option might not be supported on all platforms
+                if e.errno != errno.ENOPROTOOPT:
+                    raise
             t = s.gettimeout()
             if timeout:
                 s.settimeout(timeout)


### PR DESCRIPTION
This yields a small performance improvement by disabling Nagle's algorithm on the TCP sockets.

The change only affects the synchronous driver as most async runtime implementations already set this socket option for us.