### PR TITLE
Unify `connection_acquisition_timeout` behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,12 +39,15 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
    (instead of internal `neo4j._exceptions.BoltHandshakeError`).  
     `UnsupportedServerProduct` is now a subclass of `ServiceUnavailable` (instead of `Exception` directly).
   - `connection_acquisition_timeout` configuration option
-    - `ValueError` on invalid values (instead of `ClientError`)
+    - Raise `ValueError` on invalid values (instead of `ClientError`).
     - Consistently restrict the value to be strictly positive
     - New `ConnectionAcquisitionTimeoutError` (subclass of `DriverError`) instead of `ClientError`
       (subclass of `Neo4jError`) the timeout is exceeded.
       - This improves the differentiation between `DriverError` for client-side errors and `Neo4jError` for server-side
         errors.
+    - The option now spans *anything* required to acquire a connection.  
+      This includes potential fetching of routing tables which in itself requires acquiring a connection.
+      Previously, the timeout would be restarted for such auxiliary connection acquisitions.
   - `TypeError` instead of `ValueError` when passing a `Query` object to `Transaction.run`.
   - `TransactionError` (subclass of `DriverError`) instead of `ClientError` (subclass of `Neo4jError`) when calling
     `session.run()` while an explicit transaction is active on that session.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -430,6 +430,11 @@ it should be chosen larger than :ref:`connection-timeout-ref`.
 :Type: ``float``
 :Default: ``60.0``
 
+.. versionadded:: 6.0
+    The setting now entails *anything* required to acquire a connection.
+    This includes potential fetching of routing tables which in itself requires acquiring a connection.
+    Previously, the timeout wold be restarted for such auxiliary connection acquisitions.
+
 
 .. _connection-timeout-ref:
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -433,7 +433,7 @@ it should be chosen larger than :ref:`connection-timeout-ref`.
 .. versionadded:: 6.0
     The setting now entails *anything* required to acquire a connection.
     This includes potential fetching of routing tables which in itself requires acquiring a connection.
-    Previously, the timeout wold be restarted for such auxiliary connection acquisitions.
+    Previously, the timeout would be restarted for such auxiliary connection acquisitions.
 
 
 .. _connection-timeout-ref:

--- a/src/neo4j/_async/io/__init__.py
+++ b/src/neo4j/_async/io/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "AsyncBoltPool",
     "AsyncNeo4jPool",
     "ConnectionErrorHandler",
+    "acquisition_timeout_to_deadline",
 ]
 
 
