### PR TITLE
Fix: re-auth interfering with connectivity checks

### DIFF
--- a/src/neo4j/_async/work/session.py
+++ b/src/neo4j/_async/work/session.py
@@ -180,14 +180,16 @@ class AsyncSession(AsyncWorkspace):
 
     async def _get_server_info(self):
         assert not self._connection
-        await self._connect(READ_ACCESS, liveness_check_timeout=0)
+        await self._connect(
+            READ_ACCESS, liveness_check_timeout=0, unprepared=True
+        )
         server_info = self._connection.server_info
         await self._disconnect()
         return server_info
 
     async def _verify_authentication(self):
         assert not self._connection
-        await self._connect(READ_ACCESS, force_auth=True)
+        await self._connect(READ_ACCESS, force_auth=True, unprepared=True)
         await self._disconnect()
 
     @AsyncNonConcurrentMethodChecker._non_concurrent_method

--- a/src/neo4j/_sync/work/session.py
+++ b/src/neo4j/_sync/work/session.py
@@ -180,14 +180,16 @@ class Session(Workspace):
 
     def _get_server_info(self):
         assert not self._connection
-        self._connect(READ_ACCESS, liveness_check_timeout=0)
+        self._connect(
+            READ_ACCESS, liveness_check_timeout=0, unprepared=True
+        )
         server_info = self._connection.server_info
         self._disconnect()
         return server_info
 
     def _verify_authentication(self):
         assert not self._connection
-        self._connect(READ_ACCESS, force_auth=True)
+        self._connect(READ_ACCESS, force_auth=True, unprepared=True)
         self._disconnect()
 
     @NonConcurrentMethodChecker._non_concurrent_method

--- a/tests/unit/async_/io/test_direct.py
+++ b/tests/unit/async_/io/test_direct.py
@@ -278,3 +278,28 @@ async def test_liveness_check(
         cx1.reset.reset_mock()
         await pool.release(cx1)
         cx1.reset.assert_not_called()
+
+
+@pytest.mark.parametrize("unprepared", (True, False, None))
+@mark_async_test
+async def test_reauth(async_fake_connection_generator, unprepared):
+    async with AsyncFakeBoltPool(
+        async_fake_connection_generator,
+        ("127.0.0.1", 7687),
+    ) as pool:
+        address = neo4j.Address(("127.0.0.1", 7687))
+        # pre-populate pool
+        cx = await pool._acquire(address, None, Deadline(3), None)
+        await pool.release(cx)
+        cx.reset_mock()
+
+        kwargs = {}
+        if unprepared is not None:
+            kwargs["unprepared"] = unprepared
+        cx = await pool._acquire(address, None, Deadline(3), None, **kwargs)
+        if unprepared:
+            cx.re_auth.assert_not_called()
+        else:
+            cx.re_auth.assert_called_once()
+
+        await pool.release(cx)

--- a/tests/unit/async_/io/test_direct.py
+++ b/tests/unit/async_/io/test_direct.py
@@ -70,10 +70,11 @@ class AsyncFakeBoltPool(AsyncIOPool):
         bookmarks,
         auth,
         liveness_check_timeout,
+        unprepared=False,
         database_callback=None,
     ):
         return await self._acquire(
-            self.address, auth, timeout, liveness_check_timeout
+            self.address, auth, timeout, liveness_check_timeout, unprepared
         )
 
 

