### PR TITLE
Mark imports private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
   - Remove `ExperimentalWarning` and turn the few left instances of it into `PreviewWarning`.
   - Deprecate importing `PreviewWarning` from `neo4j`.  
     Import it from `neo4j.warnings` instead.
-- Make undocumented internal constants and helper functions private:
+- Make undocumented internal constants, helper functions, and other items private:
   - `neo4j.api`
     - `DRIVER_BOLT`
     - `DRIVER_NEO4J`
@@ -104,6 +104,8 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
     - `.default_host`
     - `.default_port`
     - `.default_target`
+  - `neo4j.graph`
+    - indirectly exposed items from imports (e.g. `collections.abc.Mapping` as `neo4j.graph.Mapping`).
 - Raise `ConfigurationError` instead of ignoring the routing context (URI query parameters) when creating a direct
   driver ("bolt[+s[sc]]://" scheme).
 - Change behavior of closed drivers:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
     - `.default_host`
     - `.default_port`
     - `.default_target`
-  - `neo4j.graph`, `neo4j.addressing`
+  - `neo4j.graph`, `neo4j.addressing`, `neo4j.api`
     - indirectly exposed items from imports (e.g. `collections.abc.Mapping` as `neo4j.graph.Mapping`).
 - Raise `ConfigurationError` instead of ignoring the routing context (URI query parameters) when creating a direct
   driver ("bolt[+s[sc]]://" scheme).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
     - `ERROR_REWRITE_MAP`
     - `client_errors`
     - `transient_errors`
+    - all other indirectly exposed items from imports (e.g. `typing` as `neo4j.exceptions.t`)
   - `neo4j.spatial`
     - `hydrate_point`
     - `dehydrate_point`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
     - `.default_host`
     - `.default_port`
     - `.default_target`
-  - `neo4j.graph`
+  - `neo4j.graph`, `neo4j.addressing`
     - indirectly exposed items from imports (e.g. `collections.abc.Mapping` as `neo4j.graph.Mapping`).
 - Raise `ConfigurationError` instead of ignoring the routing context (URI query parameters) when creating a direct
   driver ("bolt[+s[sc]]://" scheme).

--- a/src/neo4j/addressing.py
+++ b/src/neo4j/addressing.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-from __future__ import annotations
+from __future__ import annotations as _
 
 from ._addressing import (
     Address,

--- a/src/neo4j/api.py
+++ b/src/neo4j/api.py
@@ -16,22 +16,25 @@
 
 """Base classes and helpers."""
 
-from __future__ import annotations
+from __future__ import annotations as _
 
-import abc
-import typing as t
+import abc as _abc
+import typing as _t
+
+# ignore TCH001 to make sphinx not completely drop the ball
+from ._addressing import Address as _Address  # noqa: TCH001
 
 
-if t.TYPE_CHECKING:
-    import typing_extensions as te
+if _t.TYPE_CHECKING:
+    import typing_extensions as _te
     from typing_extensions import (
-        deprecated,
+        deprecated as _deprecated,
         Protocol as _Protocol,
     )
 
-    from ._addressing import Address
+
 else:
-    from ._warnings import deprecated
+    from ._warnings import deprecated as _deprecated
 
     _Protocol = object
 
@@ -61,21 +64,21 @@ __all__ = [
 ]
 
 
-READ_ACCESS: te.Final[str] = "READ"
-WRITE_ACCESS: te.Final[str] = "WRITE"
+READ_ACCESS: _te.Final[str] = "READ"
+WRITE_ACCESS: _te.Final[str] = "WRITE"
 
-URI_SCHEME_BOLT: te.Final[str] = "bolt"
-URI_SCHEME_BOLT_SELF_SIGNED_CERTIFICATE: te.Final[str] = "bolt+ssc"
-URI_SCHEME_BOLT_SECURE: te.Final[str] = "bolt+s"
+URI_SCHEME_BOLT: _te.Final[str] = "bolt"
+URI_SCHEME_BOLT_SELF_SIGNED_CERTIFICATE: _te.Final[str] = "bolt+ssc"
+URI_SCHEME_BOLT_SECURE: _te.Final[str] = "bolt+s"
 
-URI_SCHEME_NEO4J: te.Final[str] = "neo4j"
-URI_SCHEME_NEO4J_SELF_SIGNED_CERTIFICATE: te.Final[str] = "neo4j+ssc"
-URI_SCHEME_NEO4J_SECURE: te.Final[str] = "neo4j+s"
+URI_SCHEME_NEO4J: _te.Final[str] = "neo4j"
+URI_SCHEME_NEO4J_SELF_SIGNED_CERTIFICATE: _te.Final[str] = "neo4j+ssc"
+URI_SCHEME_NEO4J_SECURE: _te.Final[str] = "neo4j+s"
 
-URI_SCHEME_BOLT_ROUTING: te.Final[str] = "bolt+routing"
+URI_SCHEME_BOLT_ROUTING: _te.Final[str] = "bolt+routing"
 
-SYSTEM_DATABASE: te.Final[str] = "system"
-DEFAULT_DATABASE: te.Final[None] = None  # Must be a non string hashable value
+SYSTEM_DATABASE: _te.Final[str] = "system"
+DEFAULT_DATABASE: _te.Final[None] = None  # Must be a non string hashable value
 
 
 # TODO: This class is not tested
@@ -103,7 +106,7 @@ class Auth:
         principal: str | None,
         credentials: str | None,
         realm: str | None = None,
-        **parameters: t.Any,
+        **parameters: _t.Any,
     ) -> None:
         self.scheme = scheme
         # Neo4j servers pre 4.4 require the principal field to always be