@@ -40,6 +41,7 @@ from . import (  # noqa - imports needed to register protocol handlers
 from ._bolt import AsyncBolt
 from ._common import ConnectionErrorHandler
 from ._pool import (
+    acquisition_timeout_to_deadline,
     AcquisitionAuth,
     AcquisitionDatabase,
     AsyncBoltPool,

--- a/src/neo4j/_async/io/_pool.py
+++ b/src/neo4j/_async/io/_pool.py
@@ -260,6 +260,8 @@ class AsyncIOPool(abc.ABC):
                     with self.lock:
                         self.connections_reservations[address] -= 1
 
+        if deadline.expired():
+            return None
         max_pool_size = self.pool_config.max_connection_pool_size
         infinite_pool_size = max_pool_size < 0 or max_pool_size == float("inf")
         with self.lock:
@@ -969,7 +971,9 @@ class AsyncNeo4jPool(AsyncIOPool):
 
         :raise neo4j.exceptions.ServiceUnavailable:
         """
-        _check_acquisition_timeout(acquisition_timeout)
+        acquisition_timeout = acquisition_timeout_to_deadline(
+            acquisition_timeout
+        )
         async with self.refresh_lock:
             routing_table = await self.get_routing_table(database)
             if routing_table is not None:
@@ -1147,7 +1151,7 @@ class AsyncNeo4jPool(AsyncIOPool):
         database_callback=None,
     ):
         access_mode = check_access_mode(access_mode)
-        _check_acquisition_timeout(timeout)
+        timeout = acquisition_timeout_to_deadline(timeout)
 
         target_database = database.name
 
@@ -1240,6 +1244,13 @@ class AsyncNeo4jPool(AsyncIOPool):
             if table is not None:
                 table.writers.discard(address)
         log.debug("[#0000]  _: <POOL> table=%r", self.routing_tables)
+
+
+def acquisition_timeout_to_deadline(timeout: object) -> Deadline:
+    if isinstance(timeout, Deadline):
+        return timeout
+    _check_acquisition_timeout(timeout)
+    return Deadline(timeout)
 
 
 def _check_acquisition_timeout(timeout: object) -> None:

--- a/src/neo4j/_async/io/_pool.py
+++ b/src/neo4j/_async/io/_pool.py
@@ -661,7 +661,7 @@ class AsyncBoltPool(AsyncIOPool):
         timeout,
         database,
         bookmarks,
-        auth: AcquisitionAuth,
+        auth: AcquisitionAuth | None,
         liveness_check_timeout,
         unprepared=False,
         database_callback=None,
@@ -669,14 +669,13 @@ class AsyncBoltPool(AsyncIOPool):
         # The access_mode and database is not needed for a direct connection,
         # it's just there for consistency.
         access_mode = check_access_mode(access_mode)
-        _check_acquisition_timeout(timeout)
+        deadline = acquisition_timeout_to_deadline(timeout)
         log.debug(
             "[#0000]  _: <POOL> acquire direct connection, "
             "access_mode=%r, database=%r",
             access_mode,
             database,
         )
-        deadline = Deadline.from_timeout_or_deadline(timeout)
         return await self._acquire(
             self.address, auth, deadline, liveness_check_timeout, unprepared
         )

--- a/src/neo4j/_async/work/workspace.py
+++ b/src/neo4j/_async/work/workspace.py
@@ -30,12 +30,14 @@ from ...exceptions import (
 )
 from .._debug import AsyncNonConcurrentMethodChecker
 from ..io import (
+    acquisition_timeout_to_deadline,
     AcquisitionAuth,
     AcquisitionDatabase,
 )
 
 
 if t.TYPE_CHECKING:
+    from ..._deadline import Deadline
     from ...api import _TAuth
     from ...auth_management import (
         AsyncAuthManager,
@@ -159,13 +161,19 @@ class AsyncWorkspace(AsyncNonConcurrentMethodChecker):
             await self._connection.fetch_all()
             await self._disconnect()
 
+        acquisition_deadline = acquisition_timeout_to_deadline(
+            acquisition_timeout
+        )
+
         ssr_enabled = self._pool.ssr_enabled
         target_db = await self._get_routing_target_database(
-            acquire_auth, ssr_enabled=ssr_enabled
+            acquire_auth,
+            ssr_enabled=ssr_enabled,
+            acquisition_deadline=acquisition_deadline,
         )
         acquire_kwargs_ = {
             "access_mode": access_mode,
-            "timeout": acquisition_timeout,
+            "timeout": acquisition_deadline,
             "database": target_db,
             "bookmarks": await self._get_bookmarks(),
             "auth": acquire_auth,
@@ -188,7 +196,9 @@ class AsyncWorkspace(AsyncNonConcurrentMethodChecker):
             )
             await self._disconnect()
             target_db = await self._get_routing_target_database(
-                acquire_auth, ssr_enabled=False
+                acquire_auth,
+                ssr_enabled=False,
+                acquisition_deadline=acquisition_deadline,
             )
             acquire_kwargs_["database"] = target_db
             self._connection = await self._pool.acquire(**acquire_kwargs_)
@@ -198,6 +208,7 @@ class AsyncWorkspace(AsyncNonConcurrentMethodChecker):
         self,
         acquire_auth: AcquisitionAuth,
         ssr_enabled: bool,
+        acquisition_deadline: Deadline,
     ) -> AcquisitionDatabase:
         if (
             self._pinned_database
@@ -232,14 +243,13 @@ class AsyncWorkspace(AsyncNonConcurrentMethodChecker):
                 )
                 return AcquisitionDatabase(cached_db, guessed=True)
 
-        acquisition_timeout = self._config.connection_acquisition_timeout
         log.debug("[#0000]  _: <WORKSPACE> resolve home database")
         await self._pool.update_routing_table(
             database=self._config.database,
             imp_user=self._config.impersonated_user,
             bookmarks=await self._get_bookmarks(),
             auth=acquire_auth,
-            acquisition_timeout=acquisition_timeout,
+            acquisition_timeout=acquisition_deadline,
             database_callback=self._make_db_resolution_callback(),
         )
         return AcquisitionDatabase(self._config.database)

--- a/src/neo4j/_sync/io/__init__.py
+++ b/src/neo4j/_sync/io/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "BoltPool",
     "Neo4jPool",
     "ConnectionErrorHandler",
+    "acquisition_timeout_to_deadline",
 ]
 
 
@@ -40,6 +41,7 @@ from . import (  # noqa - imports needed to register protocol handlers
 from ._bolt import Bolt
 from ._common import ConnectionErrorHandler
 from ._pool import (
+    acquisition_timeout_to_deadline,
     AcquisitionAuth,
     AcquisitionDatabase,
     BoltPool,

--- a/src/neo4j/_sync/io/_pool.py
+++ b/src/neo4j/_sync/io/_pool.py
@@ -658,7 +658,7 @@ class BoltPool(IOPool):
         timeout,
         database,
         bookmarks,
-        auth: AcquisitionAuth,
+        auth: AcquisitionAuth | None,
         liveness_check_timeout,
         unprepared=False,
         database_callback=None,
@@ -666,14 +666,13 @@ class BoltPool(IOPool):
         # The access_mode and database is not needed for a direct connection,
         # it's just there for consistency.
         access_mode = check_access_mode(access_mode)
-        _check_acquisition_timeout(timeout)
+        deadline = acquisition_timeout_to_deadline(timeout)
         log.debug(
             "[#0000]  _: <POOL> acquire direct connection, "
             "access_mode=%r, database=%r",
             access_mode,
             database,
         )
-        deadline = Deadline.from_timeout_or_deadline(timeout)
         return self._acquire(
             self.address, auth, deadline, liveness_check_timeout, unprepared
         )

--- a/src/neo4j/_sync/io/_pool.py
+++ b/src/neo4j/_sync/io/_pool.py
@@ -257,6 +257,8 @@ class IOPool(abc.ABC):
                     with self.lock:
                         self.connections_reservations[address] -= 1
 
+        if deadline.expired():
+            return None
         max_pool_size = self.pool_config.max_connection_pool_size
         infinite_pool_size = max_pool_size < 0 or max_pool_size == float("inf")
         with self.lock:
@@ -966,7 +968,9 @@ class Neo4jPool(IOPool):
 
         :raise neo4j.exceptions.ServiceUnavailable:
         """
-        _check_acquisition_timeout(acquisition_timeout)
+        acquisition_timeout = acquisition_timeout_to_deadline(
+            acquisition_timeout
+        )
         with self.refresh_lock:
             routing_table = self.get_routing_table(database)
             if routing_table is not None:
@@ -1144,7 +1148,7 @@ class Neo4jPool(IOPool):
         database_callback=None,
     ):
         access_mode = check_access_mode(access_mode)
-        _check_acquisition_timeout(timeout)
+        timeout = acquisition_timeout_to_deadline(timeout)
 
         target_database = database.name
 
@@ -1237,6 +1241,13 @@ class Neo4jPool(IOPool):
             if table is not None:
                 table.writers.discard(address)
         log.debug("[#0000]  _: <POOL> table=%r", self.routing_tables)
+
+
+def acquisition_timeout_to_deadline(timeout: object) -> Deadline:
+    if isinstance(timeout, Deadline):
+        return timeout
+    _check_acquisition_timeout(timeout)
+    return Deadline(timeout)
 
 
 def _check_acquisition_timeout(timeout: object) -> None:

--- a/src/neo4j/_sync/work/workspace.py
+++ b/src/neo4j/_sync/work/workspace.py
@@ -30,12 +30,14 @@ from ...exceptions import (
 )
 from .._debug import NonConcurrentMethodChecker
 from ..io import (
+    acquisition_timeout_to_deadline,
     AcquisitionAuth,
     AcquisitionDatabase,
 )
 
 
 if t.TYPE_CHECKING:
+    from ..._deadline import Deadline
     from ...api import _TAuth
     from ...auth_management import AuthManager
     from ..home_db_cache import (
@@ -156,13 +158,19 @@ class Workspace(NonConcurrentMethodChecker):
             self._connection.fetch_all()
             self._disconnect()
 
+        acquisition_deadline = acquisition_timeout_to_deadline(
+            acquisition_timeout
+        )
+
         ssr_enabled = self._pool.ssr_enabled
         target_db = self._get_routing_target_database(
-            acquire_auth, ssr_enabled=ssr_enabled
+            acquire_auth,
+            ssr_enabled=ssr_enabled,
+            acquisition_deadline=acquisition_deadline,
         )
         acquire_kwargs_ = {
             "access_mode": access_mode,
-            "timeout": acquisition_timeout,
+            "timeout": acquisition_deadline,
             "database": target_db,
             "bookmarks": self._get_bookmarks(),
             "auth": acquire_auth,
@@ -185,7 +193,9 @@ class Workspace(NonConcurrentMethodChecker):
             )
             self._disconnect()
             target_db = self._get_routing_target_database(
-                acquire_auth, ssr_enabled=False
+                acquire_auth,
+                ssr_enabled=False,
+                acquisition_deadline=acquisition_deadline,
             )
             acquire_kwargs_["database"] = target_db
             self._connection = self._pool.acquire(**acquire_kwargs_)
@@ -195,6 +205,7 @@ class Workspace(NonConcurrentMethodChecker):
         self,
         acquire_auth: AcquisitionAuth,
         ssr_enabled: bool,
+        acquisition_deadline: Deadline,
     ) -> AcquisitionDatabase:
         if (
             self._pinned_database
@@ -229,14 +240,13 @@ class Workspace(NonConcurrentMethodChecker):
                 )
                 return AcquisitionDatabase(cached_db, guessed=True)
 
-        acquisition_timeout = self._config.connection_acquisition_timeout
         log.debug("[#0000]  _: <WORKSPACE> resolve home database")
         self._pool.update_routing_table(
             database=self._config.database,
             imp_user=self._config.impersonated_user,
             bookmarks=self._get_bookmarks(),
             auth=acquire_auth,
-            acquisition_timeout=acquisition_timeout,
+            acquisition_timeout=acquisition_deadline,
             database_callback=self._make_db_resolution_callback(),
         )
         return AcquisitionDatabase(self._config.database)

--- a/testkitbackend/test_config.json
+++ b/testkitbackend/test_config.json
@@ -15,13 +15,7 @@
     "'neo4j.datatypes.test_temporal_types.TestDataTypes.test_date_time_cypher_created_tz_id'":
       "test_subtest_skips.tz_id",
     "stub\\.routing\\.test_routing_v[0-9x]+\\.RoutingV[0-9x]+\\.test_should_drop_connections_failing_liveness_check":
-      "Liveness check error handling is not (yet) unified: https://github.com/neo-technology/drivers-adr/pull/83",
-    "'stub.homedb.test_homedb.TestHomeDbMixedCluster.test_connection_acquisition_timeout_during_fallback'":
-      "TODO: 6.0 - pending unification: connection acquisition timeout should count towards the total time spent waiting for a connection (including routing, home db resolution, ...)",
-    "'stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_does_encompass_router_route_response'":
-      "TODO: 6.0 - pending unification: connection acquisition timeout should count towards the total time spent waiting for a connection (including routing, home db resolution, ...)",
-    "'stub.driver_parameters.test_connection_acquisition_timeout_ms.TestConnectionAcquisitionTimeoutMs.test_router_handshake_shares_acquisition_timeout'":
-      "TODO: 6.0 - pending unification: connection acquisition timeout should count towards the total time spent waiting for a connection (including routing, home db resolution, ...)"
+      "Liveness check error handling is not (yet) unified: https://github.com/neo-technology/drivers-adr/pull/83"
   },
   "features": {
     "Feature:API:BookmarkManager": true,

--- a/tests/unit/async_/io/test_bolt_pool.py
+++ b/tests/unit/async_/io/test_bolt_pool.py
@@ -1,0 +1,156 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import contextlib
+
+import pytest
+
+from neo4j import READ_ACCESS
+from neo4j._addressing import ResolvedAddress
+from neo4j._async.config import AsyncPoolConfig
+from neo4j._async.io import (
+    AcquisitionDatabase,
+    AsyncBoltPool,
+)
+from neo4j._conf import WorkspaceConfig
+from neo4j.auth_management import AsyncAuthManagers
+from neo4j.exceptions import ConnectionAcquisitionTimeoutError
+
+from ...._async_compat import mark_async_test
+
+
+SERVER1_ADDRESS = ResolvedAddress(("1.2.3.1", 9000), host_name="host")
+
+
+def make_home_db_resolve(home_db):
+    def _home_db_resolve(db):
+        return db or home_db
+
+    return _home_db_resolve
+
+
+_default_db_resolve = make_home_db_resolve("neo4j")
+
+
+@pytest.fixture
+def custom_opener(async_fake_connection_generator, mocker):
+    def make_opener(
+        failures=None,
+        db_resolve=_default_db_resolve,
+        on_open=None,
+    ):
+        def routing_side_effect(*args, **kwargs):
+            nonlocal failures
+            opener_.route_requests.append(kwargs.get("database"))
+            res = next(failures, None)
+            if res is None:
+                routers = readers = writers = [str(SERVER1_ADDRESS)]
+                rt = {
+                    "ttl": 1000,
+                    "servers": [
+                        {"addresses": routers, "role": "ROUTE"},
+                        {"addresses": readers, "role": "READ"},
+                        {"addresses": writers, "role": "WRITE"},
+                    ],
+                }
+                db = db_resolve(kwargs.get("database"))
+                if db is not ...:
+                    rt["db"] = db
+                return [rt]
+            raise res
+
+        async def open_(addr, auth, timeout):
+            connection = async_fake_connection_generator()
+            connection.unresolved_address = addr
+            connection.timeout = timeout
+            connection.auth = auth
+            route_mock = mocker.AsyncMock()
+
+            route_mock.side_effect = routing_side_effect
+            connection.attach_mock(route_mock, "route")
+            opener_.connections.append(connection)
+
+            if callable(on_open):
+                on_open(connection)
+
+            return connection
+
+        failures = iter(failures or [])
+        opener_ = mocker.AsyncMock()
+        opener_.connections = []
+        opener_.route_requests = []
+        opener_.side_effect = open_
+        return opener_
+
+    return make_opener
+
+
+@pytest.fixture
+def opener(custom_opener):
+    return custom_opener()
+
+
+def _pool_config():
+    pool_config = AsyncPoolConfig()
+    pool_config.auth = _auth_manager(("user", "pass"))
+    return pool_config
+
+
+def _auth_manager(auth):
+    return AsyncAuthManagers.static(auth)
+
+
+def _simple_pool(opener) -> AsyncBoltPool:
+    return AsyncBoltPool(
+        opener, _pool_config(), WorkspaceConfig(), SERVER1_ADDRESS
+    )
+
+
+TEST_DB1 = AcquisitionDatabase("test_db1")
+
+
+@pytest.mark.parametrize(
+    ("timeout", "expected_error"),
+    (
+        (1, None),
+        (2 ^ 128, None),
+        (0.000000001, None),
+        (float("inf"), None),
+        (-1, ValueError),
+        (0, ValueError),
+        (float("-inf"), ValueError),
+        (float("NaN"), ValueError),
+        (float("-NaN"), ValueError),
+        ("1", TypeError),
+        (None, TypeError),
+        ([1], TypeError),
+    ),
+)
+@mark_async_test
+async def test_invalid_acquisition_timeouts(opener, timeout, expected_error):
+    pool = _simple_pool(opener)
+
+    async def call():
+        with contextlib.suppress(ConnectionAcquisitionTimeoutError):
+            await pool.acquire(
+                READ_ACCESS, timeout, TEST_DB1, None, None, None
+            )
+
+    if expected_error is None:
+        await call()
+    else:
+        with pytest.raises(expected_error):
+            await call()

--- a/tests/unit/async_/io/test_direct.py
+++ b/tests/unit/async_/io/test_direct.py
@@ -204,7 +204,7 @@ async def test_pool_max_conn_pool_size(async_fake_connection_generator):
         async_fake_connection_generator, (), max_connection_pool_size=1
     ) as pool:
         address = neo4j.Address(("127.0.0.1", 7687))
