### PR TITLE
Remove deprecated `ServerInfo.connection_id`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
   If you were calling it directly, please use `Record.__getitem__(slice(...))` or simply `record[...]` instead.
 - Remove deprecated class `neo4j.Bookmark` in favor of `neo4j.Bookmarks`.
 - Remove deprecated class `session.last_bookmark()` in favor of `last_bookmarks()`.
+- Remove deprecated `ServerInfo.connection_id`.
+  There is no replacement as this is considered internal information.
 - Remove deprecated driver configuration option `trust`.  
   Use `trusted_certificates` instead.
   - Remove the associated constants `neo4j.TRUST_ALL_CERTIFICATES` and `neo4j.TRUST_SYSTEM_CA_SIGNED_CERTIFICATES`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
   If you were calling it directly, please use `Record.__getitem__(slice(...))` or simply `record[...]` instead.
 - Remove deprecated class `neo4j.Bookmark` in favor of `neo4j.Bookmarks`.
 - Remove deprecated class `session.last_bookmark()` in favor of `last_bookmarks()`.
-- Remove deprecated `ServerInfo.connection_id`.
+- Remove deprecated `ServerInfo.connection_id`.  
   There is no replacement as this is considered internal information.
 - Remove deprecated driver configuration option `trust`.  
   Use `trusted_certificates` instead.

--- a/src/neo4j/api.py
+++ b/src/neo4j/api.py
@@ -24,15 +24,10 @@ import typing as t
 
 if t.TYPE_CHECKING:
     import typing_extensions as te
-    from typing_extensions import (
-        deprecated,
-        Protocol as _Protocol,
-    )
+    from typing_extensions import Protocol as _Protocol
 
     from ._addressing import Address
 else:
-    from ._warnings import deprecated
-
     _Protocol = object
 
 
@@ -310,15 +305,6 @@ class ServerInfo:
     def agent(self) -> str:
         """Server agent string by which the remote server identifies itself."""
         return str(self._metadata.get("server"))
-
-    @property  # type: ignore
-    @deprecated(
-        "The connection id is considered internal information "
-        "and will no longer be exposed in future versions."
-    )
-    def connection_id(self):
-        """Unique identifier for the remote server connection."""
-        return self._metadata.get("connection_id")
 
     def update(self, metadata: dict) -> None:
         """

--- a/tests/integration/test_bolt_driver.py
+++ b/tests/integration/test_bolt_driver.py
@@ -30,13 +30,3 @@ def server_info(driver):
     with driver.session() as session:
         summary = session.run("RETURN 1").consume()
         yield summary.server
-
-
-# TODO: 6.0 -
-#       This test will stay as python is currently the only driver exposing
-#       the connection id. This will be removed in 6.0
-def test_server_connection_id(driver):
-    server_info = driver.get_server_info()
-    with pytest.warns(DeprecationWarning):
-        cid = server_info.connection_id
-    assert cid.startswith("bolt-") and cid[5:].isdigit()

--- a/tests/unit/common/test_api.py
+++ b/tests/unit/common/test_api.py
@@ -137,8 +137,8 @@ def test_serverinfo_initialization() -> None:
     server_info = neo4j.ServerInfo(address, version)
     assert server_info.address is address
     assert server_info.protocol_version is version
-    with pytest.warns(DeprecationWarning):
-        assert server_info.connection_id is None
+    with pytest.raises(AttributeError):
+        _ = server_info.connection_id  # type: ignore  # expected to fail
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
There is no replacement as this is considered internal information.