### PR TITLE
`TypeError` when passing `Query` to `Transaction.run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
   - `connection_acquisition_timeout` configuration option
     - `ValueError` on invalid values (instead of `ClientError`)
     - Consistently restrict the value to be strictly positive
+ - `TypeError` instead of `ValueError` when passing a `Query` object to `Transaction.run`.
 
 
 ## Version 5.28

--- a/src/neo4j/_async/work/transaction.py
+++ b/src/neo4j/_async/work/transaction.py
@@ -173,8 +173,7 @@ class AsyncTransactionBase(AsyncNonConcurrentMethodChecker):
         :returns: a new :class:`neo4j.AsyncResult` object
         """
         if isinstance(query, Query):
-            # TODO: 6.0 - make this a TypeError and remove lint exception
-            raise ValueError("Query object is only supported for session.run")  # noqa: TRY004
+            raise TypeError("Query object is only supported for session.run")
 
         if self._closed_flag:
             raise TransactionError(self, "Transaction closed")

--- a/src/neo4j/_sync/work/transaction.py
+++ b/src/neo4j/_sync/work/transaction.py
@@ -173,8 +173,7 @@ class TransactionBase(NonConcurrentMethodChecker):
         :returns: a new :class:`neo4j.Result` object
         """
         if isinstance(query, Query):
-            # TODO: 6.0 - make this a TypeError and remove lint exception
-            raise ValueError("Query object is only supported for session.run")  # noqa: TRY004
+            raise TypeError("Query object is only supported for session.run")
 
         if self._closed_flag:
             raise TransactionError(self, "Transaction closed")

--- a/tests/unit/async_/work/test_transaction.py
+++ b/tests/unit/async_/work/test_transaction.py
@@ -141,7 +141,7 @@ async def test_transaction_run_takes_no_query_object(async_fake_connection):
     tx = AsyncTransaction(
         async_fake_connection, 2, None, on_closed, on_error, on_cancel, None
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         await tx.run(Query("RETURN 1"))
 
 

--- a/tests/unit/sync/work/test_transaction.py
+++ b/tests/unit/sync/work/test_transaction.py
@@ -141,7 +141,7 @@ def test_transaction_run_takes_no_query_object(fake_connection):
     tx = Transaction(
         fake_connection, 2, None, on_closed, on_error, on_cancel, None
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         tx.run(Query("RETURN 1"))
 
 


### PR DESCRIPTION
Raise `TypeError` instead of `ValueError` when passing a `Query` object to `Transaction.run`.