-        await pool._acquire(address, None, Deadline(0), None)
+        await pool._acquire(address, None, Deadline(float("inf")), None)
         assert pool.in_use_connection_count(address) == 1
         with pytest.raises(ConnectionAcquisitionTimeoutError):
             await pool._acquire(address, None, Deadline(0), None)

--- a/tests/unit/async_/io/test_neo4j_pool.py
+++ b/tests/unit/async_/io/test_neo4j_pool.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+import contextlib
 import inspect
 
 import pytest
@@ -37,6 +38,7 @@ from neo4j._conf import (
 from neo4j._deadline import Deadline
 from neo4j.auth_management import AsyncAuthManagers
 from neo4j.exceptions import (
+    ConnectionAcquisitionTimeoutError,
     Neo4jError,
     ServiceUnavailable,
     SessionExpired,
@@ -914,3 +916,37 @@ async def test_tracks_ssr_connection_hints(custom_routing_opener):
         await pool.release(cx)
 
     assert pool.ssr_enabled
+
+
+@pytest.mark.parametrize(
+    ("timeout", "expected_error"),
+    (
+        (1, None),
+        (2 ^ 128, None),
+        (0.000000001, None),
+        (float("inf"), None),
+        (-1, ValueError),
+        (0, ValueError),
+        (float("-inf"), ValueError),
+        (float("NaN"), ValueError),
+        (float("-NaN"), ValueError),
+        ("1", TypeError),
+        (None, TypeError),
+        ([1], TypeError),
+    ),
+)
+@mark_async_test
+async def test_invalid_acquisition_timeouts(opener, timeout, expected_error):
+    pool = _simple_pool(opener)
+
+    async def call():
+        with contextlib.suppress(ConnectionAcquisitionTimeoutError):
+            await pool.acquire(
+                READ_ACCESS, timeout, TEST_DB1, None, None, None
+            )
+
+    if expected_error is None:
+        await call()
+    else:
+        with pytest.raises(expected_error):
+            await call()

--- a/tests/unit/mixed/io/test_direct.py
+++ b/tests/unit/mixed/io/test_direct.py
@@ -141,7 +141,7 @@ class TestMixedConnectionPoolTestCase:
 
         def acquire1(pool_):
             nonlocal cx1
-            cx = pool_._acquire(address, acquire_auth1, Deadline(0), None)
+            cx = pool_._acquire(address, acquire_auth1, Deadline(1), None)
             acquire1_event.set()
             cx1 = cx
             while True:
@@ -258,7 +258,7 @@ class TestMixedConnectionPoolTestCase:
         async def acquire1(pool_):
             nonlocal cx1
             cx = await pool_._acquire(
-                address, acquire_auth1, Deadline(0), None
+                address, acquire_auth1, Deadline(1), None
             )
             cx1 = cx
             while len(pool_.cond._waiters) == 0:

--- a/tests/unit/sync/io/test_bolt_pool.py
+++ b/tests/unit/sync/io/test_bolt_pool.py
@@ -1,0 +1,156 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import contextlib
+
+import pytest
+
+from neo4j import READ_ACCESS
+from neo4j._addressing import ResolvedAddress
+from neo4j._conf import WorkspaceConfig
+from neo4j._sync.config import PoolConfig
+from neo4j._sync.io import (
+    AcquisitionDatabase,
+    BoltPool,
+)
+from neo4j.auth_management import AuthManagers
+from neo4j.exceptions import ConnectionAcquisitionTimeoutError
+
+from ...._async_compat import mark_sync_test
+
+
+SERVER1_ADDRESS = ResolvedAddress(("1.2.3.1", 9000), host_name="host")
+
+
+def make_home_db_resolve(home_db):
+    def _home_db_resolve(db):
+        return db or home_db
+
+    return _home_db_resolve
+
+
+_default_db_resolve = make_home_db_resolve("neo4j")
+
+
+@pytest.fixture
+def custom_opener(fake_connection_generator, mocker):
+    def make_opener(
+        failures=None,
+        db_resolve=_default_db_resolve,
+        on_open=None,
+    ):
+        def routing_side_effect(*args, **kwargs):
+            nonlocal failures
+            opener_.route_requests.append(kwargs.get("database"))
+            res = next(failures, None)
+            if res is None:
+                routers = readers = writers = [str(SERVER1_ADDRESS)]
+                rt = {
+                    "ttl": 1000,
+                    "servers": [
+                        {"addresses": routers, "role": "ROUTE"},
+                        {"addresses": readers, "role": "READ"},
+                        {"addresses": writers, "role": "WRITE"},
+                    ],
+                }
+                db = db_resolve(kwargs.get("database"))
+                if db is not ...:
+                    rt["db"] = db
+                return [rt]
+            raise res
+
+        def open_(addr, auth, timeout):
+            connection = fake_connection_generator()
+            connection.unresolved_address = addr
+            connection.timeout = timeout
+            connection.auth = auth
+            route_mock = mocker.MagicMock()
+
+            route_mock.side_effect = routing_side_effect
+            connection.attach_mock(route_mock, "route")
+            opener_.connections.append(connection)
+
+            if callable(on_open):
+                on_open(connection)
+
+            return connection
+
+        failures = iter(failures or [])
+        opener_ = mocker.MagicMock()
+        opener_.connections = []
+        opener_.route_requests = []
+        opener_.side_effect = open_
+        return opener_
+
+    return make_opener
+
+
+@pytest.fixture
+def opener(custom_opener):
+    return custom_opener()
+
+
+def _pool_config():
+    pool_config = PoolConfig()
+    pool_config.auth = _auth_manager(("user", "pass"))
+    return pool_config
+
+
+def _auth_manager(auth):
+    return AuthManagers.static(auth)
+
+
+def _simple_pool(opener) -> BoltPool:
+    return BoltPool(
+        opener, _pool_config(), WorkspaceConfig(), SERVER1_ADDRESS
+    )
+
+
+TEST_DB1 = AcquisitionDatabase("test_db1")
+
+
+@pytest.mark.parametrize(
+    ("timeout", "expected_error"),
+    (
+        (1, None),
+        (2 ^ 128, None),
+        (0.000000001, None),
+        (float("inf"), None),
+        (-1, ValueError),
+        (0, ValueError),
+        (float("-inf"), ValueError),
+        (float("NaN"), ValueError),
+        (float("-NaN"), ValueError),
+        ("1", TypeError),
+        (None, TypeError),
+        ([1], TypeError),
+    ),
+)
+@mark_sync_test
+def test_invalid_acquisition_timeouts(opener, timeout, expected_error):
+    pool = _simple_pool(opener)
+
+    def call():
+        with contextlib.suppress(ConnectionAcquisitionTimeoutError):
+            pool.acquire(
+                READ_ACCESS, timeout, TEST_DB1, None, None, None
+            )
+
+    if expected_error is None:
+        call()
+    else:
+        with pytest.raises(expected_error):
+            call()

--- a/tests/unit/sync/io/test_direct.py
+++ b/tests/unit/sync/io/test_direct.py
@@ -204,7 +204,7 @@ def test_pool_max_conn_pool_size(fake_connection_generator):
         fake_connection_generator, (), max_connection_pool_size=1
     ) as pool:
         address = neo4j.Address(("127.0.0.1", 7687))
-        pool._acquire(address, None, Deadline(0), None)
+        pool._acquire(address, None, Deadline(float("inf")), None)
         assert pool.in_use_connection_count(address) == 1
         with pytest.raises(ConnectionAcquisitionTimeoutError):
             pool._acquire(address, None, Deadline(0), None)

--- a/tests/unit/sync/io/test_neo4j_pool.py
+++ b/tests/unit/sync/io/test_neo4j_pool.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+import contextlib
 import inspect
 
 import pytest
@@ -37,6 +38,7 @@ from neo4j._sync.io import (
 )
 from neo4j.auth_management import AuthManagers
 from neo4j.exceptions import (
+    ConnectionAcquisitionTimeoutError,
     Neo4jError,
     ServiceUnavailable,
     SessionExpired,
@@ -914,3 +916,37 @@ def test_tracks_ssr_connection_hints(custom_routing_opener):
         pool.release(cx)
 
     assert pool.ssr_enabled
+
+
+@pytest.mark.parametrize(
+    ("timeout", "expected_error"),
+    (
+        (1, None),
+        (2 ^ 128, None),
+        (0.000000001, None),
+        (float("inf"), None),
+        (-1, ValueError),
+        (0, ValueError),
+        (float("-inf"), ValueError),
+        (float("NaN"), ValueError),
+        (float("-NaN"), ValueError),
+        ("1", TypeError),
+        (None, TypeError),
+        ([1], TypeError),
+    ),
+)
+@mark_sync_test
+def test_invalid_acquisition_timeouts(opener, timeout, expected_error):
+    pool = _simple_pool(opener)
+
+    def call():
+        with contextlib.suppress(ConnectionAcquisitionTimeoutError):
+            pool.acquire(
+                READ_ACCESS, timeout, TEST_DB1, None, None, None
+            )
+
+    if expected_error is None:
+        call()
+    else:
+        with pytest.raises(expected_error):
+            call()


### PR DESCRIPTION
The config option `connection_acquisition_timeout` now spans anything that's required to acquire a working connection from the pool. This includes
 * Potentially fetching a routing table This entails acquiring a connection in itself.
 * Bolt, TLS, TCP handshaking
 * Authentication
 * Any other required IO (e.g., DNS lookups)
 * Waiting for room in the pool
 * possibly more

Previously, the timeout wold be restarted for auxiliary connection acquisitions like those for fetching a routing table.