### PR TITLE
PEP 625 compatible distributions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,9 @@ pyarrow = ["pyarrow >= 1.0.0"]
 
 [build-system]
 requires = [
-    "setuptools == 68.0.0",  # dropped support for Python 3.7 in 68.1.0
+    "setuptools == 68.0.0; python_version <= '3.7'",  # dropped support for Python 3.7 in 68.1.0
+    "setuptools == 75.3.0; python_version == '3.8'",  # dropped support for Python 3.8 in 75.4.0
+    "setuptools == 75.6.0; python_version >= '3.9'",
     # TODO: 6.0 - can be removed once `setup.py` is simplified
     "tomlkit == 0.12.5",  # dropped support (at least CI testing) for Python 3.7 in 0.13.0
 ]


### PR DESCRIPTION
I'll quote the mail we've received from PyPI

> This email is notifying you of an upcoming deprecation that we have determined
> may affect you as a result of your recent upload to 'neo4j-driver'.
>
> In the future, PyPI will require all newly uploaded source distribution
> filenames to comply with PEP 625. Any source distributions already uploaded
> will remain in place as-is and do not need to be updated.
>
> Specifically, your recent upload of 'neo4j-driver-5.27.0.tar.gz' is
> incompatible with PEP 625 because it does not contain the normalized project
> name 'neo4j_driver'.
>
> In most cases, this can be resolved by upgrading the version of your build
> tooling to a later version that supports PEP 625 and produces compliant
> filenames.
>
> If you have questions, you can email admin@pypi.org to communicate with the
> PyPI admin@pypi.org to communicate with the PyPI administrators.

This change allows our release job running on a recent Python version to use a newer `setuptools` version which can produce PEP 625 compatible distribution files while still allowing the package to be installed with legacy Python versions (3.7 & 3.8).