### PR TITLE
Fix exception in bolt handshake when log level <10

### DIFF
--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -292,7 +292,7 @@ class AsyncBolt:
 
     # [bolt-version-bump] search tag when changing bolt version support
     @classmethod
-    def get_handshake(cls):
+    def get_handshake(cls) -> bytes:
         """
         Return the supported Bolt versions as bytes.
 

--- a/src/neo4j/_async/io/_bolt_socket.py
+++ b/src/neo4j/_async/io/_bolt_socket.py
@@ -39,7 +39,15 @@ from ...exceptions import (
 
 
 if t.TYPE_CHECKING:
+    from ssl import SSLContext
+
+    import typing_extensions as te
+
     from ..._deadline import Deadline
+    from ...addressing import (
+        Address,
+        ResolvedAddress,
+    )
 
 
 log = logging.getLogger("neo4j.io")
@@ -63,7 +71,11 @@ class BytesPrinter:
 
 
 class AsyncBoltSocket(AsyncBoltSocketBase):
-    async def _parse_handshake_response_v1(self, ctx, response):
+    async def _parse_handshake_response_v1(
+        self,
+        ctx: HandshakeCtx,
+        response: bytes,
+    ) -> tuple[int, int]:
         agreed_version = response[-1], response[-2]
         log.debug(
             "[#%04X]  S: <HANDSHAKE> 0x%06X%02X",
@@ -73,7 +85,11 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
         )
         return agreed_version
 
-    async def _parse_handshake_response_v2(self, ctx, response):
+    async def _parse_handshake_response_v2(
+        self,
+        ctx: HandshakeCtx,
+        response: bytes,
+    ) -> tuple[int, int]:
         ctx.ctx = "handshake v2 offerings count"
         num_offerings = await self._read_varint(ctx)
         offerings = []
@@ -125,7 +141,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
 
         return chosen_version
 
-    async def _read_varint(self, ctx):
+    async def _read_varint(self, ctx: HandshakeCtx) -> int:
         next_byte = (await self._handshake_read(ctx, 1))[0]
         res = next_byte & 0x7F
         i = 0
@@ -136,7 +152,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
         return res
 
     @staticmethod
-    def _encode_varint(n):
+    def _encode_varint(n: int) -> bytearray:
         res = bytearray()
         while n >= 0x80:
             res.append(n & 0x7F | 0x80)
@@ -144,7 +160,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
         res.append(n)
         return res
 
-    async def _handshake_read(self, ctx, n):
+    async def _handshake_read(self, ctx: HandshakeCtx, n: int) -> bytes:
         original_timeout = self.gettimeout()
         self.settimeout(ctx.deadline.to_timeout())
         try:
@@ -193,7 +209,11 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
         finally:
             self.settimeout(original_timeout)
 
-    async def _handshake(self, resolved_address, deadline):
+    async def _handshake(
+        self,
+        resolved_address: ResolvedAddress,
+        deadline: Deadline,
+    ) -> tuple[tuple[int, int], bytes, bytes]:
         """
         Perform BOLT handshake.
 
@@ -206,7 +226,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
 
         handshake = self.Bolt.get_handshake()
         if log.getEffectiveLevel() <= logging.DEBUG:
-            handshake_bytes = struct.unpack(">16B", handshake)
+            handshake_bytes: t.Sequence = struct.unpack(">16B", handshake)
             handshake_bytes = [
                 handshake[i : i + 4] for i in range(0, len(handshake_bytes), 4)
             ]
