### PR TITLE
Fix publishing wheels for legacy package `neo4j-driver`

### DIFF
--- a/bin/check-dist
+++ b/bin/check-dist
@@ -19,6 +19,10 @@ else
               || check_file "${DIST}/${PACKAGE}-${VERSION}.tar.gz"); then
             STATUS=1
         fi
+        if ! (check_file "${DIST}/${NORMALIZED_PACKAGE}-${VERSION}-py3-none-any.whl" \
+              || check_file "${DIST}/${PACKAGE}-${VERSION}-py3-none-any.whl"); then
+            STATUS=1
+        fi
     done
 fi
 

--- a/bin/release
+++ b/bin/release
@@ -22,6 +22,7 @@ fi
 source "${ROOT}/bin/dist-functions"
 for PACKAGE in "neo4j-driver" "neo4j"; do
     NORMALIZED_PACKAGE="$(normalize_dist_name "$PACKAGE")"
+
     if check_file "${DIST}/${NORMALIZED_PACKAGE}-${VERSION}.tar.gz"
     then
         TWINE_ARGS="${TWINE_ARGS} ${DIST}/${NORMALIZED_PACKAGE}-${VERSION}.tar.gz"
@@ -31,18 +32,16 @@ for PACKAGE in "neo4j-driver" "neo4j"; do
         echo "Source distribution file for ${PACKAGE} not found"
         exit 1
     fi
+
+    if check_file "${DIST}/${NORMALIZED_PACKAGE}-${VERSION}-py3-none-any.whl"
+    then
+        TWINE_ARGS="${TWINE_ARGS} ${DIST}/${NORMALIZED_PACKAGE}-${VERSION}-py3-none-any.whl"
+    elif check_file "${DIST}/${PACKAGE}-${VERSION}-py3-none-any.whl"; then
+        TWINE_ARGS="${TWINE_ARGS} ${DIST}/${PACKAGE}-${VERSION}-py3-none-any.whl"
+    else
+        echo "Wheel distribution file for ${PACKAGE} not found"
+        exit 1
+    fi
 done
-
-NORMALIZED_PACKAGE="$(normalize_dist_name "neo4j")"
-if check_file "${DIST}/${NORMALIZED_PACKAGE}-${VERSION}-py3-none-any.whl"
-then
-    TWINE_ARGS="${TWINE_ARGS} ${DIST}/${NORMALIZED_PACKAGE}-${VERSION}-py3-none-any.whl"
-elif check_file "${DIST}/${PACKAGE}-${VERSION}-py3-none-any.whl"; then
-    TWINE_ARGS="${TWINE_ARGS} ${DIST}/${PACKAGE}-${VERSION}-py3-none-any.whl"
-else
-    echo "Wheel distribution file for ${PACKAGE} not found"
-    exit 1
-fi
-
 
 twine upload ${TWINE_ARGS}


### PR DESCRIPTION
While #1131 enabled building the pure-Python wheels for `neo4j-driver`, it missed to update the `check-dist` and `release` scripts.