### PR TITLE
[4.4] TestKit: mute setuptools warning

### DIFF
--- a/testkit/_common.py
+++ b/testkit/_common.py
@@ -16,6 +16,9 @@ def run(args, env=None):
 def run_python(args, env=None, warning_as_error=True):
     cmd = [TEST_BACKEND_VERSION, "-u"]
     if warning_as_error:
-        cmd += ["-W", "error"]
+        cmd += [
+            "-W", "error",
+            "-W", "default:License classifiers are deprecated::setuptools.dist",
+        ]
     cmd += list(args)
     run(cmd, env=env)


### PR DESCRIPTION
We're not going to update the metadata of an LTS driver version. Instead we'll just mute the warning. Using a sufficiently old version of setuptools is what the user has to do in order to either get rid of the warning, or to keep the install working in the future when the deprecation has been turned into a removal.

Since we're not using a pyproject.toml on this LTS branch, we are unfortunately not in control of the version of setuptools used to install the driver.