@@ -273,14 +293,14 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
     @classmethod
     async def connect(
         cls,
-        address,
+        address: Address,
         *,
-        tcp_timeout,
-        deadline,
-        custom_resolver,
-        ssl_context,
-        keep_alive,
-    ):
+        tcp_timeout: float | None,
+        deadline: Deadline,
+        custom_resolver: t.Callable | None,
+        ssl_context: SSLContext | None,
+        keep_alive: bool,
+    ) -> tuple[te.Self, tuple[int, int], bytes, bytes]:
         """
         Connect and perform a handshake.
 
@@ -313,10 +333,10 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
                 )
                 return s, agreed_version, handshake, response
             except (BoltError, DriverError, OSError) as error:
-                try:
-                    local_port = s.getsockname()[1]
-                except (OSError, AttributeError, TypeError):
-                    local_port = 0
+                local_port = 0
+                if isinstance(s, cls):
+                    with suppress(OSError, AttributeError, TypeError):
+                        local_port = s.getsockname()[1]
                 err_str = error.__class__.__name__
                 if str(error):
                     err_str += ": " + str(error)
@@ -331,10 +351,10 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
                 errors.append(error)
                 failed_addresses.append(resolved_address)
             except asyncio.CancelledError:
-                try:
-                    local_port = s.getsockname()[1]
-                except (OSError, AttributeError, TypeError):
-                    local_port = 0
+                local_port = 0
+                if isinstance(s, cls):
+                    with suppress(OSError, AttributeError, TypeError):
+                        local_port = s.getsockname()[1]
                 log.debug(
                     "[#%04X]  C: <CANCELED> %s", local_port, resolved_address
                 )

--- a/src/neo4j/_async/io/_bolt_socket.py
+++ b/src/neo4j/_async/io/_bolt_socket.py
@@ -85,7 +85,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
         ctx.ctx = "handshake v2 capabilities"
         _capabilities_offer = await self._read_varint(ctx)
 
-        if log.getEffectiveLevel() >= logging.DEBUG:
+        if log.getEffectiveLevel() <= logging.DEBUG:
             log.debug(
                 "[#%04X]  S: <HANDSHAKE> %s [%i] %s %s",
                 ctx.local_port,

--- a/src/neo4j/_async/io/_bolt_socket.py
+++ b/src/neo4j/_async/io/_bolt_socket.py
@@ -204,16 +204,16 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
         """
         local_port = self.getsockname()[1]
 
