### PR TITLE
TestKit: skip connection acquisition timeout unification tests for now

### DIFF
--- a/testkitbackend/test_config.json
+++ b/testkitbackend/test_config.json
@@ -17,6 +17,10 @@
     "stub\\.routing\\.test_routing_v[0-9x]+\\.RoutingV[0-9x]+\\.test_should_drop_connections_failing_liveness_check":
       "Liveness check error handling is not (yet) unified: https://github.com/neo-technology/drivers-adr/pull/83",
     "'stub.homedb.test_homedb.TestHomeDbMixedCluster.test_connection_acquisition_timeout_during_fallback'":
+      "TODO: 6.0 - pending unification: connection acquisition timeout should count towards the total time spent waiting for a connection (including routing, home db resolution, ...)",
+    "'stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_does_encompass_router_route_response'":
+      "TODO: 6.0 - pending unification: connection acquisition timeout should count towards the total time spent waiting for a connection (including routing, home db resolution, ...)",
+    "'stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_router_handshake_shares_acquisition_timeout'":
       "TODO: 6.0 - pending unification: connection acquisition timeout should count towards the total time spent waiting for a connection (including routing, home db resolution, ...)"
   },
   "features": {


### PR DESCRIPTION
Skip tests adjusted in https://github.com/neo4j-drivers/testkit/pull/674 until we get around to implement the pending unification.