### PR TITLE
TestKit: enable home db cache feature flag

### DIFF
--- a/testkitbackend/test_config.json
+++ b/testkitbackend/test_config.json
@@ -76,6 +76,7 @@
     "Optimization:ConnectionReuse": true,
     "Optimization:EagerTransactionBegin": true,
     "Optimization:ExecuteQueryPipelining": true,
+    "Optimization:HomeDatabaseCache": true,
     "Optimization:HomeDbCacheBasicPrincipalIsImpersonatedUser": true,
     "Optimization:ImplicitDefaultArguments": true,
     "Optimization:MinimalBookmarksSet": true,


### PR DESCRIPTION
This flag was introduced later when developing the TestKit tests for the optimistic home database cache. Tests were run manually before and passed. Of course they should also run automatically in CI now.