--- a/tests/unit/async_/work/test_session.py
+++ b/tests/unit/async_/work/test_session.py
@@ -877,3 +877,65 @@ async def test_pinns_session_db_with_cache(
                 cache_spy.set.assert_called_once_with(key, resolved_db)
                 assert session._pinned_database
                 assert config.database == resolved_db
+
+
+@pytest.mark.parametrize(
+    "method", ("_get_server_info", "_verify_authentication")
+)
+@mark_async_test
+async def test_check_connections_are_unprepared_connection(
+    async_fake_pool,
+    method,
+):
+    config = SessionConfig()
+    async with AsyncSession(async_fake_pool, config) as session:
+        await getattr(session, method)()
+        assert len(async_fake_pool.acquired_connection_mocks) == 1
+        async_fake_pool.acquire.assert_awaited_once()
+        unprepared = async_fake_pool.acquire.call_args.kwargs.get("unprepared")
+        assert unprepared is True
+
+
+async def _explicit_transaction(session: AsyncSession):
+    async with await session.begin_transaction():
+        pass
+
+
+async def _autocommit_transaction(session: AsyncSession):
+    await session.run("RETURN 1")
+
+
+async def _tx_func_read(session: AsyncSession):
+    async def work(tx: AsyncManagedTransaction):
+        pass
+
+    await session.execute_read(work)
+
+
+async def _tx_func_write(session: AsyncSession):
+    async def work(tx: AsyncManagedTransaction):
+        pass
+
+    await session.execute_write(work)
+
+
+@pytest.mark.parametrize(
+    "method",
+    (
+        _explicit_transaction,
+        _autocommit_transaction,
+        _tx_func_read,
+        _tx_func_write,
+    ),
+)
+@mark_async_test
+async def test_work_connections_are_prepared_connection(
+    async_fake_pool, method
+):
+    config = SessionConfig()
+    async with AsyncSession(async_fake_pool, config) as session:
+        await method(session)
+        assert len(async_fake_pool.acquired_connection_mocks) == 1
+        async_fake_pool.acquire.assert_awaited_once()
+        unprepared = async_fake_pool.acquire.call_args.kwargs.get("unprepared")
+        assert unprepared is False or unprepared is None

--- a/tests/unit/sync/io/test_direct.py
+++ b/tests/unit/sync/io/test_direct.py
@@ -278,3 +278,28 @@ def test_liveness_check(
         cx1.reset.reset_mock()
         pool.release(cx1)
         cx1.reset.assert_not_called()
+
+
+@pytest.mark.parametrize("unprepared", (True, False, None))
+@mark_sync_test
+def test_reauth(fake_connection_generator, unprepared):
+    with FakeBoltPool(
+        fake_connection_generator,
+        ("127.0.0.1", 7687),
+    ) as pool:
+        address = neo4j.Address(("127.0.0.1", 7687))
+        # pre-populate pool
+        cx = pool._acquire(address, None, Deadline(3), None)
+        pool.release(cx)
+        cx.reset_mock()
+
+        kwargs = {}
+        if unprepared is not None:
+            kwargs["unprepared"] = unprepared
+        cx = pool._acquire(address, None, Deadline(3), None, **kwargs)
+        if unprepared:
+            cx.re_auth.assert_not_called()
+        else:
+            cx.re_auth.assert_called_once()
+
+        pool.release(cx)

--- a/tests/unit/sync/io/test_direct.py
+++ b/tests/unit/sync/io/test_direct.py
@@ -70,10 +70,11 @@ class FakeBoltPool(IOPool):
         bookmarks,
         auth,
         liveness_check_timeout,
+        unprepared=False,
         database_callback=None,
     ):
         return self._acquire(
-            self.address, auth, timeout, liveness_check_timeout
+            self.address, auth, timeout, liveness_check_timeout, unprepared
         )
 
 

--- a/tests/unit/sync/work/test_session.py
+++ b/tests/unit/sync/work/test_session.py
@@ -877,3 +877,65 @@ def test_pinns_session_db_with_cache(
                 cache_spy.set.assert_called_once_with(key, resolved_db)
                 assert session._pinned_database
                 assert config.database == resolved_db
+
+
+@pytest.mark.parametrize(
+    "method", ("_get_server_info", "_verify_authentication")
+)
+@mark_sync_test
+def test_check_connections_are_unprepared_connection(
+    fake_pool,
+    method,
+):
+    config = SessionConfig()
+    with Session(fake_pool, config) as session:
+        getattr(session, method)()
+        assert len(fake_pool.acquired_connection_mocks) == 1
+        fake_pool.acquire.assert_called_once()
+        unprepared = fake_pool.acquire.call_args.kwargs.get("unprepared")
+        assert unprepared is True
+
+
+def _explicit_transaction(session: Session):
+    with session.begin_transaction():
+        pass
+
+
+def _autocommit_transaction(session: Session):
+    session.run("RETURN 1")
+
+
+def _tx_func_read(session: Session):
+    def work(tx: ManagedTransaction):
+        pass
+
+    session.execute_read(work)
+
+
+def _tx_func_write(session: Session):
+    def work(tx: ManagedTransaction):
+        pass
+
+    session.execute_write(work)
+
+
+@pytest.mark.parametrize(
+    "method",
+    (
+        _explicit_transaction,
+        _autocommit_transaction,
+        _tx_func_read,
+        _tx_func_write,
+    ),
+)
+@mark_sync_test
+def test_work_connections_are_prepared_connection(
+    fake_pool, method
+):
+    config = SessionConfig()
+    with Session(fake_pool, config) as session:
+        method(session)
+        assert len(fake_pool.acquired_connection_mocks) == 1
+        fake_pool.acquire.assert_called_once()
+        unprepared = fake_pool.acquire.call_args.kwargs.get("unprepared")
+        assert unprepared is False or unprepared is None


### PR DESCRIPTION
Connections might have pipelined messages when being picked up from the pool (e.g., re-auth). When unflushed, those connections will be `RESET` when returned to the pool. This results in pipelineing `LOGON`, `LOGOFF`, and `RESET` where the `RESET` will skip the queue on the server side. Depending on the timing, this will leave the connection in an undesirable state (e.g., unauthenticated).

This PR circumvents this situation by acquiring an unprepared connection from the pool when performing connectivity checks. Such connections will not have any work pipelined.