### PR TITLE
Tests: detect timeout when joining threads

### DIFF
--- a/tests/unit/mixed/io/test_direct.py
+++ b/tests/unit/mixed/io/test_direct.py
@@ -122,7 +122,9 @@ class TestMixedConnectionPoolTestCase:
 
             # wait for all threads to release connections back to pool
             for t in threads:
-                t.join(timeout=1)
+                t.join(timeout=5)
+                if t.is_alive():
+                    raise TimeoutError(f"Joining thread timed out: {t!r}")
             # The pool size is still 5, but all are free
             self.assert_pool_size(address, 0, 5, pool)
 


### PR DESCRIPTION
It turns out that [`threading.Thread.join`](https://docs.python.org/3/library/threading.html#threading.Thread.join) does not raise an exception when the provided timeout is exceeded. This PR adjusts a unit test to accommodate that fact.