@@ -117,7 +120,7 @@ class Auth:
         if parameters:
             self.parameters = parameters
 
-    def __eq__(self, other: t.Any) -> bool:
+    def __eq__(self, other: _t.Any) -> bool:
         if not isinstance(other, Auth):
             return NotImplemented
         return vars(self) == vars(other)
@@ -126,8 +129,8 @@ class Auth:
 # For backwards compatibility
 AuthToken = Auth
 
-if t.TYPE_CHECKING:
-    _TAuth: t.TypeAlias = tuple[str, str] | Auth | None
+if _t.TYPE_CHECKING:
+    _TAuth: _t.TypeAlias = tuple[str, str] | Auth | None
 
 
 def basic_auth(user: str, password: str, realm: str | None = None) -> Auth:
@@ -181,7 +184,7 @@ def custom_auth(
     credentials: str | None,
     realm: str | None,
     scheme: str | None,
-    **parameters: t.Any,
+    **parameters: _t.Any,
 ) -> Auth:
     """
     Generate a custom auth token.
@@ -253,7 +256,7 @@ class Bookmarks:
         return self._raw_values
 
     @classmethod
-    def from_raw_values(cls, values: t.Iterable[str]) -> Bookmarks:
+    def from_raw_values(cls, values: _t.Iterable[str]) -> Bookmarks:
         """
         Create a Bookmarks object from a list of raw bookmark string values.
 
@@ -286,13 +289,13 @@ class Bookmarks:
 class ServerInfo:
     """Represents a package of information relating to a Neo4j server."""
 
-    def __init__(self, address: Address, protocol_version: tuple[int, int]):
+    def __init__(self, address: _Address, protocol_version: tuple[int, int]):
         self._address = address
         self._protocol_version = protocol_version
         self._metadata: dict = {}
 
     @property
-    def address(self) -> Address:
+    def address(self) -> _Address:
         """Network address of the remote server."""
         return self._address
 
@@ -312,7 +315,7 @@ class ServerInfo:
         return str(self._metadata.get("server"))
 
     @property  # type: ignore