-        if log.getEffectiveLevel() >= logging.DEBUG:
-            handshake = self.Bolt.get_handshake()
-            handshake = struct.unpack(">16B", handshake)
-            handshake = [
-                handshake[i : i + 4] for i in range(0, len(handshake), 4)
+        handshake = self.Bolt.get_handshake()
+        if log.getEffectiveLevel() <= logging.DEBUG:
+            handshake_bytes = struct.unpack(">16B", handshake)
+            handshake_bytes = [
+                handshake[i : i + 4] for i in range(0, len(handshake_bytes), 4)
             ]
 
             supported_versions = [
                 f"0x{vx[0]:02X}{vx[1]:02X}{vx[2]:02X}{vx[3]:02X}"
-                for vx in handshake
+                for vx in handshake_bytes
             ]
 
             log.debug(
@@ -227,7 +227,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
                 *supported_versions,
             )
 
-        request = self.Bolt.MAGIC_PREAMBLE + self.Bolt.get_handshake()
+        request = self.Bolt.MAGIC_PREAMBLE + handshake
 
         ctx = HandshakeCtx(
             ctx="handshake opening",

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -79,7 +79,7 @@ def _sanitize_deadline(deadline):
 class AsyncBoltSocketBase(abc.ABC):
     Bolt: te.Final[type[AsyncBolt]] = None  # type: ignore[assignment]
 
-    def __init__(self, reader, protocol, writer):
+    def __init__(self, reader, protocol, writer) -> None:
         self._reader = reader  # type: asyncio.StreamReader
         self._protocol = protocol  # type: asyncio.StreamReaderProtocol
         self._writer = writer  # type: asyncio.StreamWriter
@@ -171,7 +171,7 @@ class AsyncBoltSocketBase(abc.ABC):
     @classmethod
     async def _connect_secure(
         cls, resolved_address, timeout, keep_alive, ssl_context
-    ):
+    ) -> te.Self:
         """
         Connect to the address and return the socket.
 
@@ -202,7 +202,7 @@ class AsyncBoltSocketBase(abc.ABC):
             keep_alive = 1 if keep_alive else 0
             s.setsockopt(SOL_SOCKET, SO_KEEPALIVE, keep_alive)
 
-            ssl_kwargs = {}
+            ssl_kwargs: dict[str, t.Any] = {}
 
             if ssl_context is not None:
                 hostname = resolved_address._host_name or None

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -292,7 +292,7 @@ class Bolt:
 
     # [bolt-version-bump] search tag when changing bolt version support
     @classmethod
-    def get_handshake(cls):
+    def get_handshake(cls) -> bytes:
         """
         Return the supported Bolt versions as bytes.
 

--- a/src/neo4j/_sync/io/_bolt_socket.py
+++ b/src/neo4j/_sync/io/_bolt_socket.py
@@ -85,7 +85,7 @@ class BoltSocket(BoltSocketBase):
         ctx.ctx = "handshake v2 capabilities"
         _capabilities_offer = self._read_varint(ctx)
 
-        if log.getEffectiveLevel() >= logging.DEBUG:
+        if log.getEffectiveLevel() <= logging.DEBUG:
             log.debug(
                 "[#%04X]  S: <HANDSHAKE> %s [%i] %s %s",
                 ctx.local_port,

--- a/src/neo4j/_sync/io/_bolt_socket.py
+++ b/src/neo4j/_sync/io/_bolt_socket.py
@@ -204,16 +204,16 @@ class BoltSocket(BoltSocketBase):
         """
         local_port = self.getsockname()[1]
 
-        if log.getEffectiveLevel() >= logging.DEBUG:
-            handshake = self.Bolt.get_handshake()
-            handshake = struct.unpack(">16B", handshake)
-            handshake = [
-                handshake[i : i + 4] for i in range(0, len(handshake), 4)
+        handshake = self.Bolt.get_handshake()
+        if log.getEffectiveLevel() <= logging.DEBUG:
+            handshake_bytes = struct.unpack(">16B", handshake)
+            handshake_bytes = [
+                handshake[i : i + 4] for i in range(0, len(handshake_bytes), 4)
             ]
 
             supported_versions = [
                 f"0x{vx[0]:02X}{vx[1]:02X}{vx[2]:02X}{vx[3]:02X}"
-                for vx in handshake
+                for vx in handshake_bytes
             ]
 
             log.debug(
@@ -227,7 +227,7 @@ class BoltSocket(BoltSocketBase):
                 *supported_versions,
             )
 
-        request = self.Bolt.MAGIC_PREAMBLE + self.Bolt.get_handshake()
+        request = self.Bolt.MAGIC_PREAMBLE + handshake
 
         ctx = HandshakeCtx(
             ctx="handshake opening",

--- a/src/neo4j/_sync/io/_bolt_socket.py
+++ b/src/neo4j/_sync/io/_bolt_socket.py
@@ -39,7 +39,15 @@ from ...exceptions import (
 
 
 if t.TYPE_CHECKING:
+    from ssl import SSLContext
+
+    import typing_extensions as te
+
     from ..._deadline import Deadline
+    from ...addressing import (
+        Address,
+        ResolvedAddress,
+    )
 
 
 log = logging.getLogger("neo4j.io")
@@ -63,7 +71,11 @@ class BytesPrinter:
 
 
 class BoltSocket(BoltSocketBase):
-    def _parse_handshake_response_v1(self, ctx, response):
+    def _parse_handshake_response_v1(
+        self,
+        ctx: HandshakeCtx,
+        response: bytes,
+    ) -> tuple[int, int]:
         agreed_version = response[-1], response[-2]
         log.debug(
             "[#%04X]  S: <HANDSHAKE> 0x%06X%02X",
@@ -73,7 +85,11 @@ class BoltSocket(BoltSocketBase):
         )
         return agreed_version
 
-    def _parse_handshake_response_v2(self, ctx, response):
+    def _parse_handshake_response_v2(
+        self,
+        ctx: HandshakeCtx,
+        response: bytes,
+    ) -> tuple[int, int]:
         ctx.ctx = "handshake v2 offerings count"
         num_offerings = self._read_varint(ctx)
         offerings = []
@@ -125,7 +141,7 @@ class BoltSocket(BoltSocketBase):
 
         return chosen_version
 
-    def _read_varint(self, ctx):
+    def _read_varint(self, ctx: HandshakeCtx) -> int:
         next_byte = (self._handshake_read(ctx, 1))[0]
         res = next_byte & 0x7F
         i = 0
@@ -136,7 +152,7 @@ class BoltSocket(BoltSocketBase):
         return res
 
     @staticmethod
-    def _encode_varint(n):
+    def _encode_varint(n: int) -> bytearray:
         res = bytearray()
         while n >= 0x80:
             res.append(n & 0x7F | 0x80)
@@ -144,7 +160,7 @@ class BoltSocket(BoltSocketBase):
         res.append(n)
         return res
 
-    def _handshake_read(self, ctx, n):
+    def _handshake_read(self, ctx: HandshakeCtx, n: int) -> bytes:
         original_timeout = self.gettimeout()
         self.settimeout(ctx.deadline.to_timeout())
         try:
@@ -193,7 +209,11 @@ class BoltSocket(BoltSocketBase):
         finally:
             self.settimeout(original_timeout)
 
-    def _handshake(self, resolved_address, deadline):
+    def _handshake(
+        self,
+        resolved_address: ResolvedAddress,
+        deadline: Deadline,
+    ) -> tuple[tuple[int, int], bytes, bytes]:
         """
         Perform BOLT handshake.
 
@@ -206,7 +226,7 @@ class BoltSocket(BoltSocketBase):
 
         handshake = self.Bolt.get_handshake()
         if log.getEffectiveLevel() <= logging.DEBUG:
-            handshake_bytes = struct.unpack(">16B", handshake)
+            handshake_bytes: t.Sequence = struct.unpack(">16B", handshake)
             handshake_bytes = [
                 handshake[i : i + 4] for i in range(0, len(handshake_bytes), 4)
             ]
@@ -273,14 +293,14 @@ class BoltSocket(BoltSocketBase):
     @classmethod
     def connect(
         cls,
-        address,
+        address: Address,
         *,
-        tcp_timeout,
-        deadline,
-        custom_resolver,
-        ssl_context,
-        keep_alive,
-    ):
+        tcp_timeout: float | None,
+        deadline: Deadline,
+        custom_resolver: t.Callable | None,
+        ssl_context: SSLContext | None,
+        keep_alive: bool,
+    ) -> tuple[te.Self, tuple[int, int], bytes, bytes]:
         """
         Connect and perform a handshake.
 
@@ -313,10 +333,10 @@ class BoltSocket(BoltSocketBase):
                 )
                 return s, agreed_version, handshake, response
             except (BoltError, DriverError, OSError) as error:
-                try:
-                    local_port = s.getsockname()[1]
-                except (OSError, AttributeError, TypeError):
-                    local_port = 0
+                local_port = 0
+                if isinstance(s, cls):
+                    with suppress(OSError, AttributeError, TypeError):
+                        local_port = s.getsockname()[1]
                 err_str = error.__class__.__name__
                 if str(error):
                     err_str += ": " + str(error)
@@ -331,10 +351,10 @@ class BoltSocket(BoltSocketBase):
                 errors.append(error)
                 failed_addresses.append(resolved_address)
             except asyncio.CancelledError:
-                try:
-                    local_port = s.getsockname()[1]
-                except (OSError, AttributeError, TypeError):
-                    local_port = 0
+                local_port = 0
+                if isinstance(s, cls):
+                    with suppress(OSError, AttributeError, TypeError):
+                        local_port = s.getsockname()[1]
                 log.debug(
                     "[#%04X]  C: <CANCELED> %s", local_port, resolved_address
                 )

--- a/tests/unit/async_/io/test__bolt_socket.py
+++ b/tests/unit/async_/io/test__bolt_socket.py
@@ -1,0 +1,97 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import logging
+import typing
+from collections import deque
+
+import pytest
+
+from neo4j._async.io._bolt import AsyncBolt
+from neo4j._deadline import Deadline
+from neo4j.addressing import Address
+
+from ...._async_compat import mark_async_test
+
+
+if typing.TYPE_CHECKING:
+    _T = typing.TypeVar("_T")
+
+
+def _deque_popleft_n(d: deque[_T], n: int) -> list[_T]:
+    return [d.popleft() for _ in range(n)]
+
+
+PREAMBLE = AsyncBolt.MAGIC_PREAMBLE
+BOLT_HANDSHAKE = AsyncBolt.get_handshake()
+DEADLINE = Deadline(float("inf"))
+
+
+# [bolt-version-bump] search tag when changing bolt version support
+@mark_async_test
+@pytest.mark.parametrize("log_level", (1, logging.DEBUG, logging.CRITICAL))
+async def test_handshake(async_bolt_socket_factory, caplog, log_level):
+    chosen_version = (5, 8)
+
+    caplog.set_level(log_level)
+    response = deque((0, 0, *reversed(chosen_version)))
+    out = deque()
+    socket = async_bolt_socket_factory(response, out)
+
+    await socket._handshake(Address(("localhost", 7687)), DEADLINE)
+
+    assert _deque_popleft_n(out, len(PREAMBLE)) == list(PREAMBLE)
+    assert _deque_popleft_n(out, len(BOLT_HANDSHAKE)) == list(BOLT_HANDSHAKE)
+    assert len(response) == 0, "not all bytes were read"
+
+
+# [bolt-version-bump] search tag when changing bolt version support
+@mark_async_test
+@pytest.mark.parametrize("log_level", (1, logging.DEBUG, logging.CRITICAL))
+async def test_handshake_manifest_v1(
+    async_bolt_socket_factory,
+    caplog,
+    log_level,
+):
+    chosen_version = (5, 8)
+    expected_feature_bits = b"\x00"  # varint(0)
+
+    caplog.set_level(log_level)
+    chosen_version_bytes = (0, 0, *reversed(chosen_version))
+    response = deque(
+        (
+            *b"\x00\x00\x01\xff",  # manifest v1
+            *b"\x01",  # varint(1) number of versions offered
+            *chosen_version_bytes,
+            *expected_feature_bits,
+        )
+    )
+    out = deque()
+    socket = async_bolt_socket_factory(response, out)
+
+    await socket._handshake(Address(("localhost", 7687)), DEADLINE)
+
+    assert _deque_popleft_n(out, len(PREAMBLE)) == list(PREAMBLE)
+    assert _deque_popleft_n(out, len(BOLT_HANDSHAKE)) == list(BOLT_HANDSHAKE)
+    assert _deque_popleft_n(out, len(chosen_version_bytes)) == list(
+        chosen_version_bytes
+    )
+    assert _deque_popleft_n(out, len(expected_feature_bits)) == list(
+        expected_feature_bits
+    )
+    assert len(response) == 0, "not all bytes were read"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -22,6 +22,8 @@ from .async_.fixtures import (
     async_scripted_connection_generator,
 )
 from .fixtures import (
+    async_bolt_socket_factory,
+    bolt_socket_factory,
     notification_factory,
     raw_notification_factory,
 )
@@ -35,11 +37,13 @@ from .sync.fixtures import (
 
 
 __all__ = [
+    "async_bolt_socket_factory",
     "async_fake_connection",
     "async_fake_connection_generator",
     "async_fake_pool",
     "async_scripted_connection",
     "async_scripted_connection_generator",
+    "bolt_socket_factory",
     "fake_connection",
     "fake_connection_generator",
     "fake_pool",

--- a/tests/unit/fixtures/__init__.py
+++ b/tests/unit/fixtures/__init__.py
@@ -18,9 +18,15 @@ from .notifications import (
     notification_factory,
     raw_notification_factory,
 )
+from .socket import (
+    async_bolt_socket_factory,
+    bolt_socket_factory,
+)
 
 
 __all__ = [
+    "async_bolt_socket_factory",
+    "bolt_socket_factory",
     "notification_factory",
     "raw_notification_factory",
 ]

--- a/tests/unit/fixtures/socket.py
+++ b/tests/unit/fixtures/socket.py
@@ -29,12 +29,12 @@ from neo4j._sync.io._bolt_socket import BoltSocket
 
 
 if t.TYPE_CHECKING:
-    _T = t.TypeVar("_T")
+    _T_co = t.TypeVar("_T_co", covariant=True)
 
-    class _SocketFactory[_T](t.Protocol):
+    class _SocketFactory(t.Protocol, t.Generic[_T_co]):
         def __call__(
             self, bytes_to_read: deque, bytes_written: deque | None = None
-        ) -> _T: ...
+        ) -> _T_co: ...
 
 
 log = logging.getLogger(__name__)

--- a/tests/unit/fixtures/socket.py
+++ b/tests/unit/fixtures/socket.py
@@ -1,0 +1,119 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from socket import socket
+
+import pytest
+
+from neo4j._async.io._bolt_socket import AsyncBoltSocket
+from neo4j._sync.io._bolt_socket import BoltSocket
+
+
+log = logging.getLogger(__name__)
+
+
+def _pop_read_n(d: deque, n: int, fn_name: str) -> bytes:
+    res: str | bytes = f"Not enough data: {d}"
+    try:
+        res = bytes(d.popleft() for _ in range(n))
+        return res  # noqa: RET504 - false positive, res is used in finally
+    finally:
+        log.debug("%s(%s): %s", fn_name, n, res)
+
+
+@pytest.fixture
+def async_bolt_socket_factory(mocker):
+    def factory(bytes_to_read, bytes_written=None):
+        assert isinstance(bytes_to_read, deque)
+        bytes(bytes_to_read)  # test that bytes_to_read contains only bytes
+        write_buffer = []
+
+        async def read(n):
+            nonlocal bytes_to_read
+            return _pop_read_n(bytes_to_read, n, "read")
+
+        def write(b):
+            nonlocal write_buffer
+            log.debug("write(%s)", b)
+            write_buffer.extend(b)
+
+        async def drain():
+            log.debug("drain()")
+            if bytes_written is not None:
+                bytes_written.extend(write_buffer)
+            write_buffer.clear()
+
+        def transport_get_extra(key):
+            if key == "sockname":
+                return "localhost", 0x1234
+            if key == "peername":
+                return "peer_name"
+            raise KeyError(f"not mocked: {key}")
+
+        reader = mocker.Mock(spec=asyncio.StreamReader)
+        writer = mocker.Mock(spec=asyncio.StreamWriter)
+        protocol = mocker.Mock(spec=asyncio.StreamReaderProtocol)
+
+        reader.read.side_effect = read
+        writer.write.side_effect = write
+        writer.drain.side_effect = drain
+        writer.transport.get_extra_info.side_effect = transport_get_extra
+
+        return AsyncBoltSocket(reader, protocol, writer)
+
+    return factory
+
+
+@pytest.fixture
+def bolt_socket_factory(mocker):
+    def factory(bytes_to_read, bytes_written=None):
+        assert isinstance(bytes_to_read, deque)
+        bytes(bytes_to_read)  # test that bytes_to_read contains only bytes
+
+        def recv(n):
+            nonlocal bytes_to_read
+            return _pop_read_n(bytes_to_read, n, "recv")
+
+        def recv_into(buff, n=None):
+            if n is None:
+                raise NotImplementedError("n=None not mocked")
+            nonlocal bytes_to_read
+            res = _pop_read_n(bytes_to_read, n, "recv_into")
+            buff[:n] = res
+            return n
+
+        def send_all(b):
+            nonlocal bytes_written
+            log.debug("send_all(%s)", b)
+            if bytes_written is not None:
+                bytes_written.extend(b)
+
+        socket_mock = mocker.Mock(spec=socket)
+        socket_mock.recv.side_effect = recv
+        socket_mock.recv_into.side_effect = recv_into
+        socket_mock.sendall.side_effect = send_all
+        socket_mock.getsockname.return_value = ("localhost", 0x1234)
+        socket_mock.getpeername.return_value = "peer_name"
+        socket_mock.gettimeout.return_value = None
+
+        return BoltSocket(socket_mock)
+
+    return factory

--- a/tests/unit/fixtures/socket.py
+++ b/tests/unit/fixtures/socket.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import typing as t
 from collections import deque
 from socket import socket
 
@@ -25,6 +26,15 @@ import pytest
 
 from neo4j._async.io._bolt_socket import AsyncBoltSocket
 from neo4j._sync.io._bolt_socket import BoltSocket
+
+
+if t.TYPE_CHECKING:
+    _T = t.TypeVar("_T")
+
+    class _SocketFactory[_T](t.Protocol):
+        def __call__(
+            self, bytes_to_read: deque, bytes_written: deque | None = None
+        ) -> _T: ...
 
 
 log = logging.getLogger(__name__)
@@ -40,8 +50,8 @@ def _pop_read_n(d: deque, n: int, fn_name: str) -> bytes:
 
 
 @pytest.fixture
-def async_bolt_socket_factory(mocker):
-    def factory(bytes_to_read, bytes_written=None):
+def async_bolt_socket_factory(mocker) -> _SocketFactory[AsyncBoltSocket]:
+    def factory(bytes_to_read, bytes_written=None) -> AsyncBoltSocket:
         assert isinstance(bytes_to_read, deque)
         bytes(bytes_to_read)  # test that bytes_to_read contains only bytes
         write_buffer = []
@@ -83,8 +93,8 @@ def async_bolt_socket_factory(mocker):
 
 
 @pytest.fixture
-def bolt_socket_factory(mocker):
-    def factory(bytes_to_read, bytes_written=None):
+def bolt_socket_factory(mocker) -> _SocketFactory[BoltSocket]:
+    def factory(bytes_to_read, bytes_written=None) -> BoltSocket:
         assert isinstance(bytes_to_read, deque)
         bytes(bytes_to_read)  # test that bytes_to_read contains only bytes
 

--- a/tests/unit/sync/io/test__bolt_socket.py
+++ b/tests/unit/sync/io/test__bolt_socket.py
@@ -1,0 +1,97 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import logging
+import typing
+from collections import deque
+
+import pytest
+
+from neo4j._deadline import Deadline
+from neo4j._sync.io._bolt import Bolt
+from neo4j.addressing import Address
+
+from ...._async_compat import mark_sync_test
+
+
+if typing.TYPE_CHECKING:
+    _T = typing.TypeVar("_T")
+
+
+def _deque_popleft_n(d: deque[_T], n: int) -> list[_T]:
+    return [d.popleft() for _ in range(n)]
+
+
+PREAMBLE = Bolt.MAGIC_PREAMBLE
+BOLT_HANDSHAKE = Bolt.get_handshake()
+DEADLINE = Deadline(float("inf"))
+
+
+# [bolt-version-bump] search tag when changing bolt version support
+@mark_sync_test
+@pytest.mark.parametrize("log_level", (1, logging.DEBUG, logging.CRITICAL))
+def test_handshake(bolt_socket_factory, caplog, log_level):
+    chosen_version = (5, 8)
+
+    caplog.set_level(log_level)
+    response = deque((0, 0, *reversed(chosen_version)))
+    out = deque()
+    socket = bolt_socket_factory(response, out)
+
+    socket._handshake(Address(("localhost", 7687)), DEADLINE)
+
+    assert _deque_popleft_n(out, len(PREAMBLE)) == list(PREAMBLE)
+    assert _deque_popleft_n(out, len(BOLT_HANDSHAKE)) == list(BOLT_HANDSHAKE)
+    assert len(response) == 0, "not all bytes were read"
+
+
+# [bolt-version-bump] search tag when changing bolt version support
+@mark_sync_test
+@pytest.mark.parametrize("log_level", (1, logging.DEBUG, logging.CRITICAL))
+def test_handshake_manifest_v1(
+    bolt_socket_factory,
+    caplog,
+    log_level,
+):
+    chosen_version = (5, 8)
+    expected_feature_bits = b"\x00"  # varint(0)
+
+    caplog.set_level(log_level)
+    chosen_version_bytes = (0, 0, *reversed(chosen_version))
+    response = deque(
+        (
+            *b"\x00\x00\x01\xff",  # manifest v1
+            *b"\x01",  # varint(1) number of versions offered
+            *chosen_version_bytes,
+            *expected_feature_bits,
+        )
+    )
+    out = deque()
+    socket = bolt_socket_factory(response, out)
+
+    socket._handshake(Address(("localhost", 7687)), DEADLINE)
+
+    assert _deque_popleft_n(out, len(PREAMBLE)) == list(PREAMBLE)
+    assert _deque_popleft_n(out, len(BOLT_HANDSHAKE)) == list(BOLT_HANDSHAKE)
+    assert _deque_popleft_n(out, len(chosen_version_bytes)) == list(
+        chosen_version_bytes
+    )
+    assert _deque_popleft_n(out, len(expected_feature_bits)) == list(
+        expected_feature_bits
+    )
+    assert len(response) == 0, "not all bytes were read"


### PR DESCRIPTION
Fixes an `UnboundLocalError` that gets raised during the protocol handshake if the effective log level of the logger `"neo4j.io"` is `< 10` (strictly less than `logging.DEBUG`).

```
...
  File "<path-to-python>/site-packages/neo4j/_sync/io/_pool.py", line 408, in _acquire
    return connection_creator()
  File "<path-to-python>/site-packages/neo4j/_sync/io/_pool.py", line 230, in connection_creator
    connection = self.opener(
  File "<path-to-python>/site-packages/neo4j/_sync/io/_pool.py", line 624, in opener
    return 
Bolt.open(
  File "<path-to-python>/site-packages/neo4j/_sync/io/_bolt.py", line 369, in open
    s, protocol_version, handshake, data = BoltSocket.connect(
  File "<path-to-python>/site-packages/neo4j/_sync/io/_bolt_socket.py", line 311, in connect
    agreed_version, handshake, response = s._handshake(
  File "<path-to-python>/site-packages/neo4j/_sync/io/_bolt_socket.py", line 271, in _handshake
    return agreed_version, handshake, response
UnboundLocalError: local variable 'handshake' referenced before assignment
```