### PR TITLE
`TransactionError` on `session.run()` on busy session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
   - `connection_acquisition_timeout` configuration option
     - `ValueError` on invalid values (instead of `ClientError`)
     - Consistently restrict the value to be strictly positive
+  - `TransactionError` (subclass of `DriverError`) instead of `ClientError` (subclass of `Neo4jError`) when calling
+    `session.run()` while an explicit transaction is active on that session.
+    - This improves the differentiation between `DriverError` for client-side errors and `Neo4jError` for server-side
+      errors.
+    - It is now the same error raised as when trying to start an explicit transaction while another explicit transaction
+      is already active.
 
 
 ## Version 5.28

--- a/src/neo4j/_async/work/session.py
+++ b/src/neo4j/_async/work/session.py
@@ -41,7 +41,6 @@ from ...api import (
     WRITE_ACCESS,
 )
 from ...exceptions import (
-    ClientError,
     DriverError,
     Neo4jError,
     ServiceUnavailable,
@@ -293,6 +292,7 @@ class AsyncSession(AsyncWorkspace):
 
         :returns: a new :class:`neo4j.AsyncResult` object
 
+        :raises TransactionError: if a transaction is already open.
         :raises SessionError: if the session has been closed.
         """
         self._check_state()
@@ -302,9 +302,8 @@ class AsyncSession(AsyncWorkspace):
             raise TypeError("query must be a string or a Query instance")
 
         if self._transaction:
-            # TODO: 6.0 - change this to be a TransactionError
-            raise ClientError(
-                "Explicit Transaction must be handled explicitly"
+            raise TransactionError(
+                self._transaction, "Explicit transaction already open"
             )
 
         if self._auto_result:

--- a/src/neo4j/_sync/work/session.py
+++ b/src/neo4j/_sync/work/session.py
@@ -41,7 +41,6 @@ from ...api import (
     WRITE_ACCESS,
 )
 from ...exceptions import (
-    ClientError,
     DriverError,
     Neo4jError,
     ServiceUnavailable,
@@ -293,6 +292,7 @@ class Session(Workspace):
 
         :returns: a new :class:`neo4j.Result` object
 
+        :raises TransactionError: if a transaction is already open.
         :raises SessionError: if the session has been closed.
         """
         self._check_state()
@@ -302,9 +302,8 @@ class Session(Workspace):
             raise TypeError("query must be a string or a Query instance")
 
         if self._transaction:
-            # TODO: 6.0 - change this to be a TransactionError
-            raise ClientError(
-                "Explicit Transaction must be handled explicitly"
+            raise TransactionError(
+                self._transaction, "Explicit transaction already open"
             )
 
         if self._auto_result:


### PR DESCRIPTION
Raise `TransactionError` (subclass of `DriverError`) instead of `ClientError` (subclass of `Neo4jError`) when calling `session.run()` while an explicit transaction is active on that session.

 - This improves the differentiation between `DriverError` for client-side errors and `Neo4jError` for server-side errors.
 - It is now the same error raised as when trying to start an explicit transaction while another explicit transaction is already active.