### PR TITLE
TestKit backend: remove `severity` fill from summary serialization

### DIFF
--- a/testkitbackend/totestkit.py
+++ b/testkitbackend/totestkit.py
@@ -61,7 +61,6 @@ def summary(summary_: neo4j.ResultSummary) -> dict:
             "description": n.description,
             "severityLevel": n.severity_level.name,
             "category": n.category.name,
-            "severity": n.raw_severity_level,
             "rawCategory": n.raw_category,
             "rawSeverityLevel": n.raw_severity_level,
         }


### PR DESCRIPTION
The driver API never had this field, so the backend was faking it.

Said API has been deprecated in other drivers and was now removed in 6.x. Therefore, the backend fill can also be removed. See also:

 * https://github.com/neo4j-drivers/testkit/pull/673