### PR TITLE
Docs: specify applicability of `is_retryable`

### DIFF
--- a/src/neo4j/exceptions.py
+++ b/src/neo4j/exceptions.py
@@ -608,6 +608,12 @@ class Neo4jError(GqlError):
         retry. This method makes mostly sense when implementing a custom
         retry policy in conjunction with :ref:`explicit-transactions-ref`.
 
+        .. warning::
+
+            Auto-commit transactions
+            (:meth:`.Session.run`/:meth:`.AsyncSession.run`) are not retryable
+            regardless of this value.
+
         :returns: :data:`True` if the error is retryable,
             :data:`False` otherwise.
 
@@ -817,6 +823,12 @@ class DriverError(GqlError):
         Indicates whether a transaction that yielded this error makes sense to
         retry. This method makes mostly sense when implementing a custom
         retry policy in conjunction with :ref:`explicit-transactions-ref`.
+
+        .. warning::
+
+            Auto-commit transactions
+            (:meth:`.Session.run`/:meth:`.AsyncSession.run`) are not retryable
+            regardless of this value.
 
         :returns: :data:`True` if the error is retryable,
             :data:`False` otherwise.


### PR DESCRIPTION
Because the server-side state of auto-commit transactions cannot be known by the driver (they might even be partially committed), it's not safe to retry them solely based on the exception observed. Business logic is required to determine if the auto-commit transaction succeeded or failed after observing an error client-side.