### PR TITLE
Keep `neo4j.time.ZeroDate`

### DIFF
--- a/src/neo4j/time/__init__.py
+++ b/src/neo4j/time/__init__.py
@@ -839,13 +839,6 @@ class Date(date_base_class, metaclass=DateType):
     # CONSTRUCTOR #
 
     def __new__(cls, year: int, month: int, day: int) -> Date:
-        # TODO: 6.0 - remove the __new__ magic and ZeroDate being a singleton.
-        #             It's fine to remain as constant. Instead, simply use
-        #             __init__ and simplify pickle/copy (remove __reduce__).
-        #             N.B. this is a breaking change and must be treated as
-        #             such. Also consider introducing __slots__. Potentially
-        #             apply similar treatment to other temporal types as well
-        #             as spatial types.
         if year == month == day == 0:
             return ZeroDate
         year, month, day = _normalize_day(year, month, day)


### PR DESCRIPTION
It has some quirks:

```python
zero = neo4j.time.Date(0, 0, 0)
assert zero == neo4j.time.ZeroDate
assert zero.year == 0
assert zero.month == 0
assert zero.day == 0

# str representation is not a valid date ️
assert str(zero) == "0000-00-00"
# it's smaller than the minimum date
assert neo4j.time.ZeroDate < neo4j.time.Date.min

# on the server-side, it corresponds to the date "0000-12-31",
# not "0000-00-00"
assert get_first(driver, 'RETURN date("0000-12-31")') == zero
assert get_first(driver, "RETURN toString($x)", x=zero) == "0000-12-31"
```

However, `ZeroDate` is the only way to represent a date with ordinal 0. So removing it, means potentially breaking user code:
 * The constant gets removed.
 * The driver can only represent a (ever so slightly) smaller set of dates (this includes sending and receiving those dates).
 * The value (with its quirks) has been in the driver for almost 6 years now. Chances are, some user-code is relying on it.