-    @deprecated(
+    @_deprecated(
         "The connection id is considered internal information "
         "and will no longer be exposed in future versions."
     )
@@ -330,7 +333,7 @@ class ServerInfo:
         self._metadata.update(metadata)
 
 
-class BookmarkManager(_Protocol, metaclass=abc.ABCMeta):
+class BookmarkManager(_Protocol, metaclass=_abc.ABCMeta):
     """
     Class to manage bookmarks throughout the driver's lifetime.
 
@@ -371,11 +374,11 @@ class BookmarkManager(_Protocol, metaclass=abc.ABCMeta):
     .. versionchanged:: 5.8 Stabilized from experimental.
     """
 
-    @abc.abstractmethod
+    @_abc.abstractmethod
     def update_bookmarks(
         self,
-        previous_bookmarks: t.Collection[str],
-        new_bookmarks: t.Collection[str],
+        previous_bookmarks: _t.Collection[str],
+        new_bookmarks: _t.Collection[str],
     ) -> None:
         """
         Handle bookmark updates.
@@ -387,8 +390,8 @@ class BookmarkManager(_Protocol, metaclass=abc.ABCMeta):
         """
         ...
 
-    @abc.abstractmethod
-    def get_bookmarks(self) -> t.Collection[str]:
+    @_abc.abstractmethod
+    def get_bookmarks(self) -> _t.Collection[str]:
         """
         Return the bookmarks stored in the bookmark manager.
 
@@ -397,7 +400,7 @@ class BookmarkManager(_Protocol, metaclass=abc.ABCMeta):
         ...
 
 
-class AsyncBookmarkManager(_Protocol, metaclass=abc.ABCMeta):
+class AsyncBookmarkManager(_Protocol, metaclass=_abc.ABCMeta):
     """
     Same as :class:`.BookmarkManager` but with async methods.
 
@@ -412,16 +415,16 @@ class AsyncBookmarkManager(_Protocol, metaclass=abc.ABCMeta):
     .. versionchanged:: 5.8 Stabilized from experimental.
     """
 
-    @abc.abstractmethod
+    @_abc.abstractmethod
     async def update_bookmarks(
         self,
-        previous_bookmarks: t.Collection[str],
-        new_bookmarks: t.Collection[str],
+        previous_bookmarks: _t.Collection[str],
+        new_bookmarks: _t.Collection[str],
     ) -> None: ...
 
     update_bookmarks.__doc__ = BookmarkManager.update_bookmarks.__doc__
 
-    @abc.abstractmethod
-    async def get_bookmarks(self) -> t.Collection[str]: ...
+    @_abc.abstractmethod
+    async def get_bookmarks(self) -> _t.Collection[str]: ...
 
     get_bookmarks.__doc__ = BookmarkManager.get_bookmarks.__doc__

--- a/src/neo4j/exceptions.py
+++ b/src/neo4j/exceptions.py
@@ -60,42 +60,42 @@ Driver API Errors
     + ConnectionAcquisitionTimeoutError
 """
 
-from __future__ import annotations
+from __future__ import annotations as _
 
-import typing as t
+import typing as _t
 from copy import deepcopy as _deepcopy
 from enum import Enum as _Enum
 
 from ._warnings import preview as _preview
 
 
-if t.TYPE_CHECKING:
-    from collections.abc import Mapping
+if _t.TYPE_CHECKING:
+    from collections.abc import Mapping as _Mapping
 
-    import typing_extensions as te
+    import typing_extensions as _te
 
     from ._async.work import (
-        AsyncManagedTransaction,
-        AsyncResult,
-        AsyncSession,
-        AsyncTransaction,
+        AsyncManagedTransaction as _AsyncManagedTransaction,
+        AsyncResult as _AsyncResult,
+        AsyncSession as _AsyncSession,
+        AsyncTransaction as _AsyncTransaction,
     )
     from ._sync.work import (
-        ManagedTransaction,
-        Result,
-        Session,
-        Transaction,
+        ManagedTransaction as _ManagedTransaction,
+        Result as _Result,
+        Session as _Session,
+        Transaction as _Transaction,
     )
 
-    _TTransaction: t.TypeAlias = (
-        AsyncManagedTransaction
-        | AsyncTransaction
-        | ManagedTransaction
-        | Transaction
+    _TTransaction: _t.TypeAlias = (
+        _AsyncManagedTransaction
+        | _AsyncTransaction
+        | _ManagedTransaction
+        | _Transaction
     )
-    _TResult: t.TypeAlias = AsyncResult | Result
-    _TSession: t.TypeAlias = AsyncSession | Session
-    _T = t.TypeVar("_T")
+    _TResult: _t.TypeAlias = _AsyncResult | _Result
+    _TSession: _t.TypeAlias = _AsyncSession | _Session
+    _T = _t.TypeVar("_T")
 
 
 __all__ = [
@@ -138,9 +138,9 @@ __all__ = [
 ]
 
 
-_CLASSIFICATION_CLIENT: te.Final[str] = "ClientError"
-_CLASSIFICATION_TRANSIENT: te.Final[str] = "TransientError"
-_CLASSIFICATION_DATABASE: te.Final[str] = "DatabaseError"
+_CLASSIFICATION_CLIENT: _te.Final[str] = "ClientError"
+_CLASSIFICATION_TRANSIENT: _te.Final[str] = "TransientError"
+_CLASSIFICATION_DATABASE: _te.Final[str] = "DatabaseError"
 
 
 _ERROR_REWRITE_MAP: dict[str, tuple[str, str | None]] = {
@@ -167,18 +167,18 @@ _ERROR_REWRITE_MAP: dict[str, tuple[str, str | None]] = {
 }
 
 
-_UNKNOWN_NEO4J_CODE: te.Final[str] = "Neo.DatabaseError.General.UnknownError"
+_UNKNOWN_NEO4J_CODE: _te.Final[str] = "Neo.DatabaseError.General.UnknownError"
 # TODO: 7.0 - Make _UNKNOWN_GQL_MESSAGE the default message
-_UNKNOWN_MESSAGE: te.Final[str] = "An unknown error occurred"
-_UNKNOWN_GQL_STATUS: te.Final[str] = "50N42"
-_UNKNOWN_GQL_DESCRIPTION: te.Final[str] = (
+_UNKNOWN_MESSAGE: _te.Final[str] = "An unknown error occurred"
+_UNKNOWN_GQL_STATUS: _te.Final[str] = "50N42"
+_UNKNOWN_GQL_DESCRIPTION: _te.Final[str] = (
     "error: general processing exception - unexpected error"
 )
-_UNKNOWN_GQL_MESSAGE: te.Final[str] = (
+_UNKNOWN_GQL_MESSAGE: _te.Final[str] = (
     f"{_UNKNOWN_GQL_STATUS}: "
     "Unexpected error has occurred. See debug log for details."
 )
-_UNKNOWN_GQL_DIAGNOSTIC_RECORD: te.Final[tuple[tuple[str, t.Any], ...]] = (
+_UNKNOWN_GQL_DIAGNOSTIC_RECORD: _te.Final[tuple[tuple[str, _t.Any], ...]] = (
     ("OPERATION", ""),
     ("OPERATION_CODE", "0"),
     ("CURRENT_SCHEMA", "/"),
@@ -240,12 +240,12 @@ class GqlError(Exception):
     _gql_status_description: str
     _gql_raw_classification: str | None
     _gql_classification: GqlErrorClassification
-    _status_diagnostic_record: dict[str, t.Any]  # original, internal only
-    _diagnostic_record: dict[str, t.Any]  # copy to be used externally
+    _status_diagnostic_record: dict[str, _t.Any]  # original, internal only
+    _diagnostic_record: dict[str, _t.Any]  # copy to be used externally
     _gql_cause: GqlError | None
 
     @staticmethod
-    def _hydrate_cause(**metadata: t.Any) -> GqlError:
+    def _hydrate_cause(**metadata: _t.Any) -> GqlError:
         meta_extractor = _MetaExtractor(metadata)
         gql_status = meta_extractor.str_value("gql_status")
         description = meta_extractor.str_value("description")
@@ -276,7 +276,7 @@ class GqlError(Exception):
         gql_status: str,
         message: str,
         description: str,
-        diagnostic_record: dict[str, t.Any] | None = None,
+        diagnostic_record: dict[str, _t.Any] | None = None,
         cause: GqlError | None = None,
     ) -> None:
         self._gql_status = gql_status
@@ -438,7 +438,7 @@ class GqlError(Exception):
         if not (
             isinstance(classification, str)
             and classification
-            in t.cast(t.Iterable[str], iter(GqlErrorClassification))
+            in _t.cast(_t.Iterable[str], iter(GqlErrorClassification))
         ):
             self._gql_classification = GqlErrorClassification.UNKNOWN
         else:
@@ -450,7 +450,7 @@ class GqlError(Exception):
     def gql_classification(self) -> GqlErrorClassification:
         return self._gql_classification_no_preview
 
-    def _get_status_diagnostic_record(self) -> dict[str, t.Any]:
+    def _get_status_diagnostic_record(self) -> dict[str, _t.Any]:
         if hasattr(self, "_status_diagnostic_record"):
             return self._status_diagnostic_record
 
@@ -458,7 +458,7 @@ class GqlError(Exception):
         return self._status_diagnostic_record
 
     @property
-    def _diagnostic_record_no_preview(self) -> Mapping[str, t.Any]:
+    def _diagnostic_record_no_preview(self) -> _Mapping[str, _t.Any]:
         if hasattr(self, "_diagnostic_record"):
             return self._diagnostic_record
 
@@ -469,7 +469,7 @@ class GqlError(Exception):
 
     @property
     @_preview("GQLSTATUS support is a preview feature.")
-    def diagnostic_record(self) -> Mapping[str, t.Any]:
+    def diagnostic_record(self) -> _Mapping[str, _t.Any]:
         return self._diagnostic_record_no_preview
 
     def __str__(self):
@@ -493,7 +493,7 @@ class Neo4jError(GqlError):
     _category: str
     _title: str
     #: (dict) Any additional information returned by the server.
-    _metadata: dict[str, t.Any]
+    _metadata: dict[str, _t.Any]
     _from_server: bool
 
     _retryable = False
@@ -508,7 +508,7 @@ class Neo4jError(GqlError):
         )
 
     @staticmethod
-    def _hydrate_neo4j(**metadata: t.Any) -> Neo4jError:
+    def _hydrate_neo4j(**metadata: _t.Any) -> Neo4jError:
         meta_extractor = _MetaExtractor(metadata)
         code = meta_extractor.str_value("code") or _UNKNOWN_NEO4J_CODE
         message = meta_extractor.str_value("message") or _UNKNOWN_MESSAGE
@@ -525,7 +525,7 @@ class Neo4jError(GqlError):
         return inst
 
     @staticmethod
-    def _hydrate_gql(**metadata: t.Any) -> Neo4jError:
+    def _hydrate_gql(**metadata: _t.Any) -> Neo4jError:
         meta_extractor = _MetaExtractor(metadata)
         gql_status = meta_extractor.str_value("gql_status")
         status_description = meta_extractor.str_value("description")
@@ -643,7 +643,7 @@ class Neo4jError(GqlError):
         return self._title
 
     @property
-    def metadata(self) -> dict[str, t.Any]:
+    def metadata(self) -> dict[str, _t.Any]:
         # Undocumented, might be useful for debugging
         return self._metadata
 
@@ -709,16 +709,16 @@ class Neo4jError(GqlError):
 
 
 class _MetaExtractor:
-    def __init__(self, metadata: dict[str, t.Any]) -> None:
+    def __init__(self, metadata: dict[str, _t.Any]) -> None:
         self._metadata = metadata
 
-    def rest(self) -> dict[str, t.Any]:
+    def rest(self) -> dict[str, _t.Any]:
         return self._metadata
 
-    @t.overload
+    @_t.overload
     def str_value(self, key: str) -> str | None: ...
 
-    @t.overload
+    @_t.overload
     def str_value(self, key: str, default: _T) -> str | _T: ...
 
     def str_value(
@@ -729,15 +729,15 @@ class _MetaExtractor:
             res = default
         return res
 
-    @t.overload
-    def map_value(self, key: str) -> dict[str, t.Any] | None: ...
+    @_t.overload
+    def map_value(self, key: str) -> dict[str, _t.Any] | None: ...
 
-    @t.overload
-    def map_value(self, key: str, default: _T) -> dict[str, t.Any] | _T: ...
+    @_t.overload
+    def map_value(self, key: str, default: _T) -> dict[str, _t.Any] | _T: ...
 
     def map_value(
         self, key: str, default: _T | None = None
-    ) -> dict[str, t.Any] | _T | None:
+    ) -> dict[str, _t.Any] | _T | None:
         res = self._metadata.pop(key, default)
         if not (
             isinstance(res, dict) and all(isinstance(k, str) for k in res)

--- a/src/neo4j/graph/__init__.py
+++ b/src/neo4j/graph/__init__.py
@@ -16,16 +16,16 @@
 
 """Graph data types as returned by the DBMS."""
 
-from __future__ import annotations
+from __future__ import annotations as _
 
-import typing as t
-from collections.abc import Mapping
+import typing as _t
+from collections.abc import Mapping as _Mapping
 
 
-if t.TYPE_CHECKING:
-    from typing_extensions import deprecated
+if _t.TYPE_CHECKING:
+    from typing_extensions import deprecated as _deprecated
 else:
-    from .._warnings import deprecated
+    from .._warnings import deprecated as _deprecated
 
 
 __all__ = [
@@ -36,7 +36,7 @@ __all__ = [
 ]
 
 
-_T = t.TypeVar("_T")
+_T = _t.TypeVar("_T")
 
 
 class Graph:
@@ -71,7 +71,7 @@ class Graph:
         try:
             cls = self._relationship_types[name]
         except KeyError:
-            cls = self._relationship_types[name] = t.cast(
+            cls = self._relationship_types[name] = _t.cast(
                 type[Relationship], type(str(name), (Relationship,), {})
             )
         return cls
@@ -92,7 +92,7 @@ class Graph:
         return graph
 
 
-class Entity(t.Mapping[str, t.Any]):
+class Entity(_t.Mapping[str, _t.Any]):
     """
     Graph entity base.
 
@@ -106,7 +106,7 @@ class Entity(t.Mapping[str, t.Any]):
         graph: Graph,
         element_id: str,
         id_: int,
-        properties: dict[str, t.Any] | None,
+        properties: dict[str, _t.Any] | None,
     ) -> None:
         self._graph = graph
         self._element_id = element_id
@@ -115,7 +115,7 @@ class Entity(t.Mapping[str, t.Any]):
             k: v for k, v in (properties or {}).items() if v is not None
         }
 
-    def __eq__(self, other: t.Any) -> bool:
+    def __eq__(self, other: _t.Any) -> bool:
         # TODO: 6.0 - return NotImplemented on type mismatch instead of False
         try:
             return (
@@ -135,13 +135,13 @@ class Entity(t.Mapping[str, t.Any]):
     def __len__(self) -> int:
         return len(self._properties)
 
-    def __getitem__(self, name: str) -> t.Any:
+    def __getitem__(self, name: str) -> _t.Any:
         return self._properties.get(name)
 
     def __contains__(self, name: object) -> bool:
         return name in self._properties
 
-    def __iter__(self) -> t.Iterator[str]:
+    def __iter__(self) -> _t.Iterator[str]:
         return iter(self._properties)
 
     @property
@@ -150,7 +150,7 @@ class Entity(t.Mapping[str, t.Any]):
         return self._graph
 
     @property  # type: ignore
-    @deprecated("`id` is deprecated, use `element_id` instead")
+    @_deprecated("`id` is deprecated, use `element_id` instead")
     def id(self) -> int:
         """
         The legacy identity of this entity in its container :class:`.Graph`.
@@ -182,24 +182,24 @@ class Entity(t.Mapping[str, t.Any]):
         """
         return self._element_id
 
-    def get(self, name: str, default: object = None) -> t.Any:
+    def get(self, name: str, default: object = None) -> _t.Any:
         """Get a property value by name, optionally with a default."""
         return self._properties.get(name, default)
 
-    def keys(self) -> t.KeysView[str]:
+    def keys(self) -> _t.KeysView[str]:
         """Return an iterable of all property names."""
         return self._properties.keys()
 
-    def values(self) -> t.ValuesView[t.Any]:
+    def values(self) -> _t.ValuesView[_t.Any]:
         """Return an iterable of all property values."""
         return self._properties.values()
 
-    def items(self) -> t.ItemsView[str, t.Any]:
+    def items(self) -> _t.ItemsView[str, _t.Any]:
         """Return an iterable of all property name-value pairs."""
         return self._properties.items()
 
 
-class EntitySetView(Mapping, t.Generic[_T]):
+class EntitySetView(_Mapping, _t.Generic[_T]):
     """View of a set of :class:`.Entity` instances within a :class:`.Graph`."""
 
     def __init__(
@@ -214,7 +214,7 @@ class EntitySetView(Mapping, t.Generic[_T]):
     def __len__(self) -> int:
         return len(self._entity_dict)
 
-    def __iter__(self) -> t.Iterator[_T]:
+    def __iter__(self) -> _t.Iterator[_T]:
         return iter(self._entity_dict.values())
 
 
@@ -226,8 +226,8 @@ class Node(Entity):
         graph: Graph,
         element_id: str,
         id_: int,
-        n_labels: t.Iterable[str] | None = None,
-        properties: dict[str, t.Any] | None = None,
+        n_labels: _t.Iterable[str] | None = None,
+        properties: dict[str, _t.Any] | None = None,
     ) -> None:
         Entity.__init__(self, graph, element_id, id_, properties)
         self._labels = frozenset(n_labels or ())
@@ -252,7 +252,7 @@ class Relationship(Entity):
         graph: Graph,
         element_id: str,
         id_: int,
-        properties: dict[str, t.Any],
+        properties: dict[str, _t.Any],
     ) -> None:
         Entity.__init__(self, graph, element_id, id_, properties)
         self._start_node: Node | None = None
@@ -307,9 +307,9 @@ class Path:
         for i, relationship in enumerate(relationships, start=1):
             assert isinstance(relationship, Relationship)
             if relationship.start_node == nodes[-1]:
-                nodes.append(t.cast(Node, relationship.end_node))
+                nodes.append(_t.cast(Node, relationship.end_node))
             elif relationship.end_node == nodes[-1]:
-                nodes.append(t.cast(Node, relationship.start_node))
+                nodes.append(_t.cast(Node, relationship.start_node))
             else:
                 raise ValueError(
                     f"Relationship {i} does not connect to the last node"
@@ -323,7 +323,7 @@ class Path:
             f"size={len(self)}>"
         )
 
-    def __eq__(self, other: t.Any) -> bool:
+    def __eq__(self, other: _t.Any) -> bool:
         # TODO: 6.0 - return NotImplemented on type mismatch instead of False
         try:
             return (
@@ -345,7 +345,7 @@ class Path:
     def __len__(self) -> int:
         return len(self._relationships)
 
-    def __iter__(self) -> t.Iterator[Relationship]:
+    def __iter__(self) -> _t.Iterator[Relationship]:
         return iter(self._relationships)
 
     @property


### PR DESCRIPTION
Mark indirectly exposed items from imports as private (e.g. `collections.abc.Mapping` as `neo4j.graph.Mapping`).

Affected packages/modules: `neo4j.exceptions`, `neo4j.graph`, `neo4j.addressing`, `neo4j.api`.