### PR TITLE
Refactor type annotations

### DIFF
--- a/benchkit/app.py
+++ b/benchkit/app.py
@@ -20,7 +20,6 @@ import typing as t
 from contextlib import contextmanager
 from multiprocessing import Semaphore
 
-import typing_extensions as te
 from sanic import Sanic
 from sanic.exceptions import (
     BadRequest,
@@ -43,7 +42,7 @@ if t.TYPE_CHECKING:
     from .workloads import Workload
 
 
-T_App: te.TypeAlias = "Sanic[Config, BenchKitContext]"
+T_App: t.TypeAlias = "Sanic[Config, BenchKitContext]"
 
 
 def create_app() -> T_App:

--- a/benchkit/workloads.py
+++ b/benchkit/workloads.py
@@ -19,13 +19,16 @@ from __future__ import annotations
 import asyncio
 import enum
 import typing as t
+from collections.abc import (
+    Iterable,
+    Iterator,
+    Mapping,
+)
 from dataclasses import dataclass
-
-import typing_extensions as te
 
 
 if t.TYPE_CHECKING:
-    from collections.abc import Iterator
+    import typing_extensions as te
 
     from neo4j import (
         AsyncDriver,
@@ -40,7 +43,7 @@ __all__ = [
 ]
 
 
-class Workloads(t.Mapping):
+class Workloads(Mapping):
     def __init__(self) -> None:
         self._workloads: dict[str, Workload] = {}
         self._current_id: int = 0
@@ -517,7 +520,7 @@ class _WorkloadQuery:
 
     @classmethod
     def parse_multiple(cls, queries: t.Any) -> list[te.Self]:
-        if not isinstance(queries, t.Iterable):
+        if not isinstance(queries, Iterable):
             raise TypeError("Workload queries must be a list")
         return [cls.parse(query) for query in queries]
 
@@ -544,7 +547,7 @@ class _WorkloadQuery:
 @dataclass
 class _WorkloadConfig:
     database: str | None
-    routing: te.Literal["r", "w"]
+    routing: t.Literal["r", "w"]
 
     @classmethod
     def parse(cls, data: t.Any) -> te.Self:
@@ -554,7 +557,7 @@ class _WorkloadConfig:
             if not isinstance(database, str):
                 raise TypeError("Workload database must be a string")
 
-        routing: te.Literal["r", "w"] = "w"
+        routing: t.Literal["r", "w"] = "w"
         if "routing" in data:
             raw_routing = data["routing"]
             if not isinstance(routing, str):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,6 @@
 
 import os
 import sys
-import typing
 
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -123,17 +122,7 @@ todo_include_todos = True
 # Don't include type hints in function signatures
 autodoc_typehints = "description"
 
-autodoc_type_aliases = {
-    # The code-base uses `import typing_extensions as te`.
-    # Re-write these to use `typing` instead, as Sphinx always resolves against
-    # the latest version of the `typing` module.
-    # This is a work-around to make Sphinx resolve type hints correctly, even
-    # though we're using `from __future__ import annotations`.
-    "te": typing,
-    # Type alias that's only defined and imported if `typing.TYPE_CHECKING`
-    # is `True`.
-    "_TAuth": "typing.Tuple[typing.Any, typing.Any] | Auth | None",
-}
+autodoc_type_aliases = {}
 
 # -- Options for HTML output ----------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ extend-exclude = [
 
 [tool.ruff.lint]
 preview = true  # to get CPY lints
+typing-modules = ["neo4j._typing"]
 extend-ignore = [
     "RUF002",  # allow ’ (RIGHT SINGLE QUOTATION MARK) to be used as an apostrophe (e.g. "it’s")
 

--- a/src/neo4j/__init__.py
+++ b/src/neo4j/__init__.py
@@ -14,8 +14,7 @@
 # limitations under the License.
 
 
-import typing as _t
-
+from . import _typing as _t
 from ._api import (  # noqa: F401 dynamic attributes
     NotificationCategory,
     NotificationDisabledCategory,

--- a/src/neo4j/_addressing.py
+++ b/src/neo4j/_addressing.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import typing as t
 from contextlib import suppress as _suppress
 from socket import (
     AddressFamily,
@@ -25,9 +24,7 @@ from socket import (
     getservbyname,
 )
 
-
-if t.TYPE_CHECKING:
-    import typing_extensions as te
+from . import _typing as t
 
 
 _T = t.TypeVar("_T")
@@ -35,7 +32,7 @@ _T = t.TypeVar("_T")
 
 if t.TYPE_CHECKING:
 
-    class _WithPeerName(te.Protocol):
+    class _WithPeerName(t.Protocol):
         def getpeername(self) -> tuple: ...
 
 

--- a/src/neo4j/_api.py
+++ b/src/neo4j/_api.py
@@ -16,19 +16,17 @@
 
 from __future__ import annotations
 
-import typing as t
 from enum import Enum
 from urllib.parse import (
     parse_qs,
     urlparse,
 )
 
-from . import api
+from . import (
+    _typing as t,
+    api,
+)
 from .exceptions import ConfigurationError
-
-
-if t.TYPE_CHECKING:
-    import typing_extensions as te
 
 
 __all__ = [
@@ -51,14 +49,14 @@ __all__ = [
 ]
 
 
-DRIVER_BOLT: te.Final[str] = "DRIVER_BOLT"
-DRIVER_NEO4J: te.Final[str] = "DRIVER_NEO4J"
+DRIVER_BOLT: t.Final[str] = "DRIVER_BOLT"
+DRIVER_NEO4J: t.Final[str] = "DRIVER_NEO4J"
 
-SECURITY_TYPE_NOT_SECURE: te.Final[str] = "SECURITY_TYPE_NOT_SECURE"
-SECURITY_TYPE_SELF_SIGNED_CERTIFICATE: te.Final[str] = (
+SECURITY_TYPE_NOT_SECURE: t.Final[str] = "SECURITY_TYPE_NOT_SECURE"
+SECURITY_TYPE_SELF_SIGNED_CERTIFICATE: t.Final[str] = (
     "SECURITY_TYPE_SELF_SIGNED_CERTIFICATE"
 )
-SECURITY_TYPE_SECURE: te.Final[str] = "SECURITY_TYPE_SECURE"
+SECURITY_TYPE_SECURE: t.Final[str] = "SECURITY_TYPE_SECURE"
 
 
 def parse_neo4j_uri(uri):
@@ -184,7 +182,7 @@ class NotificationMinimumSeverity(str, Enum):
 if t.TYPE_CHECKING:
     T_NotificationMinimumSeverity = (
         NotificationMinimumSeverity
-        | te.Literal[
+        | t.Literal[
             "OFF",
             "WARNING",
             "INFORMATION",
@@ -331,7 +329,7 @@ if t.TYPE_CHECKING:
     T_NotificationDisabledCategory = (
         NotificationDisabledCategory
         | NotificationDisabledClassification
-        | te.Literal[
+        | t.Literal[
             "HINT",
             "UNRECOGNIZED",
             "UNSUPPORTED",
@@ -458,5 +456,5 @@ class TelemetryAPI(int, Enum):
 
 
 if t.TYPE_CHECKING:
-    T_RoutingControl = RoutingControl | te.Literal["r", "w"]
+    T_RoutingControl = RoutingControl | t.Literal["r", "w"]
     __all__.append("T_RoutingControl")

--- a/src/neo4j/_async/_debug/_concurrency_check.py
+++ b/src/neo4j/_async/_debug/_concurrency_check.py
@@ -18,10 +18,10 @@ from __future__ import annotations
 
 import inspect
 import traceback
-import typing as t
 from copy import deepcopy
 from functools import wraps
 
+from ... import _typing as t
 from ..._async_compat.concurrency import (
     AsyncLock,
     AsyncRLock,

--- a/src/neo4j/_async/auth_management.py
+++ b/src/neo4j/_async/auth_management.py
@@ -17,9 +17,9 @@
 from __future__ import annotations
 
 import abc
-import typing as t
 from logging import getLogger
 
+from .. import _typing as t
 from .._async_compat.concurrency import (
     AsyncCooperativeLock,
     AsyncLock,
@@ -32,9 +32,11 @@ from .._auth_management import (
     ExpiringAuth,
 )
 
+# ignore TCH001 to make sphinx not completely drop the ball
+from ..api import _TAuth  # noqa: TCH001
+
 
 if t.TYPE_CHECKING:
-    from ..api import _TAuth
     from ..exceptions import Neo4jError
 
 

--- a/src/neo4j/_async/bookmark_manager.py
+++ b/src/neo4j/_async/bookmark_manager.py
@@ -16,8 +16,7 @@
 
 from __future__ import annotations
 
-import typing as t
-
+from .. import _typing as t
 from .._async_compat.concurrency import AsyncCooperativeLock
 from .._async_compat.util import AsyncUtil
 from ..api import (

--- a/src/neo4j/_async/config.py
+++ b/src/neo4j/_async/config.py
@@ -16,8 +16,7 @@
 
 from __future__ import annotations
 
-import typing as t
-
+from .. import _typing as t
 from .._async_compat.concurrency import AsyncLock
 from .._conf import (
     Config,

--- a/src/neo4j/_async/driver.py
+++ b/src/neo4j/_async/driver.py
@@ -17,18 +17,8 @@
 from __future__ import annotations
 
 import asyncio
-import typing as t
 
-
-if t.TYPE_CHECKING:
-    import ssl
-    import typing_extensions as te
-
-    from .._api import (
-        T_NotificationDisabledCategory,
-        T_NotificationMinimumSeverity,
-    )
-
+from .. import _typing as t
 from .._addressing import Address
 from .._api import (
     DRIVER_BOLT,
@@ -60,6 +50,7 @@ from .._work import (
     unit_of_work,
 )
 from ..api import (
+    _TAuth,
     AsyncBookmarkManager,
     Auth,
     BookmarkManager,
@@ -102,10 +93,11 @@ if t.TYPE_CHECKING:
     import ssl
     from enum import Enum
 
-    import typing_extensions as te
-
-    from .._api import T_RoutingControl
-    from ..api import _TAuth
+    from .._api import (
+        T_NotificationDisabledCategory,
+        T_NotificationMinimumSeverity,
+        T_RoutingControl,
+    )
 
     class _DefaultEnum(Enum):
         default = "default"
@@ -610,7 +602,7 @@ class AsyncDriver:
     @t.overload
     async def execute_query(
         self,
-        query_: te.LiteralString | Query,
+        query_: t.LiteralString | Query,
         parameters_: dict[str, t.Any] | None = None,
         routing_: T_RoutingControl = RoutingControl.WRITE,
         database_: str | None = None,
@@ -628,7 +620,7 @@ class AsyncDriver:
     @t.overload
     async def execute_query(
         self,
-        query_: te.LiteralString | Query,
+        query_: t.LiteralString | Query,
         parameters_: dict[str, t.Any] | None = None,
         routing_: T_RoutingControl = RoutingControl.WRITE,
         database_: str | None = None,
@@ -643,7 +635,7 @@ class AsyncDriver:
 
     async def execute_query(
         self,
-        query_: te.LiteralString | Query,
+        query_: t.LiteralString | Query,
         parameters_: dict[str, t.Any] | None = None,
         routing_: T_RoutingControl = RoutingControl.WRITE,
         database_: str | None = None,
@@ -652,7 +644,7 @@ class AsyncDriver:
             AsyncBookmarkManager
             | BookmarkManager
             | None
-            | te.Literal[_DefaultEnum.default]
+            | t.Literal[_DefaultEnum.default]
         ) = _default,
         auth_: _TAuth = None,
         result_transformer_: t.Callable[
@@ -1274,7 +1266,7 @@ class AsyncDriver:
 
 async def _work(
     tx: AsyncManagedTransaction,
-    query: te.LiteralString,
+    query: t.LiteralString,
     parameters: dict[str, t.Any],
     transformer: t.Callable[[AsyncResult], t.Awaitable[_T]],
 ) -> _T:

--- a/src/neo4j/_async/home_db_cache.py
+++ b/src/neo4j/_async/home_db_cache.py
@@ -19,9 +19,9 @@
 from __future__ import annotations
 
 import math
-import typing as t
 from time import monotonic
 
+from .. import _typing as t
 from .._async_compat.concurrency import AsyncCooperativeLock
 
 

--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -18,11 +18,11 @@ from __future__ import annotations
 
 import abc
 import asyncio
-import typing as t
 from collections import deque
 from logging import getLogger
 from time import monotonic
 
+from ... import _typing as t
 from ..._addressing import ResolvedAddress
 from ..._async_compat.util import AsyncUtil
 from ..._auth_management import to_auth_dict
@@ -58,8 +58,6 @@ from ._common import (
 
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
-
     from ..._api import TelemetryAPI
 
 
@@ -264,7 +262,7 @@ class AsyncBolt:
         dict[BoltProtocolVersion, type[AsyncBolt]]
     ] = {}
 
-    def __init_subclass__(cls: type[te.Self], **kwargs: t.Any) -> None:
+    def __init_subclass__(cls: type[t.Self], **kwargs: t.Any) -> None:
         if cls.SKIP_REGISTRATION:
             super().__init_subclass__(**kwargs)
             return

--- a/src/neo4j/_async/io/_bolt3.py
+++ b/src/neo4j/_async/io/_bolt3.py
@@ -16,11 +16,11 @@
 
 from __future__ import annotations
 
-import typing as t
 from enum import Enum
 from logging import getLogger
 from ssl import SSLSocket
 
+from ... import _typing as t
 from ..._exceptions import BoltProtocolError
 from ..._io import BoltProtocolVersion
 from ...api import READ_ACCESS

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 
-import typing as t
 from enum import Enum
 from logging import getLogger
 from ssl import SSLSocket
 
+from ... import _typing as t
 from ..._api import TelemetryAPI
 from ..._async_compat.util import AsyncUtil
 from ..._codec.hydration import v2 as hydration_v2

--- a/src/neo4j/_async/io/_bolt_socket.py
+++ b/src/neo4j/_async/io/_bolt_socket.py
@@ -20,9 +20,9 @@ import asyncio
 import dataclasses
 import logging
 import struct
-import typing as t
 from contextlib import suppress
 
+from ... import _typing as t
 from ..._addressing import Address
 from ..._async_compat.network import (
     AsyncBoltSocketBase,
@@ -41,8 +41,6 @@ from ...exceptions import (
 
 if t.TYPE_CHECKING:
     from ssl import SSLContext
-
-    import typing_extensions as te
 
     from ..._addressing import ResolvedAddress
     from ..._deadline import Deadline
@@ -298,7 +296,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
         custom_resolver: t.Callable | None,
         ssl_context: SSLContext | None,
         keep_alive: bool,
-    ) -> tuple[te.Self, BoltProtocolVersion]:
+    ) -> tuple[t.Self, BoltProtocolVersion]:
         """
         Connect and perform a handshake.
 

--- a/src/neo4j/_async/io/_pool.py
+++ b/src/neo4j/_async/io/_pool.py
@@ -20,7 +20,6 @@ import abc
 import asyncio
 import logging
 import math
-import typing as t
 from collections import (
     defaultdict,
     deque,
@@ -31,6 +30,7 @@ from dataclasses import dataclass
 from logging import getLogger
 from random import choice
 
+from ... import _typing as t
 from ..._api import check_access_mode
 from ..._async_compat.concurrency import (
     AsyncCondition,

--- a/src/neo4j/_async/work/result.py
+++ b/src/neo4j/_async/work/result.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import inspect
-import typing as t
 from collections import deque
 from logging import getLogger
 from pathlib import Path
@@ -26,10 +25,7 @@ from warnings import (
     warn_explicit,
 )
 
-
-if t.TYPE_CHECKING:
-    import typing_extensions as te
-
+from ... import _typing as t
 from ..._api import (
     NotificationCategory,
     NotificationMinimumSeverity,
@@ -105,7 +101,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
     """
 
     _creation_stack: list[inspect.FrameInfo] | None
-    _creation_frame_cache: None | te.Literal[False] | inspect.FrameInfo
+    _creation_frame_cache: None | t.Literal[False] | inspect.FrameInfo
 
     def __init__(
         self,
@@ -362,7 +358,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
                 )
 
     @property
-    def _creation_frame(self) -> te.Literal[False] | inspect.FrameInfo:
+    def _creation_frame(self) -> t.Literal[False] | inspect.FrameInfo:
         if self._creation_frame_cache is not None:
             return self._creation_frame_cache
 
@@ -565,11 +561,11 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
 
     @t.overload
     async def single(
-        self, strict: te.Literal[False] = False
+        self, strict: t.Literal[False] = False
     ) -> Record | None: ...
 
     @t.overload
-    async def single(self, strict: te.Literal[True]) -> Record: ...
+    async def single(self, strict: t.Literal[True]) -> Record: ...
 
     @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def single(self, strict: bool = False) -> Record | None:

--- a/src/neo4j/_async/work/session.py
+++ b/src/neo4j/_async/work/session.py
@@ -17,11 +17,11 @@
 from __future__ import annotations
 
 import asyncio
-import typing as t
 from logging import getLogger
 from random import random
 from time import monotonic
 
+from ... import _typing as t
 from ..._api import TelemetryAPI
 from ..._async_compat import async_sleep
 from ..._async_compat.util import AsyncUtil
@@ -51,12 +51,10 @@ from .workspace import AsyncWorkspace
 
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
-
     from ..io import AsyncBolt
 
     _R = t.TypeVar("_R")
-    _P = te.ParamSpec("_P")
+    _P = t.ParamSpec("_P")
 
 
 log = getLogger("neo4j.pool")
@@ -256,7 +254,7 @@ class AsyncSession(AsyncWorkspace):
     @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def run(
         self,
-        query: te.LiteralString | Query,
+        query: t.LiteralString | Query,
         parameters: dict[str, t.Any] | None = None,
         **kwargs: t.Any,
     ) -> AsyncResult:
@@ -498,7 +496,7 @@ class AsyncSession(AsyncWorkspace):
         access_mode: str,
         api: TelemetryAPI,
         transaction_function: t.Callable[
-            te.Concatenate[AsyncManagedTransaction, _P], t.Awaitable[_R]
+            t.Concatenate[AsyncManagedTransaction, _P], t.Awaitable[_R]
         ],
         # *args: _P.args, **kwargs: _P.kwargs
         # gives more type safety, but is less performant and makes for harder
@@ -591,7 +589,7 @@ class AsyncSession(AsyncWorkspace):
     async def execute_read(
         self,
         transaction_function: t.Callable[
-            te.Concatenate[AsyncManagedTransaction, _P], t.Awaitable[_R]
+            t.Concatenate[AsyncManagedTransaction, _P], t.Awaitable[_R]
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -670,7 +668,7 @@ class AsyncSession(AsyncWorkspace):
     async def execute_write(
         self,
         transaction_function: t.Callable[
-            te.Concatenate[AsyncManagedTransaction, _P], t.Awaitable[_R]
+            t.Concatenate[AsyncManagedTransaction, _P], t.Awaitable[_R]
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,

--- a/src/neo4j/_async/work/transaction.py
+++ b/src/neo4j/_async/work/transaction.py
@@ -17,18 +17,14 @@
 from __future__ import annotations
 
 import asyncio
-import typing as t
 
+from ... import _typing as t  # noqa: TCH001
 from ..._async_compat.util import AsyncUtil
 from ..._work import Query
 from ...exceptions import TransactionError
 from .._debug import AsyncNonConcurrentMethodChecker
 from ..io import ConnectionErrorHandler
 from .result import AsyncResult
-
-
-if t.TYPE_CHECKING:
-    import typing_extensions as te
 
 
 __all__ = (
@@ -66,7 +62,7 @@ class AsyncTransactionBase(AsyncNonConcurrentMethodChecker):
         self._on_database = on_database
         super().__init__()
 
-    async def _enter(self) -> te.Self:
+    async def _enter(self) -> t.Self:
         return self
 
     @AsyncNonConcurrentMethodChecker._non_concurrent_method
@@ -137,7 +133,7 @@ class AsyncTransactionBase(AsyncNonConcurrentMethodChecker):
     @AsyncNonConcurrentMethodChecker._non_concurrent_method
     async def run(
         self,
-        query: te.LiteralString,
+        query: t.LiteralString,
         parameters: dict[str, t.Any] | None = None,
         **kwparameters: t.Any,
     ) -> AsyncResult:

--- a/src/neo4j/_async/work/workspace.py
+++ b/src/neo4j/_async/work/workspace.py
@@ -17,8 +17,8 @@
 from __future__ import annotations
 
 import logging
-import typing as t
 
+from ... import _typing as t
 from ..._async_compat.util import AsyncUtil
 from ..._auth_management import to_auth_dict
 from ..._conf import WorkspaceConfig

--- a/src/neo4j/_async_compat/concurrency.py
+++ b/src/neo4j/_async_compat/concurrency.py
@@ -20,12 +20,8 @@ import asyncio
 import collections
 import re
 import threading
-import typing as t
 
-
-if t.TYPE_CHECKING:
-    import typing_extensions as te
-
+from .. import _typing as t  # noqa: TCH001
 from .shims import wait_for
 
 
@@ -479,8 +475,8 @@ class AsyncCondition:
         self.notify(len(self._waiters))
 
 
-Condition: te.TypeAlias = threading.Condition
-CooperativeLock: te.TypeAlias = threading.Lock
-Lock: te.TypeAlias = threading.Lock
-CooperativeRLock: te.TypeAlias = threading.RLock
-RLock: te.TypeAlias = threading.RLock
+Condition: t.TypeAlias = threading.Condition
+CooperativeLock: t.TypeAlias = threading.Lock
+Lock: t.TypeAlias = threading.Lock
+CooperativeRLock: t.TypeAlias = threading.RLock
+RLock: t.TypeAlias = threading.RLock

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -20,7 +20,6 @@ import abc
 import asyncio
 import errno
 import logging
-import typing as t
 from contextlib import suppress
 from socket import (
     AF_INET,
@@ -40,6 +39,7 @@ from ssl import (
     SSLSocket,
 )
 
+from ... import _typing as t
 from ..._deadline import Deadline
 from ..._exceptions import (
     BoltProtocolError,
@@ -51,8 +51,6 @@ from ..shims import wait_for
 
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
-
     from ..._addressing import (
         Address,
         ResolvedAddress,
@@ -75,7 +73,7 @@ def _sanitize_deadline(deadline):
 
 
 class AsyncBoltSocketBase(abc.ABC):
-    Bolt: te.Final[type[AsyncBolt]] = None  # type: ignore[assignment]
+    Bolt: t.Final[type[AsyncBolt]] = None  # type: ignore[assignment]
 
     def __init__(self, reader, protocol, writer) -> None:
         self._reader = reader  # type: asyncio.StreamReader
@@ -169,7 +167,7 @@ class AsyncBoltSocketBase(abc.ABC):
     @classmethod
     async def _connect_secure(
         cls, resolved_address, timeout, keep_alive, ssl_context
-    ) -> te.Self:
+    ) -> t.Self:
         """
         Connect to the address and return the socket.
 
@@ -289,7 +287,7 @@ class AsyncBoltSocketBase(abc.ABC):
         custom_resolver: t.Callable | None,
         ssl_context: SSLContext | None,
         keep_alive: bool,
-    ) -> tuple[te.Self, BoltProtocolVersion]: ...
+    ) -> tuple[t.Self, BoltProtocolVersion]: ...
 
     @classmethod
     async def close_socket(cls, socket_):
@@ -308,7 +306,7 @@ class AsyncBoltSocketBase(abc.ABC):
 
 
 class BoltSocketBase:
-    Bolt: te.Final[type[Bolt]] = None  # type: ignore[assignment]
+    Bolt: t.Final[type[Bolt]] = None  # type: ignore[assignment]
 
     def __init__(self, socket_: socket):
         self._socket = socket_
@@ -480,7 +478,7 @@ class BoltSocketBase:
         custom_resolver: t.Callable | None,
         ssl_context: SSLContext | None,
         keep_alive: bool,
-    ) -> tuple[te.Self, BoltProtocolVersion]: ...
+    ) -> tuple[t.Self, BoltProtocolVersion]: ...
 
     @classmethod
     def close_socket(cls, socket_):

--- a/src/neo4j/_async_compat/util.py
+++ b/src/neo4j/_async_compat/util.py
@@ -19,15 +19,14 @@ from __future__ import annotations
 import asyncio
 import inspect
 import traceback
-import typing as t
 from functools import wraps
+
+from .. import _typing as t
 
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
-
     _T = t.TypeVar("_T")
-    _P = te.ParamSpec("_P")
+    _P = t.ParamSpec("_P")
 
 
 __all__ = [

--- a/src/neo4j/_auth_management.py
+++ b/src/neo4j/_auth_management.py
@@ -18,20 +18,24 @@ from __future__ import annotations
 
 import abc
 import time
-import typing as t
 from dataclasses import dataclass
 
-from .api import Auth
-from .exceptions import ConfigurationError
+# ignore TCH003 to make sphinx not completely drop the ball
+from os import PathLike  # noqa: TCH003
+
+from . import _typing as t
+from .api import (
+    _TAuth,
+    Auth,
+)
+from .exceptions import (
+    ConfigurationError,
+    Neo4jError,
+)
 
 
 if t.TYPE_CHECKING:
-    from os import PathLike
-
-    from typing_extensions import Protocol as _Protocol
-
-    from .api import _TAuth
-    from .exceptions import Neo4jError
+    from ._typing import Protocol as _Protocol
 else:
     _Protocol = object
 

--- a/src/neo4j/_codec/hydration/_common.py
+++ b/src/neo4j/_codec/hydration/_common.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 
-import typing as t
 from copy import copy
 from dataclasses import dataclass
 
+from ... import _typing as t
 from ...graph import Graph
 from ..packstream import Structure
 

--- a/src/neo4j/_conf.py
+++ b/src/neo4j/_conf.py
@@ -17,8 +17,8 @@
 from __future__ import annotations
 
 from abc import ABCMeta
-from collections.abc import Mapping
 
+from . import _typing as t
 from ._warnings import (
     deprecation_warn,
     preview_warn,
@@ -238,7 +238,7 @@ class ConfigType(ABCMeta):
         )
 
 
-class Config(Mapping, metaclass=ConfigType):
+class Config(t.Mapping, metaclass=ConfigType):
     """Base class for all configuration containers."""
 
     @staticmethod

--- a/src/neo4j/_data.py
+++ b/src/neo4j/_data.py
@@ -16,19 +16,14 @@
 
 from __future__ import annotations
 
-import typing as t
 from abc import (
     ABC,
     abstractmethod,
 )
-from collections.abc import (
-    Mapping,
-    Sequence,
-    Set,
-)
 from functools import reduce
 from operator import xor as xor_operator
 
+from . import _typing as t
 from ._codec.hydration import BrokenHydrationObject
 from ._conf import iter_items
 from .exceptions import BrokenRecordError
@@ -50,7 +45,7 @@ _T = t.TypeVar("_T")
 _K: t.TypeAlias = int | str
 
 
-class Record(tuple, Mapping):
+class Record(tuple, t.Mapping):
     """
     Immutable, ordered collection of key-value pairs.
 
@@ -103,8 +98,8 @@ class Record(tuple, Mapping):
         :param other:
         :returns:
         """
-        compare_as_sequence = isinstance(other, Sequence)
-        compare_as_mapping = isinstance(other, Mapping)
+        compare_as_sequence = isinstance(other, t.Sequence)
+        compare_as_mapping = isinstance(other, t.Mapping)
         if compare_as_sequence and compare_as_mapping:
             other = t.cast(t.Mapping, other)
             return list(self) == list(other) and dict(self) == dict(other)
@@ -343,10 +338,10 @@ class RecordExporter(DataTransformer):
             return path
         elif isinstance(x, (str, Point, Date, Time, DateTime, Duration)):
             return x
-        elif isinstance(x, (Sequence, Set)):
+        elif isinstance(x, (t.Sequence, t.Set)):
             typ = type(x)
             return typ(map(self.transform, x))
-        elif isinstance(x, Mapping):
+        elif isinstance(x, t.Mapping):
             typ = type(x)
             return typ((k, self.transform(v)) for k, v in x.items())
         else:
@@ -361,7 +356,7 @@ class RecordTableRowExporter(DataTransformer):
         return key.replace("\\", "\\\\").replace(".", "\\.")
 
     def transform(self, x):
-        assert isinstance(x, Mapping)
+        assert isinstance(x, t.Mapping)
         typ = type(x)
         return typ(
             item
@@ -390,7 +385,7 @@ class RecordTableRowExporter(DataTransformer):
             return res
         elif isinstance(x, (Path, str)):
             return {prefix: x}
-        elif isinstance(x, Sequence):
+        elif isinstance(x, t.Sequence):
             return dict(
                 item
                 for i, v in enumerate(x)
@@ -398,7 +393,7 @@ class RecordTableRowExporter(DataTransformer):
                     v, prefix=f"{prefix}[].{i}"
                 ).items()
             )
-        elif isinstance(x, Mapping):
+        elif isinstance(x, t.Mapping):
             typ = type(x)
             return typ(
                 item

--- a/src/neo4j/_debug/_notification_printer.py
+++ b/src/neo4j/_debug/_notification_printer.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-import typing as t
+from .. import _typing as t
 
 
 if t.TYPE_CHECKING:

--- a/src/neo4j/_io/__init__.py
+++ b/src/neo4j/_io/__init__.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-import typing as t
+from .. import _typing as t  # noqa: TCH001
 
 
 __all__ = [

--- a/src/neo4j/_meta.py
+++ b/src/neo4j/_meta.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 
 import platform
 import sys
-import typing as t
 
+from . import _typing as t
 from ._codec.packstream import RUST_AVAILABLE
 
 

--- a/src/neo4j/_optional_deps/__init__.py
+++ b/src/neo4j/_optional_deps/__init__.py
@@ -14,8 +14,11 @@
 # limitations under the License.
 
 
-import typing as t
+from __future__ import annotations
+
 from contextlib import suppress
+
+from .. import _typing as t  # noqa: TCH001
 
 
 np: t.Any = None

--- a/src/neo4j/_sync/_debug/_concurrency_check.py
+++ b/src/neo4j/_sync/_debug/_concurrency_check.py
@@ -18,10 +18,10 @@ from __future__ import annotations
 
 import inspect
 import traceback
-import typing as t
 from copy import deepcopy
 from functools import wraps
 
+from ... import _typing as t
 from ..._async_compat.concurrency import (
     Lock,
     RLock,

--- a/src/neo4j/_sync/auth_management.py
+++ b/src/neo4j/_sync/auth_management.py
@@ -17,9 +17,9 @@
 from __future__ import annotations
 
 import abc
-import typing as t
 from logging import getLogger
 
+from .. import _typing as t
 from .._async_compat.concurrency import (
     CooperativeLock,
     Lock,
@@ -32,9 +32,11 @@ from .._auth_management import (
     ExpiringAuth,
 )
 
+# ignore TCH001 to make sphinx not completely drop the ball
+from ..api import _TAuth  # noqa: TCH001
+
 
 if t.TYPE_CHECKING:
-    from ..api import _TAuth
     from ..exceptions import Neo4jError
 
 

--- a/src/neo4j/_sync/bookmark_manager.py
+++ b/src/neo4j/_sync/bookmark_manager.py
@@ -16,8 +16,7 @@
 
 from __future__ import annotations
 
-import typing as t
-
+from .. import _typing as t
 from .._async_compat.concurrency import CooperativeLock
 from .._async_compat.util import Util
 from ..api import (

--- a/src/neo4j/_sync/config.py
+++ b/src/neo4j/_sync/config.py
@@ -16,8 +16,7 @@
 
 from __future__ import annotations
 
-import typing as t
-
+from .. import _typing as t
 from .._async_compat.concurrency import Lock
 from .._conf import (
     Config,

--- a/src/neo4j/_sync/driver.py
+++ b/src/neo4j/_sync/driver.py
@@ -17,18 +17,8 @@
 from __future__ import annotations
 
 import asyncio
-import typing as t
 
-
-if t.TYPE_CHECKING:
-    import ssl
-    import typing_extensions as te
-
-    from .._api import (
-        T_NotificationDisabledCategory,
-        T_NotificationMinimumSeverity,
-    )
-
+from .. import _typing as t
 from .._addressing import Address
 from .._api import (
     DRIVER_BOLT,
@@ -60,6 +50,7 @@ from .._work import (
     unit_of_work,
 )
 from ..api import (
+    _TAuth,
     Auth,
     BookmarkManager,
     Bookmarks,
@@ -101,10 +92,11 @@ if t.TYPE_CHECKING:
     import ssl
     from enum import Enum
 
-    import typing_extensions as te
-
-    from .._api import T_RoutingControl
-    from ..api import _TAuth
+    from .._api import (
+        T_NotificationDisabledCategory,
+        T_NotificationMinimumSeverity,
+        T_RoutingControl,
+    )
 
     class _DefaultEnum(Enum):
         default = "default"
@@ -609,7 +601,7 @@ class Driver:
     @t.overload
     def execute_query(
         self,
-        query_: te.LiteralString | Query,
+        query_: t.LiteralString | Query,
         parameters_: dict[str, t.Any] | None = None,
         routing_: T_RoutingControl = RoutingControl.WRITE,
         database_: str | None = None,
@@ -627,7 +619,7 @@ class Driver:
     @t.overload
     def execute_query(
         self,
-        query_: te.LiteralString | Query,
+        query_: t.LiteralString | Query,
         parameters_: dict[str, t.Any] | None = None,
         routing_: T_RoutingControl = RoutingControl.WRITE,
         database_: str | None = None,
@@ -642,7 +634,7 @@ class Driver:
 
     def execute_query(
         self,
-        query_: te.LiteralString | Query,
+        query_: t.LiteralString | Query,
         parameters_: dict[str, t.Any] | None = None,
         routing_: T_RoutingControl = RoutingControl.WRITE,
         database_: str | None = None,
@@ -651,7 +643,7 @@ class Driver:
             BookmarkManager
             | BookmarkManager
             | None
-            | te.Literal[_DefaultEnum.default]
+            | t.Literal[_DefaultEnum.default]
         ) = _default,
         auth_: _TAuth = None,
         result_transformer_: t.Callable[
@@ -1273,7 +1265,7 @@ class Driver:
 
 def _work(
     tx: ManagedTransaction,
-    query: te.LiteralString,
+    query: t.LiteralString,
     parameters: dict[str, t.Any],
     transformer: t.Callable[[Result], t.Union[_T]],
 ) -> _T:

--- a/src/neo4j/_sync/home_db_cache.py
+++ b/src/neo4j/_sync/home_db_cache.py
@@ -19,9 +19,9 @@
 from __future__ import annotations
 
 import math
-import typing as t
 from time import monotonic
 
+from .. import _typing as t
 from .._async_compat.concurrency import CooperativeLock
 
 

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -18,11 +18,11 @@ from __future__ import annotations
 
 import abc
 import asyncio
-import typing as t
 from collections import deque
 from logging import getLogger
 from time import monotonic
 
+from ... import _typing as t
 from ..._addressing import ResolvedAddress
 from ..._async_compat.util import Util
 from ..._auth_management import to_auth_dict
@@ -58,8 +58,6 @@ from ._common import (
 
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
-
     from ..._api import TelemetryAPI
 
 
@@ -264,7 +262,7 @@ class Bolt:
         dict[BoltProtocolVersion, type[Bolt]]
     ] = {}
 
-    def __init_subclass__(cls: type[te.Self], **kwargs: t.Any) -> None:
+    def __init_subclass__(cls: type[t.Self], **kwargs: t.Any) -> None:
         if cls.SKIP_REGISTRATION:
             super().__init_subclass__(**kwargs)
             return

--- a/src/neo4j/_sync/io/_bolt3.py
+++ b/src/neo4j/_sync/io/_bolt3.py
@@ -16,11 +16,11 @@
 
 from __future__ import annotations
 
-import typing as t
 from enum import Enum
 from logging import getLogger
 from ssl import SSLSocket
 
+from ... import _typing as t
 from ..._exceptions import BoltProtocolError
 from ..._io import BoltProtocolVersion
 from ...api import READ_ACCESS

--- a/src/neo4j/_sync/io/_bolt5.py
+++ b/src/neo4j/_sync/io/_bolt5.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 
-import typing as t
 from enum import Enum
 from logging import getLogger
 from ssl import SSLSocket
 
+from ... import _typing as t
 from ..._api import TelemetryAPI
 from ..._async_compat.util import Util
 from ..._codec.hydration import v2 as hydration_v2

--- a/src/neo4j/_sync/io/_bolt_socket.py
+++ b/src/neo4j/_sync/io/_bolt_socket.py
@@ -20,9 +20,9 @@ import asyncio
 import dataclasses
 import logging
 import struct
-import typing as t
 from contextlib import suppress
 
+from ... import _typing as t
 from ..._addressing import Address
 from ..._async_compat.network import (
     BoltSocketBase,
@@ -41,8 +41,6 @@ from ...exceptions import (
 
 if t.TYPE_CHECKING:
     from ssl import SSLContext
-
-    import typing_extensions as te
 
     from ..._addressing import ResolvedAddress
     from ..._deadline import Deadline
@@ -298,7 +296,7 @@ class BoltSocket(BoltSocketBase):
         custom_resolver: t.Callable | None,
         ssl_context: SSLContext | None,
         keep_alive: bool,
-    ) -> tuple[te.Self, BoltProtocolVersion]:
+    ) -> tuple[t.Self, BoltProtocolVersion]:
         """
         Connect and perform a handshake.
 

--- a/src/neo4j/_sync/io/_pool.py
+++ b/src/neo4j/_sync/io/_pool.py
@@ -20,7 +20,6 @@ import abc
 import asyncio
 import logging
 import math
-import typing as t
 from collections import (
     defaultdict,
     deque,
@@ -31,6 +30,7 @@ from dataclasses import dataclass
 from logging import getLogger
 from random import choice
 
+from ... import _typing as t
 from ..._api import check_access_mode
 from ..._async_compat.concurrency import (
     Condition,

--- a/src/neo4j/_sync/work/result.py
+++ b/src/neo4j/_sync/work/result.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import inspect
-import typing as t
 from collections import deque
 from logging import getLogger
 from pathlib import Path
@@ -26,10 +25,7 @@ from warnings import (
     warn_explicit,
 )
 
-
-if t.TYPE_CHECKING:
-    import typing_extensions as te
-
+from ... import _typing as t
 from ..._api import (
     NotificationCategory,
     NotificationMinimumSeverity,
@@ -105,7 +101,7 @@ class Result(NonConcurrentMethodChecker):
     """
 
     _creation_stack: list[inspect.FrameInfo] | None
-    _creation_frame_cache: None | te.Literal[False] | inspect.FrameInfo
+    _creation_frame_cache: None | t.Literal[False] | inspect.FrameInfo
 
     def __init__(
         self,
@@ -362,7 +358,7 @@ class Result(NonConcurrentMethodChecker):
                 )
 
     @property
-    def _creation_frame(self) -> te.Literal[False] | inspect.FrameInfo:
+    def _creation_frame(self) -> t.Literal[False] | inspect.FrameInfo:
         if self._creation_frame_cache is not None:
             return self._creation_frame_cache
 
@@ -565,11 +561,11 @@ class Result(NonConcurrentMethodChecker):
 
     @t.overload
     def single(
-        self, strict: te.Literal[False] = False
+        self, strict: t.Literal[False] = False
     ) -> Record | None: ...
 
     @t.overload
-    def single(self, strict: te.Literal[True]) -> Record: ...
+    def single(self, strict: t.Literal[True]) -> Record: ...
 
     @NonConcurrentMethodChecker._non_concurrent_method
     def single(self, strict: bool = False) -> Record | None:

--- a/src/neo4j/_sync/work/session.py
+++ b/src/neo4j/_sync/work/session.py
@@ -17,11 +17,11 @@
 from __future__ import annotations
 
 import asyncio
-import typing as t
 from logging import getLogger
 from random import random
 from time import monotonic
 
+from ... import _typing as t
 from ..._api import TelemetryAPI
 from ..._async_compat import sleep
 from ..._async_compat.util import Util
@@ -51,12 +51,10 @@ from .workspace import Workspace
 
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
-
     from ..io import Bolt
 
     _R = t.TypeVar("_R")
-    _P = te.ParamSpec("_P")
+    _P = t.ParamSpec("_P")
 
 
 log = getLogger("neo4j.pool")
@@ -256,7 +254,7 @@ class Session(Workspace):
     @NonConcurrentMethodChecker._non_concurrent_method
     def run(
         self,
-        query: te.LiteralString | Query,
+        query: t.LiteralString | Query,
         parameters: dict[str, t.Any] | None = None,
         **kwargs: t.Any,
     ) -> Result:
@@ -498,7 +496,7 @@ class Session(Workspace):
         access_mode: str,
         api: TelemetryAPI,
         transaction_function: t.Callable[
-            te.Concatenate[ManagedTransaction, _P], t.Union[_R]
+            t.Concatenate[ManagedTransaction, _P], t.Union[_R]
         ],
         # *args: _P.args, **kwargs: _P.kwargs
         # gives more type safety, but is less performant and makes for harder
@@ -591,7 +589,7 @@ class Session(Workspace):
     def execute_read(
         self,
         transaction_function: t.Callable[
-            te.Concatenate[ManagedTransaction, _P], t.Union[_R]
+            t.Concatenate[ManagedTransaction, _P], t.Union[_R]
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,
@@ -670,7 +668,7 @@ class Session(Workspace):
     def execute_write(
         self,
         transaction_function: t.Callable[
-            te.Concatenate[ManagedTransaction, _P], t.Union[_R]
+            t.Concatenate[ManagedTransaction, _P], t.Union[_R]
         ],
         *args: _P.args,
         **kwargs: _P.kwargs,

--- a/src/neo4j/_sync/work/transaction.py
+++ b/src/neo4j/_sync/work/transaction.py
@@ -17,18 +17,14 @@
 from __future__ import annotations
 
 import asyncio
-import typing as t
 
+from ... import _typing as t  # noqa: TCH001
 from ..._async_compat.util import Util
 from ..._work import Query
 from ...exceptions import TransactionError
 from .._debug import NonConcurrentMethodChecker
 from ..io import ConnectionErrorHandler
 from .result import Result
-
-
-if t.TYPE_CHECKING:
-    import typing_extensions as te
 
 
 __all__ = (
@@ -66,7 +62,7 @@ class TransactionBase(NonConcurrentMethodChecker):
         self._on_database = on_database
         super().__init__()
 
-    def _enter(self) -> te.Self:
+    def _enter(self) -> t.Self:
         return self
 
     @NonConcurrentMethodChecker._non_concurrent_method
@@ -137,7 +133,7 @@ class TransactionBase(NonConcurrentMethodChecker):
     @NonConcurrentMethodChecker._non_concurrent_method
     def run(
         self,
-        query: te.LiteralString,
+        query: t.LiteralString,
         parameters: dict[str, t.Any] | None = None,
         **kwparameters: t.Any,
     ) -> Result:

--- a/src/neo4j/_sync/work/workspace.py
+++ b/src/neo4j/_sync/work/workspace.py
@@ -17,8 +17,8 @@
 from __future__ import annotations
 
 import logging
-import typing as t
 
+from ... import _typing as t
 from ..._async_compat.util import Util
 from ..._auth_management import to_auth_dict
 from ..._conf import WorkspaceConfig

--- a/src/neo4j/_typing.py
+++ b/src/neo4j/_typing.py
@@ -1,0 +1,104 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+from collections.abc import (
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Collection,
+    Generator,
+    Hashable,
+    ItemsView,
+    Iterable,
+    Iterator,
+    KeysView,
+    Mapping,
+    Sequence,
+    Set,
+    ValuesView,
+)
+from typing import (
+    Any,
+    cast,
+    ClassVar,
+    Concatenate,
+    Final,
+    Generic,
+    Literal,
+    NamedTuple,
+    overload,
+    ParamSpec,
+    Protocol,
+    SupportsIndex,
+    TextIO,
+    TYPE_CHECKING,
+    TypeAlias,
+    TypedDict,
+    TypeVar,
+    Union,
+)
+
+
+__all__: tuple[str, ...] = (
+    "TYPE_CHECKING",
+    "Any",
+    "AsyncIterator",
+    "Awaitable",
+    "Callable",
+    "ClassVar",
+    "Collection",
+    "Concatenate",
+    "Final",
+    "Generator",
+    "Generic",
+    "Hashable",
+    "ItemsView",
+    "Iterable",
+    "Iterator",
+    "KeysView",
+    "Literal",
+    "Mapping",
+    "NamedTuple",
+    "ParamSpec",
+    "Protocol",
+    "Sequence",
+    "Set",
+    "SupportsIndex",
+    "TextIO",
+    "TypeAlias",
+    "TypeVar",
+    "TypedDict",
+    "Union",
+    "ValuesView",
+    "cast",
+    "overload",
+)
+
+if TYPE_CHECKING:
+    from typing_extensions import NotRequired  # Python 3.11+  # noqa: TCH004
+    from typing_extensions import Self  # Python 3.11  # noqa: TCH004
+    from typing_extensions import (  # Python 3.11  # noqa: TCH004 Python
+        LiteralString,
+    )
+
+    __all__ = (  # noqa: PLE0604 false positive
+        *__all__,
+        "LiteralString",
+        "Self",
+        "NotRequired",
+    )

--- a/src/neo4j/_warnings.py
+++ b/src/neo4j/_warnings.py
@@ -13,14 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 from __future__ import annotations
 
 import asyncio
-import typing as t
 from functools import wraps
 from inspect import isclass
 from warnings import warn
 
+from . import _typing as t
 from .warnings import PreviewWarning
 
 

--- a/src/neo4j/_work/eager_result.py
+++ b/src/neo4j/_work/eager_result.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-import typing as t
+from .. import _typing as t
 
 
 if t.TYPE_CHECKING:

--- a/src/neo4j/_work/query.py
+++ b/src/neo4j/_work/query.py
@@ -16,12 +16,10 @@
 
 from __future__ import annotations
 
-import typing as t
+from .. import _typing as t
 
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
-
     _T = t.TypeVar("_T")
 
 
@@ -68,7 +66,7 @@ class Query:
 
     def __init__(
         self,
-        text: te.LiteralString,
+        text: t.LiteralString,
         metadata: dict[str, t.Any] | None = None,
         timeout: float | None = None,
     ) -> None:
@@ -77,12 +75,12 @@ class Query:
         self.metadata = metadata
         self.timeout = timeout
 
-    def __str__(self) -> te.LiteralString:
+    def __str__(self) -> t.LiteralString:
         # we know that if Query is constructed with a LiteralString,
         # str(self.text) will be a LiteralString as well. The conversion isn't
         # necessary if the user adheres to the type hints. However, it was
         # here before, and we don't want to break backwards compatibility.
-        text: te.LiteralString = str(self.text)  # type: ignore[assignment]
+        text: t.LiteralString = str(self.text)  # type: ignore[assignment]
         return text
 
 

--- a/src/neo4j/_work/summary.py
+++ b/src/neo4j/_work/summary.py
@@ -18,6 +18,9 @@ from __future__ import annotations
 
 import itertools
 import typing as t
+
+# ignore TCH003 to make sphinx not completely drop the ball
+from collections.abc import Sequence  # noqa: TCH003
 from copy import deepcopy
 from dataclasses import dataclass
 
@@ -31,8 +34,6 @@ from .._warnings import preview
 
 
 if t.TYPE_CHECKING:
-    from collections.abc import Sequence
-
     import typing_extensions as te
 
     from .._addressing import Address
@@ -60,7 +61,7 @@ class ResultSummary:
     #: A string that describes the type of query
     # ``'r'`` = read-only, ``'rw'`` = read/write, ``'w'`` = write-only,
     # ``'s'`` = schema.
-    query_type: te.Literal["r", "rw", "w", "s"] | None
+    query_type: t.Literal["r", "rw", "w", "s"] | None
 
     #: A :class:`neo4j.SummaryCounters` instance. Counters for operations the
     #: query triggered.
@@ -524,7 +525,7 @@ class SummaryNotification:
                 metadata.get("position")
             ),
         }
-        str_keys: tuple[te.Literal["title", "code", "description"], ...] = (
+        str_keys: tuple[t.Literal["title", "code", "description"], ...] = (
             "title",
             "code",
             "description",

--- a/src/neo4j/api.py
+++ b/src/neo4j/api.py
@@ -19,14 +19,13 @@
 from __future__ import annotations
 
 import abc
-import typing as t
+
+from . import _typing as _t
 
 
-if t.TYPE_CHECKING:
-    import typing_extensions as te
-    from typing_extensions import Protocol as _Protocol
-
+if _t.TYPE_CHECKING:
     from ._addressing import Address
+    from ._typing import Protocol as _Protocol
 else:
     _Protocol = object
 
@@ -56,21 +55,21 @@ __all__ = [
 ]
 
 
-READ_ACCESS: te.Final[str] = "READ"
-WRITE_ACCESS: te.Final[str] = "WRITE"
+READ_ACCESS: _t.Final[str] = "READ"
+WRITE_ACCESS: _t.Final[str] = "WRITE"
 
-URI_SCHEME_BOLT: te.Final[str] = "bolt"
-URI_SCHEME_BOLT_SELF_SIGNED_CERTIFICATE: te.Final[str] = "bolt+ssc"
-URI_SCHEME_BOLT_SECURE: te.Final[str] = "bolt+s"
+URI_SCHEME_BOLT: _t.Final[str] = "bolt"
+URI_SCHEME_BOLT_SELF_SIGNED_CERTIFICATE: _t.Final[str] = "bolt+ssc"
+URI_SCHEME_BOLT_SECURE: _t.Final[str] = "bolt+s"
 
-URI_SCHEME_NEO4J: te.Final[str] = "neo4j"
-URI_SCHEME_NEO4J_SELF_SIGNED_CERTIFICATE: te.Final[str] = "neo4j+ssc"
-URI_SCHEME_NEO4J_SECURE: te.Final[str] = "neo4j+s"
+URI_SCHEME_NEO4J: _t.Final[str] = "neo4j"
+URI_SCHEME_NEO4J_SELF_SIGNED_CERTIFICATE: _t.Final[str] = "neo4j+ssc"
+URI_SCHEME_NEO4J_SECURE: _t.Final[str] = "neo4j+s"
 
-URI_SCHEME_BOLT_ROUTING: te.Final[str] = "bolt+routing"
+URI_SCHEME_BOLT_ROUTING: _t.Final[str] = "bolt+routing"
 
-SYSTEM_DATABASE: te.Final[str] = "system"
-DEFAULT_DATABASE: te.Final[None] = None  # Must be a non string hashable value
+SYSTEM_DATABASE: _t.Final[str] = "system"
+DEFAULT_DATABASE: _t.Final[None] = None  # Must be a non string hashable value
 
 
 # TODO: This class is not tested
@@ -98,7 +97,7 @@ class Auth:
         principal: str | None,
         credentials: str | None,
         realm: str | None = None,
-        **parameters: t.Any,
+        **parameters: _t.Any,
     ) -> None:
         self.scheme = scheme
         # Neo4j servers pre 4.4 require the principal field to always be
@@ -112,7 +111,7 @@ class Auth:
         if parameters:
             self.parameters = parameters
 
-    def __eq__(self, other: t.Any) -> bool:
+    def __eq__(self, other: _t.Any) -> bool:
         if not isinstance(other, Auth):
             return NotImplemented
         return vars(self) == vars(other)
@@ -121,8 +120,7 @@ class Auth:
 # For backwards compatibility
 AuthToken = Auth
 
-if t.TYPE_CHECKING:
-    _TAuth: t.TypeAlias = tuple[str, str] | Auth | None
+_TAuth: _t.TypeAlias = tuple[str, str] | Auth | None
 
 
 def basic_auth(user: str, password: str, realm: str | None = None) -> Auth:
@@ -176,7 +174,7 @@ def custom_auth(
     credentials: str | None,
     realm: str | None,
     scheme: str | None,
-    **parameters: t.Any,
+    **parameters: _t.Any,
 ) -> Auth:
     """
     Generate a custom auth token.
@@ -248,7 +246,7 @@ class Bookmarks:
         return self._raw_values
 
     @classmethod
-    def from_raw_values(cls, values: t.Iterable[str]) -> Bookmarks:
+    def from_raw_values(cls, values: _t.Iterable[str]) -> Bookmarks:
         """
         Create a Bookmarks object from a list of raw bookmark string values.
 
@@ -360,8 +358,8 @@ class BookmarkManager(_Protocol, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def update_bookmarks(
         self,
-        previous_bookmarks: t.Collection[str],
-        new_bookmarks: t.Collection[str],
+        previous_bookmarks: _t.Collection[str],
+        new_bookmarks: _t.Collection[str],
     ) -> None:
         """
         Handle bookmark updates.
@@ -374,7 +372,7 @@ class BookmarkManager(_Protocol, metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
-    def get_bookmarks(self) -> t.Collection[str]:
+    def get_bookmarks(self) -> _t.Collection[str]:
         """
         Return the bookmarks stored in the bookmark manager.
 
@@ -401,13 +399,13 @@ class AsyncBookmarkManager(_Protocol, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     async def update_bookmarks(
         self,
-        previous_bookmarks: t.Collection[str],
-        new_bookmarks: t.Collection[str],
+        previous_bookmarks: _t.Collection[str],
+        new_bookmarks: _t.Collection[str],
     ) -> None: ...
 
     update_bookmarks.__doc__ = BookmarkManager.update_bookmarks.__doc__
 
     @abc.abstractmethod
-    async def get_bookmarks(self) -> t.Collection[str]: ...
+    async def get_bookmarks(self) -> _t.Collection[str]: ...
 
     get_bookmarks.__doc__ = BookmarkManager.get_bookmarks.__doc__

--- a/src/neo4j/debug.py
+++ b/src/neo4j/debug.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import asyncio
-import typing as t
 from contextlib import suppress as _suppress
 from logging import (
     CRITICAL,
@@ -31,6 +30,9 @@ from logging import (
     WARNING,
 )
 from sys import stderr
+
+# ignore TCH001 to make sphinx not completely drop the ball
+from . import _typing as _t  # noqa: TCH001
 
 
 __all__ = [
@@ -115,7 +117,7 @@ class Watcher:
         self,
         *logger_names: str | None,
         default_level: int = DEBUG,
-        default_out: t.TextIO = stderr,
+        default_out: _t.TextIO = stderr,
         colour: bool = False,
         thread_info: bool = True,
         task_info: bool = True,
@@ -148,7 +150,7 @@ class Watcher:
         self.stop()
 
     def watch(
-        self, level: int | None = None, out: t.TextIO | None = None
+        self, level: int | None = None, out: _t.TextIO | None = None
     ) -> None:
         """
         Enable logging for all loggers.
@@ -185,7 +187,7 @@ class Watcher:
 def watch(
     *logger_names: str | None,
     level: int = DEBUG,
-    out: t.TextIO = stderr,
+    out: _t.TextIO = stderr,
     colour: bool = False,
     thread_info: bool = True,
     task_info: bool = True,
@@ -211,7 +213,6 @@ def watch(
     :param logger_names: Names of loggers to watch.
     :param level: see ``default_level`` of :class:`.Watcher`.
     :param out: see ``default_out`` of :class:`.Watcher`.
-    :type out: stream or file-like object
     :param colour: see ``colour`` of :class:`.Watcher`.
     :param thread_info: see ``thread_info`` of :class:`.Watcher`.
     :param task_info: see ``task_info`` of :class:`.Watcher`.

--- a/src/neo4j/exceptions.py
+++ b/src/neo4j/exceptions.py
@@ -62,18 +62,14 @@ Driver API Errors
 
 from __future__ import annotations
 
-import typing as t
 from copy import deepcopy as _deepcopy
 from enum import Enum as _Enum
 
+from . import _typing as _t
 from ._warnings import preview as _preview
 
 
-if t.TYPE_CHECKING:
-    from collections.abc import Mapping
-
-    import typing_extensions as te
-
+if _t.TYPE_CHECKING:
     from ._async.work import (
         AsyncManagedTransaction,
         AsyncResult,
@@ -87,15 +83,15 @@ if t.TYPE_CHECKING:
         Transaction,
     )
 
-    _TTransaction: t.TypeAlias = (
+    _TTransaction: _t.TypeAlias = (
         AsyncManagedTransaction
         | AsyncTransaction
         | ManagedTransaction
         | Transaction
     )
-    _TResult: t.TypeAlias = AsyncResult | Result
-    _TSession: t.TypeAlias = AsyncSession | Session
-    _T = t.TypeVar("_T")
+    _TResult: _t.TypeAlias = AsyncResult | Result
+    _TSession: _t.TypeAlias = AsyncSession | Session
+    _T = _t.TypeVar("_T")
 
 
 __all__ = [
@@ -138,9 +134,9 @@ __all__ = [
 ]
 
 
-_CLASSIFICATION_CLIENT: te.Final[str] = "ClientError"
-_CLASSIFICATION_TRANSIENT: te.Final[str] = "TransientError"
-_CLASSIFICATION_DATABASE: te.Final[str] = "DatabaseError"
+_CLASSIFICATION_CLIENT: _t.Final[str] = "ClientError"
+_CLASSIFICATION_TRANSIENT: _t.Final[str] = "TransientError"
+_CLASSIFICATION_DATABASE: _t.Final[str] = "DatabaseError"
 
 
 _ERROR_REWRITE_MAP: dict[str, tuple[str, str | None]] = {
@@ -167,18 +163,18 @@ _ERROR_REWRITE_MAP: dict[str, tuple[str, str | None]] = {
 }
 
 
-_UNKNOWN_NEO4J_CODE: te.Final[str] = "Neo.DatabaseError.General.UnknownError"
+_UNKNOWN_NEO4J_CODE: _t.Final[str] = "Neo.DatabaseError.General.UnknownError"
 # TODO: 7.0 - Make _UNKNOWN_GQL_MESSAGE the default message
-_UNKNOWN_MESSAGE: te.Final[str] = "An unknown error occurred"
-_UNKNOWN_GQL_STATUS: te.Final[str] = "50N42"
-_UNKNOWN_GQL_DESCRIPTION: te.Final[str] = (
+_UNKNOWN_MESSAGE: _t.Final[str] = "An unknown error occurred"
+_UNKNOWN_GQL_STATUS: _t.Final[str] = "50N42"
+_UNKNOWN_GQL_DESCRIPTION: _t.Final[str] = (
     "error: general processing exception - unexpected error"
 )
-_UNKNOWN_GQL_MESSAGE: te.Final[str] = (
+_UNKNOWN_GQL_MESSAGE: _t.Final[str] = (
     f"{_UNKNOWN_GQL_STATUS}: "
     "Unexpected error has occurred. See debug log for details."
 )
-_UNKNOWN_GQL_DIAGNOSTIC_RECORD: te.Final[tuple[tuple[str, t.Any], ...]] = (
+_UNKNOWN_GQL_DIAGNOSTIC_RECORD: _t.Final[tuple[tuple[str, _t.Any], ...]] = (
     ("OPERATION", ""),
     ("OPERATION_CODE", "0"),
     ("CURRENT_SCHEMA", "/"),
@@ -240,12 +236,12 @@ class GqlError(Exception):
     _gql_status_description: str
     _gql_raw_classification: str | None
     _gql_classification: GqlErrorClassification
-    _status_diagnostic_record: dict[str, t.Any]  # original, internal only
-    _diagnostic_record: dict[str, t.Any]  # copy to be used externally
+    _status_diagnostic_record: dict[str, _t.Any]  # original, internal only
+    _diagnostic_record: dict[str, _t.Any]  # copy to be used externally
     _gql_cause: GqlError | None
 
     @staticmethod
-    def _hydrate_cause(**metadata: t.Any) -> GqlError:
+    def _hydrate_cause(**metadata: _t.Any) -> GqlError:
         meta_extractor = _MetaExtractor(metadata)
         gql_status = meta_extractor.str_value("gql_status")
         description = meta_extractor.str_value("description")
@@ -276,7 +272,7 @@ class GqlError(Exception):
         gql_status: str,
         message: str,
         description: str,
-        diagnostic_record: dict[str, t.Any] | None = None,
+        diagnostic_record: dict[str, _t.Any] | None = None,
         cause: GqlError | None = None,
     ) -> None:
         self._gql_status = gql_status
@@ -438,7 +434,7 @@ class GqlError(Exception):
         if not (
             isinstance(classification, str)
             and classification
-            in t.cast(t.Iterable[str], iter(GqlErrorClassification))
+            in _t.cast(_t.Iterable[str], iter(GqlErrorClassification))
         ):
             self._gql_classification = GqlErrorClassification.UNKNOWN
         else:
@@ -450,7 +446,7 @@ class GqlError(Exception):
     def gql_classification(self) -> GqlErrorClassification:
         return self._gql_classification_no_preview
 
-    def _get_status_diagnostic_record(self) -> dict[str, t.Any]:
+    def _get_status_diagnostic_record(self) -> dict[str, _t.Any]:
         if hasattr(self, "_status_diagnostic_record"):
             return self._status_diagnostic_record
 
@@ -458,7 +454,7 @@ class GqlError(Exception):
         return self._status_diagnostic_record
 
     @property
-    def _diagnostic_record_no_preview(self) -> Mapping[str, t.Any]:
+    def _diagnostic_record_no_preview(self) -> _t.Mapping[str, _t.Any]:
         if hasattr(self, "_diagnostic_record"):
             return self._diagnostic_record
 
@@ -469,7 +465,7 @@ class GqlError(Exception):
 
     @property
     @_preview("GQLSTATUS support is a preview feature.")
-    def diagnostic_record(self) -> Mapping[str, t.Any]:
+    def diagnostic_record(self) -> _t.Mapping[str, _t.Any]:
         return self._diagnostic_record_no_preview
 
     def __str__(self):
@@ -493,7 +489,7 @@ class Neo4jError(GqlError):
     _category: str
     _title: str
     #: (dict) Any additional information returned by the server.
-    _metadata: dict[str, t.Any]
+    _metadata: dict[str, _t.Any]
     _from_server: bool
 
     _retryable = False
@@ -508,7 +504,7 @@ class Neo4jError(GqlError):
         )
 
     @staticmethod
-    def _hydrate_neo4j(**metadata: t.Any) -> Neo4jError:
+    def _hydrate_neo4j(**metadata: _t.Any) -> Neo4jError:
         meta_extractor = _MetaExtractor(metadata)
         code = meta_extractor.str_value("code") or _UNKNOWN_NEO4J_CODE
         message = meta_extractor.str_value("message") or _UNKNOWN_MESSAGE
@@ -525,7 +521,7 @@ class Neo4jError(GqlError):
         return inst
 
     @staticmethod
-    def _hydrate_gql(**metadata: t.Any) -> Neo4jError:
+    def _hydrate_gql(**metadata: _t.Any) -> Neo4jError:
         meta_extractor = _MetaExtractor(metadata)
         gql_status = meta_extractor.str_value("gql_status")
         status_description = meta_extractor.str_value("description")
@@ -643,7 +639,7 @@ class Neo4jError(GqlError):
         return self._title
 
     @property
-    def metadata(self) -> dict[str, t.Any]:
+    def metadata(self) -> dict[str, _t.Any]:
         # Undocumented, might be useful for debugging
         return self._metadata
 
@@ -709,16 +705,16 @@ class Neo4jError(GqlError):
 
 
 class _MetaExtractor:
-    def __init__(self, metadata: dict[str, t.Any]) -> None:
+    def __init__(self, metadata: dict[str, _t.Any]) -> None:
         self._metadata = metadata
 
-    def rest(self) -> dict[str, t.Any]:
+    def rest(self) -> dict[str, _t.Any]:
         return self._metadata
 
-    @t.overload
+    @_t.overload
     def str_value(self, key: str) -> str | None: ...
 
-    @t.overload
+    @_t.overload
     def str_value(self, key: str, default: _T) -> str | _T: ...
 
     def str_value(
@@ -729,15 +725,15 @@ class _MetaExtractor:
             res = default
         return res
 
-    @t.overload
-    def map_value(self, key: str) -> dict[str, t.Any] | None: ...
+    @_t.overload
+    def map_value(self, key: str) -> dict[str, _t.Any] | None: ...
 
-    @t.overload
-    def map_value(self, key: str, default: _T) -> dict[str, t.Any] | _T: ...
+    @_t.overload
+    def map_value(self, key: str, default: _T) -> dict[str, _t.Any] | _T: ...
 
     def map_value(
         self, key: str, default: _T | None = None
-    ) -> dict[str, t.Any] | _T | None:
+    ) -> dict[str, _t.Any] | _T | None:
         res = self._metadata.pop(key, default)
         if not (
             isinstance(res, dict) and all(isinstance(k, str) for k in res)

--- a/src/neo4j/graph/__init__.py
+++ b/src/neo4j/graph/__init__.py
@@ -18,11 +18,12 @@
 
 from __future__ import annotations
 
-import typing as t
 from collections.abc import Mapping
 
+from .. import _typing as _t
 
-if t.TYPE_CHECKING:
+
+if _t.TYPE_CHECKING:
     from typing_extensions import deprecated
 else:
     from .._warnings import deprecated
@@ -36,7 +37,7 @@ __all__ = [
 ]
 
 
-_T = t.TypeVar("_T")
+_T = _t.TypeVar("_T")
 
 
 class Graph:
@@ -71,7 +72,7 @@ class Graph:
         try:
             cls = self._relationship_types[name]
         except KeyError:
-            cls = self._relationship_types[name] = t.cast(
+            cls = self._relationship_types[name] = _t.cast(
                 type[Relationship], type(str(name), (Relationship,), {})
             )
         return cls
@@ -92,7 +93,7 @@ class Graph:
         return graph
 
 
-class Entity(t.Mapping[str, t.Any]):
+class Entity(_t.Mapping[str, _t.Any]):
     """
     Graph entity base.
 
@@ -106,7 +107,7 @@ class Entity(t.Mapping[str, t.Any]):
         graph: Graph,
         element_id: str,
         id_: int,
-        properties: dict[str, t.Any] | None,
+        properties: dict[str, _t.Any] | None,
     ) -> None:
         self._graph = graph
         self._element_id = element_id
@@ -115,7 +116,7 @@ class Entity(t.Mapping[str, t.Any]):
             k: v for k, v in (properties or {}).items() if v is not None
         }
 
-    def __eq__(self, other: t.Any) -> bool:
+    def __eq__(self, other: _t.Any) -> bool:
         # TODO: 6.0 - return NotImplemented on type mismatch instead of False
         try:
             return (
@@ -135,13 +136,13 @@ class Entity(t.Mapping[str, t.Any]):
     def __len__(self) -> int:
         return len(self._properties)
 
-    def __getitem__(self, name: str) -> t.Any:
+    def __getitem__(self, name: str) -> _t.Any:
         return self._properties.get(name)
 
     def __contains__(self, name: object) -> bool:
         return name in self._properties
 
-    def __iter__(self) -> t.Iterator[str]:
+    def __iter__(self) -> _t.Iterator[str]:
         return iter(self._properties)
 
     @property
@@ -182,24 +183,24 @@ class Entity(t.Mapping[str, t.Any]):
         """
         return self._element_id
 
-    def get(self, name: str, default: object = None) -> t.Any:
+    def get(self, name: str, default: object = None) -> _t.Any:
         """Get a property value by name, optionally with a default."""
         return self._properties.get(name, default)
 
-    def keys(self) -> t.KeysView[str]:
+    def keys(self) -> _t.KeysView[str]:
         """Return an iterable of all property names."""
         return self._properties.keys()
 
-    def values(self) -> t.ValuesView[t.Any]:
+    def values(self) -> _t.ValuesView[_t.Any]:
         """Return an iterable of all property values."""
         return self._properties.values()
 
-    def items(self) -> t.ItemsView[str, t.Any]:
+    def items(self) -> _t.ItemsView[str, _t.Any]:
         """Return an iterable of all property name-value pairs."""
         return self._properties.items()
 
 
-class EntitySetView(Mapping, t.Generic[_T]):
+class EntitySetView(Mapping, _t.Generic[_T]):
     """View of a set of :class:`.Entity` instances within a :class:`.Graph`."""
 
     def __init__(
@@ -214,7 +215,7 @@ class EntitySetView(Mapping, t.Generic[_T]):
     def __len__(self) -> int:
         return len(self._entity_dict)
 
-    def __iter__(self) -> t.Iterator[_T]:
+    def __iter__(self) -> _t.Iterator[_T]:
         return iter(self._entity_dict.values())
 
 
@@ -226,8 +227,8 @@ class Node(Entity):
         graph: Graph,
         element_id: str,
         id_: int,
-        n_labels: t.Iterable[str] | None = None,
-        properties: dict[str, t.Any] | None = None,
+        n_labels: _t.Iterable[str] | None = None,
+        properties: dict[str, _t.Any] | None = None,
     ) -> None:
         Entity.__init__(self, graph, element_id, id_, properties)
         self._labels = frozenset(n_labels or ())
@@ -252,7 +253,7 @@ class Relationship(Entity):
         graph: Graph,
         element_id: str,
         id_: int,
-        properties: dict[str, t.Any],
+        properties: dict[str, _t.Any],
     ) -> None:
         Entity.__init__(self, graph, element_id, id_, properties)
         self._start_node: Node | None = None
@@ -307,9 +308,9 @@ class Path:
         for i, relationship in enumerate(relationships, start=1):
             assert isinstance(relationship, Relationship)
             if relationship.start_node == nodes[-1]:
-                nodes.append(t.cast(Node, relationship.end_node))
+                nodes.append(_t.cast(Node, relationship.end_node))
             elif relationship.end_node == nodes[-1]:
-                nodes.append(t.cast(Node, relationship.start_node))
+                nodes.append(_t.cast(Node, relationship.start_node))
             else:
                 raise ValueError(
                     f"Relationship {i} does not connect to the last node"
@@ -323,7 +324,7 @@ class Path:
             f"size={len(self)}>"
         )
 
-    def __eq__(self, other: t.Any) -> bool:
+    def __eq__(self, other: _t.Any) -> bool:
         # TODO: 6.0 - return NotImplemented on type mismatch instead of False
         try:
             return (
@@ -345,7 +346,7 @@ class Path:
     def __len__(self) -> int:
         return len(self._relationships)
 
-    def __iter__(self) -> t.Iterator[Relationship]:
+    def __iter__(self) -> _t.Iterator[Relationship]:
         return iter(self._relationships)
 
     @property

--- a/src/neo4j/spatial/__init__.py
+++ b/src/neo4j/spatial/__init__.py
@@ -18,8 +18,9 @@
 
 from __future__ import annotations as _
 
-import typing as _t
 from threading import Lock as _Lock
+
+from .. import _typing as _t
 
 
 __all__ = [

--- a/src/neo4j/time/__init__.py
+++ b/src/neo4j/time/__init__.py
@@ -24,7 +24,6 @@ as a number of utility functions.
 from __future__ import annotations
 
 import re
-import typing as t
 from datetime import (
     date,
     datetime,
@@ -41,10 +40,7 @@ from time import (
     struct_time,
 )
 
-
-if t.TYPE_CHECKING:
-    import typing_extensions as te
-
+from .. import _typing as _t
 from ._arithmetic import (
     round_half_to_even,
     symmetric_divmod,
@@ -79,12 +75,12 @@ MAX_INT64 = (2**63) - 1
 #: The smallest year number allowed in a :class:`.Date` or :class:`.DateTime`
 #: object to be compatible with :class:`datetime.date` and
 #: :class:`datetime.datetime`.
-MIN_YEAR: te.Final[int] = 1
+MIN_YEAR: _t.Final[int] = 1
 
 #: The largest year number allowed in a :class:`.Date` or :class:`.DateTime`
 #: object to be compatible with :class:`datetime.date` and
 #: :class:`datetime.datetime`.
-MAX_YEAR: te.Final[int] = 9999
+MAX_YEAR: _t.Final[int] = 9999
 
 DATE_ISO_PATTERN = re_compile(r"^(\d{4})-(\d{2})-(\d{2})$")
 TIME_ISO_PATTERN = re_compile(
@@ -373,7 +369,7 @@ class Clock:
         raise NotImplementedError("No clock implementation selected")
 
 
-if t.TYPE_CHECKING:
+if _t.TYPE_CHECKING:
     # make typechecker believe that Duration subclasses datetime.timedelta
     # https://github.com/python/typeshed/issues/8409#issuecomment-1197704527
     duration_base_class = timedelta
@@ -429,10 +425,10 @@ class Duration(  # type: ignore[misc]
 
     # i64: i64:i64: i32
 
-    min: te.Final[Duration] = None  # type: ignore
+    min: _t.Final[Duration] = None  # type: ignore
     """The lowest duration value possible."""
 
-    max: te.Final[Duration] = None  # type: ignore
+    max: _t.Final[Duration] = None  # type: ignore
     """The highest duration value possible."""
 
     def __new__(
@@ -791,7 +787,7 @@ Duration.max = Duration(  # type: ignore
 )
 
 
-if t.TYPE_CHECKING:
+if _t.TYPE_CHECKING:
     # make typechecker believe that Date subclasses datetime.date
     # https://github.com/python/typeshed/issues/8409#issuecomment-1197704527
     date_base_class = date
@@ -1060,7 +1056,7 @@ class Date(date_base_class, metaclass=DateType):
 
     # CLASS METHOD ALIASES #
 
-    if t.TYPE_CHECKING:
+    if _t.TYPE_CHECKING:
 
         @classmethod
         def fromisoformat(cls, s: str) -> Date: ...
@@ -1078,13 +1074,13 @@ class Date(date_base_class, metaclass=DateType):
 
     # CLASS ATTRIBUTES #
 
-    min: te.Final[Date] = None  # type: ignore
+    min: _t.Final[Date] = None  # type: ignore
     """The earliest date value possible."""
 
-    max: te.Final[Date] = None  # type: ignore
+    max: _t.Final[Date] = None  # type: ignore
     """The latest date value possible."""
 
-    resolution: te.Final[Duration] = None  # type: ignore
+    resolution: _t.Final[Duration] = None  # type: ignore
     """The minimum resolution supported."""
 
     # INSTANCE ATTRIBUTES #
@@ -1287,10 +1283,10 @@ class Date(date_base_class, metaclass=DateType):
             return new_date
         return NotImplemented
 
-    @t.overload  # type: ignore[override]
+    @_t.overload  # type: ignore[override]
     def __sub__(self, other: Date | date) -> Duration: ...
 
-    @t.overload
+    @_t.overload
     def __sub__(self, other: Duration) -> Date: ...
 
     def __sub__(self, other):
@@ -1325,13 +1321,13 @@ class Date(date_base_class, metaclass=DateType):
 
     # INSTANCE METHODS #
 
-    if t.TYPE_CHECKING:
+    if _t.TYPE_CHECKING:
 
         def replace(
             self,
-            year: te.SupportsIndex = ...,
-            month: te.SupportsIndex = ...,
-            day: te.SupportsIndex = ...,
+            year: _t.SupportsIndex = ...,
+            month: _t.SupportsIndex = ...,
+            day: _t.SupportsIndex = ...,
             **kwargs: object,
         ) -> Date: ...
 
@@ -1452,7 +1448,7 @@ class Date(date_base_class, metaclass=DateType):
         except KeyError:
             raise AttributeError(f"Date has no attribute {name!r}") from None
 
-    if t.TYPE_CHECKING:
+    if _t.TYPE_CHECKING:
 
         def iso_calendar(self) -> tuple[int, int, int]: ...
 
@@ -1472,7 +1468,7 @@ Date.resolution = Duration(days=1)  # type: ignore
 ZeroDate = object.__new__(Date)
 
 
-if t.TYPE_CHECKING:
+if _t.TYPE_CHECKING:
     # make typechecker believe that Time subclasses datetime.time
     # https://github.com/python/typeshed/issues/8409#issuecomment-1197704527
     time_base_class = time
@@ -1770,7 +1766,7 @@ class Time(time_base_class, metaclass=TimeType):
 
     # CLASS METHOD ALIASES #
 
-    if t.TYPE_CHECKING:
+    if _t.TYPE_CHECKING:
 
         @classmethod
         def from_iso_format(cls, s: str) -> Time: ...
@@ -1780,13 +1776,13 @@ class Time(time_base_class, metaclass=TimeType):
 
     # CLASS ATTRIBUTES #
 
-    min: te.Final[Time] = None  # type: ignore
+    min: _t.Final[Time] = None  # type: ignore
     """The earliest time value possible."""
 
-    max: te.Final[Time] = None  # type: ignore
+    max: _t.Final[Time] = None  # type: ignore
     """The latest time value possible."""
 
-    resolution: te.Final[Duration] = None  # type: ignore
+    resolution: _t.Final[Duration] = None  # type: ignore
     """The minimum resolution supported."""
 
     # INSTANCE ATTRIBUTES #
@@ -1940,14 +1936,14 @@ class Time(time_base_class, metaclass=TimeType):
 
     # INSTANCE METHODS #
 
-    if t.TYPE_CHECKING:
+    if _t.TYPE_CHECKING:
 
         def replace(  # type: ignore[override]
             self,
-            hour: te.SupportsIndex = ...,
-            minute: te.SupportsIndex = ...,
-            second: te.SupportsIndex = ...,
-            nanosecond: te.SupportsIndex = ...,
+            hour: _t.SupportsIndex = ...,
+            minute: _t.SupportsIndex = ...,
+            second: _t.SupportsIndex = ...,
+            nanosecond: _t.SupportsIndex = ...,
             tzinfo: _tzinfo | None = ...,
             **kwargs: object,
         ) -> Time: ...
@@ -2106,7 +2102,7 @@ class Time(time_base_class, metaclass=TimeType):
         except KeyError:
             raise AttributeError(f"Date has no attribute {name!r}") from None
 
-    if t.TYPE_CHECKING:
+    if _t.TYPE_CHECKING:
 
         def isoformat(self) -> str:  # type: ignore[override]
             ...
@@ -2126,14 +2122,14 @@ Time.resolution = Duration(  # type: ignore
 
 #: A :class:`.Time` instance set to `00:00:00`.
 #: This has a :attr:`.ticks` value of `0`.
-Midnight: te.Final[Time] = Time.min
+Midnight: _t.Final[Time] = Time.min
 
 #: A :class:`.Time` instance set to `12:00:00`.
 #: This has a :attr:`.ticks` value of `43200000000000`.
-Midday: te.Final[Time] = Time(hour=12)
+Midday: _t.Final[Time] = Time(hour=12)
 
 
-if t.TYPE_CHECKING:
+if _t.TYPE_CHECKING:
     # make typechecker believe that DateTime subclasses datetime.datetime
     # https://github.com/python/typeshed/issues/8409#issuecomment-1197704527
     date_time_base_class = datetime
@@ -2360,7 +2356,7 @@ class DateTime(date_time_base_class, metaclass=DateTimeType):
 
     # CLASS METHOD ALIASES #
 
-    if t.TYPE_CHECKING:
+    if _t.TYPE_CHECKING:
 
         @classmethod
         def fromisoformat(cls, s) -> DateTime: ...
@@ -2389,13 +2385,13 @@ class DateTime(date_time_base_class, metaclass=DateTimeType):
 
     # CLASS ATTRIBUTES #
 
-    min: te.Final[DateTime] = None  # type: ignore
+    min: _t.Final[DateTime] = None  # type: ignore
     """The earliest date time value possible."""
 
-    max: te.Final[DateTime] = None  # type: ignore
+    max: _t.Final[DateTime] = None  # type: ignore
     """The latest date time value possible."""
 
-    resolution: te.Final[Duration] = None  # type: ignore
+    resolution: _t.Final[Duration] = None  # type: ignore
     """The minimum resolution supported."""
 
     # INSTANCE ATTRIBUTES #
@@ -2672,13 +2668,13 @@ class DateTime(date_time_base_class, metaclass=DateTimeType):
             return self.combine(date_, time_).replace(tzinfo=self.tzinfo)
         return NotImplemented
 
-    @t.overload  # type: ignore[override]
+    @_t.overload  # type: ignore[override]
     def __sub__(self, other: DateTime) -> Duration: ...
 
-    @t.overload
+    @_t.overload
     def __sub__(self, other: datetime) -> timedelta: ...
 
-    @t.overload
+    @_t.overload
     def __sub__(self, other: Duration | timedelta) -> DateTime: ...
 
     def __sub__(self, other):
@@ -2747,17 +2743,17 @@ class DateTime(date_time_base_class, metaclass=DateTimeType):
         """Get the time with timezone info."""
         return self.__time
 
-    if t.TYPE_CHECKING:
+    if _t.TYPE_CHECKING:
 
         def replace(  # type: ignore[override]
             self,
-            year: te.SupportsIndex = ...,
-            month: te.SupportsIndex = ...,
-            day: te.SupportsIndex = ...,
-            hour: te.SupportsIndex = ...,
-            minute: te.SupportsIndex = ...,
-            second: te.SupportsIndex = ...,
-            nanosecond: te.SupportsIndex = ...,
+            year: _t.SupportsIndex = ...,
+            month: _t.SupportsIndex = ...,
+            day: _t.SupportsIndex = ...,
+            hour: _t.SupportsIndex = ...,
+            minute: _t.SupportsIndex = ...,
+            second: _t.SupportsIndex = ...,
+            nanosecond: _t.SupportsIndex = ...,
             tzinfo: _tzinfo | None = ...,
             **kwargs: object,
         ) -> DateTime: ...
@@ -2787,7 +2783,7 @@ class DateTime(date_time_base_class, metaclass=DateTimeType):
         """
         if self.tzinfo is None:
             return self
-        offset = t.cast(timedelta, self.utcoffset())
+        offset = _t.cast(timedelta, self.utcoffset())
         utc = (self - offset).replace(tzinfo=tz)
         try:
             return tz.fromutc(utc)  # type: ignore
@@ -2953,7 +2949,7 @@ class DateTime(date_time_base_class, metaclass=DateTimeType):
                 f"DateTime has no attribute {name!r}"
             ) from None
 
-    if t.TYPE_CHECKING:
+    if _t.TYPE_CHECKING:
 
         def astimezone(  # type: ignore[override]
             self, tz: _tzinfo

--- a/src/neo4j/time/_arithmetic.py
+++ b/src/neo4j/time/_arithmetic.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-from typing import TypeVar
+from .. import _typing as t
 
 
 __all__ = [
@@ -86,7 +86,7 @@ def nano_divmod(x, y):
     return int(q), number(r / 1000000000)
 
 
-_TDividend = TypeVar("_TDividend", int, float)
+_TDividend = t.TypeVar("_TDividend", int, float)
 
 
 def symmetric_divmod(

--- a/src/neo4j/warnings.py
+++ b/src/neo4j/warnings.py
@@ -16,12 +16,11 @@
 
 from __future__ import annotations
 
-import typing as t
-
+from . import _typing as _t
 from ._debug import NotificationPrinter
 
 
-if t.TYPE_CHECKING:
+if _t.TYPE_CHECKING:
     from ._work.summary import SummaryNotification
 
 

--- a/testkitbackend/_async/requests.py
+++ b/testkitbackend/_async/requests.py
@@ -49,12 +49,10 @@ from ..exceptions import MarkdAsDriverError
 
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
-
     from neo4j._auth_management import ClientCertificate
 
     T = t.TypeVar("T")
-    P = te.ParamSpec("P")
+    P = t.ParamSpec("P")
 
 
 def snake_case_to_pascal_case(name: str) -> str:

--- a/testkitbackend/_sync/requests.py
+++ b/testkitbackend/_sync/requests.py
@@ -49,12 +49,10 @@ from ..exceptions import MarkdAsDriverError
 
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
-
     from neo4j._auth_management import ClientCertificate
 
     T = t.TypeVar("T")
-    P = te.ParamSpec("P")
+    P = t.ParamSpec("P")
 
 
 def snake_case_to_pascal_case(name: str) -> str:

--- a/tests/unit/async_/test_driver.py
+++ b/tests/unit/async_/test_driver.py
@@ -18,17 +18,13 @@ from __future__ import annotations
 
 import inspect
 import ssl
-import typing as t
 import warnings
 
 import pytest
 
-
-if t.TYPE_CHECKING:
-    import typing_extensions as te
-
 import neo4j
 from neo4j import (
+    _typing as t,
     AsyncBoltDriver,
     AsyncGraphDatabase,
     AsyncNeo4jDriver,
@@ -497,7 +493,7 @@ async def test_with_custom_ducktype_client_certificate_provider(
 if t.TYPE_CHECKING:
     _T_NotificationMinimumSeverity: t.TypeAlias = (
         NotificationMinimumSeverity
-        | te.Literal[
+        | t.Literal[
             "OFF",
             "WARNING",
             "INFORMATION",
@@ -506,7 +502,7 @@ if t.TYPE_CHECKING:
 
     _T_NotificationDisabledCategory: t.TypeAlias = (
         NotificationDisabledCategory
-        | te.Literal[
+        | t.Literal[
             "HINT",
             "UNRECOGNIZED",
             "UNSUPPORTED",
@@ -518,7 +514,7 @@ if t.TYPE_CHECKING:
 
     _T_NotificationDisabledClassification: t.TypeAlias = (
         NotificationDisabledClassification
-        | te.Literal[
+        | t.Literal[
             "HINT",
             "UNRECOGNIZED",
             "UNSUPPORTED",
@@ -531,14 +527,14 @@ if t.TYPE_CHECKING:
 
 if t.TYPE_CHECKING:
 
-    class NotificationFilter(te.TypedDict):
-        notifications_min_severity: te.NotRequired[
+    class NotificationFilter(t.TypedDict):
+        notifications_min_severity: t.NotRequired[
             _T_NotificationMinimumSeverity | None
         ]
-        notifications_disabled_categories: te.NotRequired[
+        notifications_disabled_categories: t.NotRequired[
             t.Iterable[_T_NotificationDisabledCategory] | None
         ]
-        notifications_disabled_classifications: te.NotRequired[
+        notifications_disabled_classifications: t.NotRequired[
             t.Iterable[_T_NotificationDisabledClassification] | None
         ]
 
@@ -907,7 +903,7 @@ async def test_execute_query_work(mocker) -> None:
 @pytest.mark.parametrize("positional", (True, False))
 @mark_async_test
 async def test_execute_query_query(
-    query: te.LiteralString | Query,
+    query: t.LiteralString | Query,
     positional: bool,
     session_cls_mock,
     unit_of_work_mock,
@@ -1123,7 +1119,7 @@ async def test_execute_query_parameter_precedence(
 async def test_execute_query_routing_control(
     mode: str,
     positional: bool,
-    routing_mode: neo4j.RoutingControl | te.Literal["r", "w"] | None,
+    routing_mode: neo4j.RoutingControl | t.Literal["r", "w"] | None,
     session_cls_mock,
     mocker,
 ) -> None:

--- a/tests/unit/common/graph/test_graph.py
+++ b/tests/unit/common/graph/test_graph.py
@@ -18,19 +18,21 @@ from __future__ import annotations
 
 import copy
 import pickle
-import typing as t
 from itertools import zip_longest
 
 import pytest
 
-
-if t.TYPE_CHECKING:
-    import typing_extensions as te
-
-    from neo4j.graph import Graph, Node, Relationship
-
+from neo4j import _typing as t
 from neo4j._codec.hydration.v1.hydration_handler import _GraphHydrator
 from neo4j.graph import Path
+
+
+if t.TYPE_CHECKING:
+    from neo4j.graph import (
+        Graph,
+        Node,
+        Relationship,
+    )
 
 
 class GraphBuilder:
@@ -39,7 +41,7 @@ class GraphBuilder:
         self._node_counter = 0
         self._relationship_counter = 0
 
-    def with_node(self, *labels, **properties) -> te.Self:
+    def with_node(self, *labels, **properties) -> t.Self:
         id_ = self._node_counter
         element_id = f"e{id_}"
         self._node_counter += 1
@@ -48,7 +50,7 @@ class GraphBuilder:
 
     def with_relationship(
         self, start_node_id, end_node_id, type_, **properties
-    ) -> te.Self:
+    ) -> t.Self:
         id_ = self._relationship_counter
         element_id = f"e{id_}"
         start_node_element_id = f"e{start_node_id}"

--- a/tests/unit/common/test_debug.py
+++ b/tests/unit/common/test_debug.py
@@ -20,22 +20,20 @@ import asyncio
 import io
 import logging
 import sys
-import typing as t
 
 import pytest
 
-
-if t.TYPE_CHECKING:
-    import typing_extensions as te
-
-from neo4j import debug as neo4j_debug
+from neo4j import (
+    _typing as t,
+    debug as neo4j_debug,
+)
 
 from ..._async_compat import mark_async_test
 
 
 if t.TYPE_CHECKING:
 
-    class _TSetupMockProtocol(te.Protocol):
+    class _TSetupMockProtocol(t.Protocol):
         def __call__(self, *args: str) -> t.Sequence[t.Any]: ...
 
 

--- a/tests/unit/common/work/test_summary.py
+++ b/tests/unit/common/work/test_summary.py
@@ -23,8 +23,6 @@ import warnings
 if t.TYPE_CHECKING:
     from collections.abc import Sequence
 
-    import typing_extensions as te
-
     _T = t.TypeVar("_T")
     _TDict = t.TypeVar("_TDict", bound=dict)
 
@@ -134,7 +132,7 @@ def test_summary_query_type(summary_args_kwargs, summary_in) -> None:
         kwargs["metadata"]["type"] = summary_in
 
     summary = ResultSummary(*args, **kwargs)
-    summary_out: te.Literal["r", "w", "rw", "s"] | None
+    summary_out: t.Literal["r", "w", "rw", "s"] | None
     summary_out = summary.query_type
 
     assert summary_out is summary_in
@@ -307,7 +305,7 @@ class StatusOrderHelper:
     @staticmethod
     def make_raw_status(
         i: int,
-        type_: te.Literal[
+        type_: t.Literal[
             "WARNING", "INFORMATION", "SUCCESS", "OMITTED", "NODATA"
         ],
     ) -> dict:
@@ -342,7 +340,7 @@ class StatusOrderHelper:
     def assert_notification_is_status(
         notification: dict,
         i: int,
-        type_: te.Literal[
+        type_: t.Literal[
             "WARNING", "INFORMATION", "SUCCESS", "OMITTED", "NODATA"
         ],
     ) -> None:
@@ -352,7 +350,7 @@ class StatusOrderHelper:
     def assert_parsed_notification_is_status(
         notification: SummaryNotification,
         i: int,
-        type_: te.Literal[
+        type_: t.Literal[
             "WARNING", "INFORMATION", "SUCCESS", "OMITTED", "NODATA"
         ],
     ) -> None:
@@ -362,7 +360,7 @@ class StatusOrderHelper:
     def assert_status_data_matches(
         status: GqlStatusObject,
         i: int,
-        type_: te.Literal[
+        type_: t.Literal[
             "WARNING", "INFORMATION", "SUCCESS", "OMITTED", "NODATA"
         ],
     ) -> None:
@@ -1349,7 +1347,7 @@ def test_status_from_notifications(
 
 def update_summary_kwargs_result_type(
     kwargs: dict,
-    result_type: te.Literal["success", "no data", "omitted result"],
+    result_type: t.Literal["success", "no data", "omitted result"],
 ) -> dict:
     if result_type == "success":
         kwargs["had_key"] = True

--- a/tests/unit/fixtures/notifications.py
+++ b/tests/unit/fixtures/notifications.py
@@ -16,40 +16,37 @@
 
 from __future__ import annotations
 
-import typing as t
-
 import pytest
 
+from neo4j import (
+    _typing as t,
+    SummaryNotification,
+)
+
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
 
-from neo4j import SummaryNotification
+    class Position(t.TypedDict):
+        offset: t.NotRequired[int | None]
+        line: t.NotRequired[int | None]
+        column: t.NotRequired[int | None]
 
+    class TNotificationData(t.TypedDict):
+        code: t.NotRequired[str | None]
+        severity: t.NotRequired[str | None]
+        title: t.NotRequired[str | None]
+        description: t.NotRequired[str | None]
+        category: t.NotRequired[str | None]
+        position: t.NotRequired[Position | None]
 
-if t.TYPE_CHECKING:
-
-    class Position(te.TypedDict):
-        offset: te.NotRequired[int | None]
-        line: te.NotRequired[int | None]
-        column: te.NotRequired[int | None]
-
-    class TNotificationData(te.TypedDict):
-        code: te.NotRequired[str | None]
-        severity: te.NotRequired[str | None]
-        title: te.NotRequired[str | None]
-        description: te.NotRequired[str | None]
-        category: te.NotRequired[str | None]
-        position: te.NotRequired[Position | None]
-
-    class TNotificationFactory(te.Protocol):
+    class TNotificationFactory(t.Protocol):
         def __call__(
             self,
             data: TNotificationData | None = None,
             data_overwrite: TNotificationData | None = None,
         ) -> SummaryNotification: ...
 
-    class TRawNotificationFactory(te.Protocol):
+    class TRawNotificationFactory(t.Protocol):
         def __call__(
             self,
             data: TNotificationData | None = None,

--- a/tests/unit/mixed/async_compat/test_network.py
+++ b/tests/unit/mixed/async_compat/test_network.py
@@ -18,11 +18,11 @@ from __future__ import annotations
 
 import asyncio
 import socket
-import typing as t
 
 import freezegun
 import pytest
 
+from neo4j import _typing as t
 from neo4j._async.io._bolt_socket import AsyncBoltSocket
 from neo4j._exceptions import SocketDeadlineExceededError
 
@@ -30,14 +30,13 @@ from ...._async_compat.mark_decorator import mark_async_test
 
 
 if t.TYPE_CHECKING:
-    import typing_extensions as te
     from freezegun.api import (
         FrozenDateTimeFactory,
         StepTickTimeFactory,
         TickingDateTimeFactory,
     )
 
-    TFreezeTime: te.TypeAlias = (
+    TFreezeTime: t.TypeAlias = (
         StepTickTimeFactory | TickingDateTimeFactory | FrozenDateTimeFactory
     )
 

--- a/tests/unit/sync/test_driver.py
+++ b/tests/unit/sync/test_driver.py
@@ -18,17 +18,13 @@ from __future__ import annotations
 
 import inspect
 import ssl
-import typing as t
 import warnings
 
 import pytest
 
-
-if t.TYPE_CHECKING:
-    import typing_extensions as te
-
 import neo4j
 from neo4j import (
+    _typing as t,
     BoltDriver,
     GraphDatabase,
     Neo4jDriver,
@@ -496,7 +492,7 @@ def test_with_custom_ducktype_client_certificate_provider(
 if t.TYPE_CHECKING:
     _T_NotificationMinimumSeverity: t.TypeAlias = (
         NotificationMinimumSeverity
-        | te.Literal[
+        | t.Literal[
             "OFF",
             "WARNING",
             "INFORMATION",
@@ -505,7 +501,7 @@ if t.TYPE_CHECKING:
 
     _T_NotificationDisabledCategory: t.TypeAlias = (
         NotificationDisabledCategory
-        | te.Literal[
+        | t.Literal[
             "HINT",
             "UNRECOGNIZED",
             "UNSUPPORTED",
@@ -517,7 +513,7 @@ if t.TYPE_CHECKING:
 
     _T_NotificationDisabledClassification: t.TypeAlias = (
         NotificationDisabledClassification
-        | te.Literal[
+        | t.Literal[
             "HINT",
             "UNRECOGNIZED",
             "UNSUPPORTED",
@@ -530,14 +526,14 @@ if t.TYPE_CHECKING:
 
 if t.TYPE_CHECKING:
 
-    class NotificationFilter(te.TypedDict):
-        notifications_min_severity: te.NotRequired[
+    class NotificationFilter(t.TypedDict):
+        notifications_min_severity: t.NotRequired[
             _T_NotificationMinimumSeverity | None
         ]
-        notifications_disabled_categories: te.NotRequired[
+        notifications_disabled_categories: t.NotRequired[
             t.Iterable[_T_NotificationDisabledCategory] | None
         ]
-        notifications_disabled_classifications: te.NotRequired[
+        notifications_disabled_classifications: t.NotRequired[
             t.Iterable[_T_NotificationDisabledClassification] | None
         ]
 
@@ -906,7 +902,7 @@ def test_execute_query_work(mocker) -> None:
 @pytest.mark.parametrize("positional", (True, False))
 @mark_sync_test
 def test_execute_query_query(
-    query: te.LiteralString | Query,
+    query: t.LiteralString | Query,
     positional: bool,
     session_cls_mock,
     unit_of_work_mock,
@@ -1122,7 +1118,7 @@ def test_execute_query_parameter_precedence(
 def test_execute_query_routing_control(
     mode: str,
     positional: bool,
-    routing_mode: neo4j.RoutingControl | te.Literal["r", "w"] | None,
+    routing_mode: neo4j.RoutingControl | t.Literal["r", "w"] | None,
     session_cls_mock,
     mocker,
 ) -> None:


### PR DESCRIPTION
 * Move all imports for typing into a central file.  
   This will make upgrading easier when bumping the minimum Python version in the future. It also enables a more consistent code style.
 * Upgrade typing imports to be in line with the new Python 3.10 base-line.  
   E.g., import `collections.abc.Mapping` instead of `typing.Mapping`.
 * Moved some imports out of `if TYPE_CHECKING` blocks to help Sphinx produce useful type annotations in the docs again.