### PR TITLE
Chain failure causes on routing table fetching failure

### DIFF
--- a/src/neo4j/_async/io/_pool.py
+++ b/src/neo4j/_async/io/_pool.py
@@ -20,6 +20,7 @@ import abc
 import asyncio
 import logging
 import math
+import sys
 from collections import (
     defaultdict,
     deque,
@@ -53,6 +54,7 @@ from ...exceptions import (
     DriverError,
     Neo4jError,
     ReadServiceUnavailable,
+    RoutingServiceUnavailable,
     ServiceUnavailable,
     SessionExpired,
     WriteServiceUnavailable,
@@ -810,6 +812,7 @@ class AsyncNeo4jPool(AsyncIOPool):
         imp_user,
         bookmarks,
         auth,
+        ignored_errors=None,
     ):
         """
         Fetch a routing table from a given router address.
@@ -823,6 +826,7 @@ class AsyncNeo4jPool(AsyncIOPool):
         :type imp_user: str or None
         :param bookmarks: bookmarks used when fetching routing table
         :param auth: auth
+        :param ignored_errors: optional list to accumulate ignored errors in
 
         :returns: a new RoutingTable instance or None if the given router is
                  currently unable to provide routing information
@@ -843,15 +847,16 @@ class AsyncNeo4jPool(AsyncIOPool):
             # router. Hence, the driver should fail fast during discovery.
             if e._is_fatal_during_discovery():
                 raise
-        except (ServiceUnavailable, SessionExpired):
-            pass
+            if ignored_errors is not None:
+                ignored_errors.append(e)
+        except (ServiceUnavailable, SessionExpired) as e:
+            if ignored_errors is not None:
+                ignored_errors.append(e)
         if not new_routing_info:
             log.debug(
                 "[#0000]  _: <POOL> failed to fetch routing info from %r",
                 address,
             )
-            # TODO: 7.0 - when Python 3.11+ is the minimum,
-            #       use exception groups instead of swallowing discovery errors
             return None
         else:
             servers = new_routing_info[0]["servers"]
@@ -876,6 +881,12 @@ class AsyncNeo4jPool(AsyncIOPool):
                 "server %s",
                 address,
             )
+            if ignored_errors is not None:
+                ignored_errors.append(
+                    RoutingServiceUnavailable(
+                        "Rejected routing table: no routers"
+                    )
+                )
             return None
 
         # No readers
@@ -884,6 +895,12 @@ class AsyncNeo4jPool(AsyncIOPool):
                 "[#0000]  _: <POOL> no read servers returned from server %s",
                 address,
             )
+            if ignored_errors is not None:
+                ignored_errors.append(
+                    ReadServiceUnavailable(
+                        "Rejected routing table: no readers"
+                    )
+                )
             return None
 
         # At least one of each is fine, so return this table
@@ -898,6 +915,7 @@ class AsyncNeo4jPool(AsyncIOPool):
         auth,
         acquisition_timeout,
         database_callback,
+        ignored_errors=None,
     ):
         """
         Try to update routing tables with the given routers.
@@ -924,6 +942,7 @@ class AsyncNeo4jPool(AsyncIOPool):
                     imp_user=imp_user,
                     bookmarks=bookmarks,
                     auth=auth,
+                    ignored_errors=ignored_errors,
                 )
                 if new_routing_table is not None:
                     new_database = new_routing_table.database
@@ -973,6 +992,7 @@ class AsyncNeo4jPool(AsyncIOPool):
         acquisition_timeout = acquisition_timeout_to_deadline(
             acquisition_timeout
         )
+        errors = []
         async with self.refresh_lock:
             routing_table = await self.get_routing_table(database)
             if routing_table is not None:
@@ -997,6 +1017,7 @@ class AsyncNeo4jPool(AsyncIOPool):
                     auth=auth,
                     acquisition_timeout=acquisition_timeout,
                     database_callback=database_callback,
+                    ignored_errors=errors,
                 )
             ):
                 # Why is only the first initial routing address used?
@@ -1009,6 +1030,7 @@ class AsyncNeo4jPool(AsyncIOPool):
                 auth=auth,
                 acquisition_timeout=acquisition_timeout,
                 database_callback=database_callback,
+                ignored_errors=errors,
             ):
                 return
 
@@ -1022,6 +1044,7 @@ class AsyncNeo4jPool(AsyncIOPool):
                     auth=auth,
                     acquisition_timeout=acquisition_timeout,
                     database_callback=database_callback,
+                    ignored_errors=errors,
                 )
             ):
                 # Why is only the first initial routing address used?
@@ -1029,7 +1052,33 @@ class AsyncNeo4jPool(AsyncIOPool):
 
             # None of the routers have been successful, so just fail
             log.error("Unable to retrieve routing information")
-            raise ServiceUnavailable("Unable to retrieve routing information")
+            if sys.version_info >= (3, 11):
+                e = ExceptionGroup(  # noqa: F821 # version guard in place
+                    "All routing table requests failed", errors
+                )
+            else:
+                e = None
+                for error in errors:
+                    if e is None:
+                        e = error
+                        continue
+                    cause = error
+                    seen_causes = {id(cause)}
+                    while True:
+                        next_cause = getattr(cause, "__cause__", None)
+                        if next_cause is None:
+                            break
+                        if id(next_cause) in seen_causes:
+                            # Avoid infinite recursion in case of circular
+                            # references.
+                            break
+                        cause = next_cause
+                        seen_causes.add(id(cause))
+                    cause.__cause__ = e
+                    e = error
+            raise ServiceUnavailable(
+                "Unable to retrieve routing information"
+            ) from e
 
     async def update_connection_pool(self):
         async with self.refresh_lock:

--- a/src/neo4j/_sync/io/_pool.py
+++ b/src/neo4j/_sync/io/_pool.py
@@ -20,6 +20,7 @@ import abc
 import asyncio
 import logging
 import math
+import sys
 from collections import (
     defaultdict,
     deque,
@@ -53,6 +54,7 @@ from ...exceptions import (
     DriverError,
     Neo4jError,
     ReadServiceUnavailable,
+    RoutingServiceUnavailable,
     ServiceUnavailable,
     SessionExpired,
     WriteServiceUnavailable,
@@ -807,6 +809,7 @@ class Neo4jPool(IOPool):
         imp_user,
         bookmarks,
         auth,
+        ignored_errors=None,
     ):
         """
         Fetch a routing table from a given router address.
@@ -820,6 +823,7 @@ class Neo4jPool(IOPool):
         :type imp_user: str or None
         :param bookmarks: bookmarks used when fetching routing table
         :param auth: auth
+        :param ignored_errors: optional list to accumulate ignored errors in
 
         :returns: a new RoutingTable instance or None if the given router is
                  currently unable to provide routing information
@@ -840,15 +844,16 @@ class Neo4jPool(IOPool):
             # router. Hence, the driver should fail fast during discovery.
             if e._is_fatal_during_discovery():
                 raise
-        except (ServiceUnavailable, SessionExpired):
-            pass
+            if ignored_errors is not None:
+                ignored_errors.append(e)
+        except (ServiceUnavailable, SessionExpired) as e:
+            if ignored_errors is not None:
+                ignored_errors.append(e)
         if not new_routing_info:
             log.debug(
                 "[#0000]  _: <POOL> failed to fetch routing info from %r",
                 address,
             )
-            # TODO: 7.0 - when Python 3.11+ is the minimum,
-            #       use exception groups instead of swallowing discovery errors
             return None
         else:
             servers = new_routing_info[0]["servers"]
@@ -873,6 +878,12 @@ class Neo4jPool(IOPool):
                 "server %s",
                 address,
             )
+            if ignored_errors is not None:
+                ignored_errors.append(
+                    RoutingServiceUnavailable(
+                        "Rejected routing table: no routers"
+                    )
+                )
             return None
 
         # No readers
@@ -881,6 +892,12 @@ class Neo4jPool(IOPool):
                 "[#0000]  _: <POOL> no read servers returned from server %s",
                 address,
             )
+            if ignored_errors is not None:
+                ignored_errors.append(
+                    ReadServiceUnavailable(
+                        "Rejected routing table: no readers"
+                    )
+                )
             return None
 
         # At least one of each is fine, so return this table
@@ -895,6 +912,7 @@ class Neo4jPool(IOPool):
         auth,
         acquisition_timeout,
         database_callback,
+        ignored_errors=None,
     ):
         """
         Try to update routing tables with the given routers.
@@ -921,6 +939,7 @@ class Neo4jPool(IOPool):
                     imp_user=imp_user,
                     bookmarks=bookmarks,
                     auth=auth,
+                    ignored_errors=ignored_errors,
                 )
                 if new_routing_table is not None:
                     new_database = new_routing_table.database
@@ -970,6 +989,7 @@ class Neo4jPool(IOPool):
         acquisition_timeout = acquisition_timeout_to_deadline(
             acquisition_timeout
         )
+        errors = []
         with self.refresh_lock:
             routing_table = self.get_routing_table(database)
             if routing_table is not None:
@@ -994,6 +1014,7 @@ class Neo4jPool(IOPool):
                     auth=auth,
                     acquisition_timeout=acquisition_timeout,
                     database_callback=database_callback,
+                    ignored_errors=errors,
                 )
             ):
                 # Why is only the first initial routing address used?
@@ -1006,6 +1027,7 @@ class Neo4jPool(IOPool):
                 auth=auth,
                 acquisition_timeout=acquisition_timeout,
                 database_callback=database_callback,
+                ignored_errors=errors,
             ):
                 return
 
@@ -1019,6 +1041,7 @@ class Neo4jPool(IOPool):
                     auth=auth,
                     acquisition_timeout=acquisition_timeout,
                     database_callback=database_callback,
+                    ignored_errors=errors,
                 )
             ):
                 # Why is only the first initial routing address used?
@@ -1026,7 +1049,33 @@ class Neo4jPool(IOPool):
 
             # None of the routers have been successful, so just fail
             log.error("Unable to retrieve routing information")
-            raise ServiceUnavailable("Unable to retrieve routing information")
+            if sys.version_info >= (3, 11):
+                e = ExceptionGroup(  # noqa: F821 # version guard in place
+                    "All routing table requests failed", errors
+                )
+            else:
+                e = None
+                for error in errors:
+                    if e is None:
+                        e = error
+                        continue
+                    cause = error
+                    seen_causes = {id(cause)}
+                    while True:
+                        next_cause = getattr(cause, "__cause__", None)
+                        if next_cause is None:
+                            break
+                        if id(next_cause) in seen_causes:
+                            # Avoid infinite recursion in case of circular
+                            # references.
+                            break
+                        cause = next_cause
+                        seen_causes.add(id(cause))
+                    cause.__cause__ = e
+                    e = error
+            raise ServiceUnavailable(
+                "Unable to retrieve routing information"
+            ) from e
 
     def update_connection_pool(self):
         with self.refresh_lock:

--- a/tests/unit/async_/io/test_neo4j_pool.py
+++ b/tests/unit/async_/io/test_neo4j_pool.py
@@ -16,6 +16,7 @@
 
 import contextlib
 import inspect
+import sys
 
 import pytest
 
@@ -648,6 +649,68 @@ async def test_discovery_is_retried(custom_routing_opener, error):
     # successful router
     # same reader again
     assert len(opener.connections) == 4
+
+
+@mark_async_test
+async def test_failed_discovery_chains_errors(custom_routing_opener) -> None:
+    error1 = Neo4jError._hydrate_neo4j(
+        code="Neo.ClientError.Security.AuthorizationExpired",
+        message="message",
+    )
+    error2 = ServiceUnavailable("message")
+    error2_cause = Exception("just (be)cause")
+    error2.__cause__ = error2_cause
+    error3 = SessionExpired("message")
+    error4 = Neo4jError._hydrate_neo4j(
+        code="Neo.Made.Up.Code",
+        message="message",
+    )
+    opener = custom_routing_opener(
+        [
+            None,  # first call to router for seeding the RT with more routers
+            error1,  # router 1 fails
+            error2,  # router 2 fails
+            error3,  # router 3 fails
+            error4,  # initial router fails
+        ]
+    )
+    pool = AsyncNeo4jPool(
+        opener,
+        _pool_config(),
+        WorkspaceConfig(),
+        ResolvedAddress(("1.2.3.1", 9999), host_name="host"),
+    )
+    cx1 = await pool.acquire(READ_ACCESS, 30, TEST_DB1, None, None, None)
+    await pool.release(cx1)
+    pool.routing_tables.get(TEST_DB1.name).ttl = 0
+
+    with pytest.raises(ServiceUnavailable) as exc_info:
+        await pool.acquire(READ_ACCESS, 30, TEST_DB1, None, None, None)
+
+    exc = exc_info.value
+    if sys.version_info >= (3, 11):
+        group = exc.__cause__
+        assert isinstance(group, ExceptionGroup)  # noqa: F821
+        assert all(
+            a is b
+            for a, b in zip(
+                group.exceptions,
+                [error1, error2, error3, error4],
+                strict=True,
+            )
+        )
+        assert error4.__cause__ is None
+        assert error3.__cause__ is None
+        assert error2.__cause__ is error2_cause
+        assert error2_cause.__cause__ is None
+        assert error1.__cause__ is None
+    else:
+        assert exc.__cause__ is error4
+        assert error4.__cause__ is error3
+        assert error3.__cause__ is error2
+        assert error2.__cause__ is error2_cause
+        assert error2_cause.__cause__ is error1
+        assert error1.__cause__ is None
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/sync/io/test_neo4j_pool.py
+++ b/tests/unit/sync/io/test_neo4j_pool.py
@@ -16,6 +16,7 @@
 
 import contextlib
 import inspect
+import sys
 
 import pytest
 
@@ -648,6 +649,68 @@ def test_discovery_is_retried(custom_routing_opener, error):
     # successful router
     # same reader again
     assert len(opener.connections) == 4
+
+
+@mark_sync_test
+def test_failed_discovery_chains_errors(custom_routing_opener) -> None:
+    error1 = Neo4jError._hydrate_neo4j(
+        code="Neo.ClientError.Security.AuthorizationExpired",
+        message="message",
+    )
+    error2 = ServiceUnavailable("message")
+    error2_cause = Exception("just (be)cause")
+    error2.__cause__ = error2_cause
+    error3 = SessionExpired("message")
+    error4 = Neo4jError._hydrate_neo4j(
+        code="Neo.Made.Up.Code",
+        message="message",
+    )
+    opener = custom_routing_opener(
+        [
+            None,  # first call to router for seeding the RT with more routers
+            error1,  # router 1 fails
+            error2,  # router 2 fails
+            error3,  # router 3 fails
+            error4,  # initial router fails
+        ]
+    )
+    pool = Neo4jPool(
+        opener,
+        _pool_config(),
+        WorkspaceConfig(),
+        ResolvedAddress(("1.2.3.1", 9999), host_name="host"),
+    )
+    cx1 = pool.acquire(READ_ACCESS, 30, TEST_DB1, None, None, None)
+    pool.release(cx1)
+    pool.routing_tables.get(TEST_DB1.name).ttl = 0
+
+    with pytest.raises(ServiceUnavailable) as exc_info:
+        pool.acquire(READ_ACCESS, 30, TEST_DB1, None, None, None)
+
+    exc = exc_info.value
+    if sys.version_info >= (3, 11):
+        group = exc.__cause__
+        assert isinstance(group, ExceptionGroup)  # noqa: F821
+        assert all(
+            a is b
+            for a, b in zip(
+                group.exceptions,
+                [error1, error2, error3, error4],
+                strict=True,
+            )
+        )
+        assert error4.__cause__ is None
+        assert error3.__cause__ is None
+        assert error2.__cause__ is error2_cause
+        assert error2_cause.__cause__ is None
+        assert error1.__cause__ is None
+    else:
+        assert exc.__cause__ is error4
+        assert error4.__cause__ is error3
+        assert error3.__cause__ is error2
+        assert error2.__cause__ is error2_cause
+        assert error2_cause.__cause__ is error1
+        assert error1.__cause__ is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Current Error
When a routing driver (`neo4j[+s[sc]]` URL scheme), fails to fetch a routing table, is swallows all errors from the connection and RT fetching attempts that lead up to the failure and just reports

```
neo4j.exceptions.ServiceUnavailable: Unable to retrieve routing information
```

This hides the relevant information to the user: why did this fail? SSL problems, connectivity issues, unsupported server version, ...?

## New Erorr
This PR chains all errors (and their causes) as `__cause__` of the top-level `ServiceUnavailable`. When available an `ExceptionGroup` is used (running on Python 3.11+), else all errors are flattened into a single cause chain.

### Example Output Python 3.11
<details>
<summary>output</summary>

```
  | ExceptionGroup: All routing table requests failed (4 sub-exceptions)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 439, in _connect_secure
    |     s = ssl_context.wrap_socket(s, server_hostname=sni_host)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/lib/python3.11/ssl.py", line 517, in wrap_socket
    |     return self.sslsocket_class._create(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/lib/python3.11/ssl.py", line 1108, in _create
    |     self.do_handshake()
    |   File "/usr/lib/python3.11/ssl.py", line 1379, in do_handshake
    |     self._sslobj.do_handshake()
    | ssl.SSLEOFError: [SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1006)
    |
    | The above exception was the direct cause of the following exception:
    |
    | Traceback (most recent call last):
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 324, in connect
    |     s = cls._connect_secure(
    |         ^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 441, in _connect_secure
    |     raise BoltSecurityError(
    | neo4j._exceptions.BoltSecurityError: [SSLEOFError] Connection Failed. Please ensure that your database is listening on the correct host and port and that you have enabled encryption if required. Note that the default encryption setting has changed in Neo4j 4.0. See the docs for more information. Failed to establish encrypted connection. (code 8: Exec format error)
    |
    | The above exception was the direct cause of the following exception:
    |
    | Traceback (most recent call last):
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 832, in fetch_routing_table
    |     new_routing_info = self.fetch_routing_info(
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 791, in fetch_routing_info
    |     cx = self._acquire(address, auth, deadline, None)
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 416, in _acquire
    |     return connection_creator()
    |            ^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 231, in connection_creator
    |     connection = self.opener(
    |                  ^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 710, in opener
    |     return Bolt.open(
    |            ^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_bolt.py", line 364, in open
    |     s, protocol_version = BoltSocket.connect(
    |                           ^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 371, in connect
    |     raise ServiceUnavailable(
    | neo4j.exceptions.ServiceUnavailable: Couldn't connect to [::1]:7687 (resolved to ('[::1]:7687',)):
[SSLEOFError] Connection Failed. Please ensure that your database is listening on the correct host and port and that you have enabled encryption if required. Note that the default encryption setting has changed in Neo4j 4.0. See the docs for more information. Failed to establish encrypted connection. (code 8: Exec format error)
    +---------------- 2 ----------------
    | Traceback (most recent call last):
    |   File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 439, in _connect_secure
    |     s = ssl_context.wrap_socket(s, server_hostname=sni_host)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/lib/python3.11/ssl.py", line 517, in wrap_socket
    |     return self.sslsocket_class._create(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/lib/python3.11/ssl.py", line 1108, in _create
    |     self.do_handshake()
    |   File "/usr/lib/python3.11/ssl.py", line 1379, in do_handshake
    |     self._sslobj.do_handshake()
    | ssl.SSLEOFError: [SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1006)
    |
    | The above exception was the direct cause of the following exception:
    |
    | Traceback (most recent call last):
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 324, in connect
    |     s = cls._connect_secure(
    |         ^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 441, in _connect_secure
    |     raise BoltSecurityError(
    | neo4j._exceptions.BoltSecurityError: [SSLEOFError] Connection Failed. Please ensure that your database is listening on the correct host and port and that you have enabled encryption if required. Note that the default encryption setting has changed in Neo4j 4.0. See the docs for more information. Failed to establish encrypted connection. (code 8: Exec format error)
    |
    | The above exception was the direct cause of the following exception:
    |
    | Traceback (most recent call last):
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 832, in fetch_routing_table
    |     new_routing_info = self.fetch_routing_info(
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 791, in fetch_routing_info
    |     cx = self._acquire(address, auth, deadline, None)
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 416, in _acquire
    |     return connection_creator()
    |            ^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 231, in connection_creator
    |     connection = self.opener(
    |                  ^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 710, in opener
    |     return Bolt.open(
    |            ^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_bolt.py", line 364, in open
    |     s, protocol_version = BoltSocket.connect(
    |                           ^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 371, in connect
    |     raise ServiceUnavailable(
    | neo4j.exceptions.ServiceUnavailable: Couldn't connect to 127.0.0.1:7687 (resolved to ('127.0.0.1:7687',)):
[SSLEOFError] Connection Failed. Please ensure that your database is listening on the correct host and port and that you have enabled encryption if required. Note that the default encryption setting has changed in Neo4j 4.0. See the docs for more information. Failed to establish encrypted connection. (code 8: Exec format error)
    +---------------- 3 ----------------
    | Traceback (most recent call last):
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 324, in connect
    |     s = cls._connect_secure(
    |         ^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 415, in _connect_secure
    |     raise ServiceUnavailable(
    | neo4j.exceptions.ServiceUnavailable: Timed out trying to establish connection to ResolvedIPv4Address(('172.0.0.1', 7687))
    |
    | The above exception was the direct cause of the following exception:
    |
    | Traceback (most recent call last):
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 832, in fetch_routing_table
    |     new_routing_info = self.fetch_routing_info(
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 791, in fetch_routing_info
    |     cx = self._acquire(address, auth, deadline, None)
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 416, in _acquire
    |     return connection_creator()
    |            ^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 231, in connection_creator
    |     connection = self.opener(
    |                  ^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 710, in opener
    |     return Bolt.open(
    |            ^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_bolt.py", line 364, in open
    |     s, protocol_version = BoltSocket.connect(
    |                           ^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 371, in connect
    |     raise ServiceUnavailable(
    | neo4j.exceptions.ServiceUnavailable: Couldn't connect to 172.0.0.1:7687 (resolved to ('172.0.0.1:7687',)):
Timed out trying to establish connection to ResolvedIPv4Address(('172.0.0.1', 7687))
    +---------------- 4 ----------------
    | Traceback (most recent call last):
    |   File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 439, in _connect_secure
    |     s = ssl_context.wrap_socket(s, server_hostname=sni_host)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/lib/python3.11/ssl.py", line 517, in wrap_socket
    |     return self.sslsocket_class._create(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/lib/python3.11/ssl.py", line 1108, in _create
    |     self.do_handshake()
    |   File "/usr/lib/python3.11/ssl.py", line 1379, in do_handshake
    |     self._sslobj.do_handshake()
    | ConnectionResetError: [Errno 104] Connection reset by peer
    |
    | The above exception was the direct cause of the following exception:
    |
    | Traceback (most recent call last):
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 324, in connect
    |     s = cls._connect_secure(
    |         ^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 441, in _connect_secure
    |     raise BoltSecurityError(
    | neo4j._exceptions.BoltSecurityError: [ConnectionResetError] Connection Failed. Please ensure that your database is listening on the correct host and port and that you have enabled encryption if required. Note that the default encryption setting has changed in Neo4j 4.0. See the docs for more information. Failed to establish encrypted connection. (code 104: Connection reset by peer)
    |
    | The above exception was the direct cause of the following exception:
    |
    | Traceback (most recent call last):
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 832, in fetch_routing_table
    |     new_routing_info = self.fetch_routing_info(
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 791, in fetch_routing_info
    |     cx = self._acquire(address, auth, deadline, None)
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 416, in _acquire
    |     return connection_creator()
    |            ^^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 231, in connection_creator
    |     connection = self.opener(
    |                  ^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 710, in opener
    |     return Bolt.open(
    |            ^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_bolt.py", line 364, in open
    |     s, protocol_version = BoltSocket.connect(
    |                           ^^^^^^^^^^^^^^^^^^^
    |   File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 371, in connect
    |     raise ServiceUnavailable(
    | neo4j.exceptions.ServiceUnavailable: Couldn't connect to 34.78.76.49:7687 (resolved to ('34.78.76.49:7687',)):
[ConnectionResetError] Connection Failed. Please ensure that your database is listening on the correct host and port and that you have enabled encryption if required. Note that the default encryption setting has changed in Neo4j 4.0. See the docs for more information. Failed to establish encrypted connection. (code 104: Connection reset by peer)
    +------------------------------------

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/alice/main.py", line 180, in <module>
    main()
  File "/home/alice/main.py", line 50, in main
    driver.verify_connectivity()
  File "/<neo4j-install-path>/neo4j/_sync/driver.py", line 1054, in verify_connectivity
    self._get_server_info(session_config)
  File "/<neo4j-install-path>/neo4j/_sync/driver.py", line 1283, in _get_server_info
    return session._get_server_info()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/<neo4j-install-path>/neo4j/_sync/work/session.py", line 173, in _get_server_info
    self._connect(
  File "/<neo4j-install-path>/neo4j/_sync/work/session.py", line 126, in _connect
    super()._connect(
  File "/<neo4j-install-path>/neo4j/_sync/work/workspace.py", line 160, in _connect
    target_db = self._get_routing_target_database(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/<neo4j-install-path>/neo4j/_sync/work/workspace.py", line 234, in _get_routing_target_database
    self._pool.update_routing_table(
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 1075, in update_routing_table
    raise ServiceUnavailable(
neo4j.exceptions.ServiceUnavailable: Unable to retrieve routing information
```

</details>

### Example Output Python 3.10
<details>
<summary>output</summary>

```
Traceback (most recent call last):
  File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 439, in _connect_secure
    s = ssl_context.wrap_socket(s, server_hostname=sni_host)
  File "/usr/lib/python3.10/ssl.py", line 513, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/lib/python3.10/ssl.py", line 1100, in _create
    self.do_handshake()
  File "/usr/lib/python3.10/ssl.py", line 1371, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLEOFError: [SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1007)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 324, in connect
    s = cls._connect_secure(
  File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 441, in _connect_secure
    raise BoltSecurityError(
neo4j._exceptions.BoltSecurityError: [SSLEOFError] Connection Failed. Please ensure that your database is listening on the correct host and port and that you have enabled encryption if required. Note that the default encryption setting has changed in Neo4j 4.0. See the docs for more information. Failed to establish encrypted connection. (code 8: Exec format error)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 832, in fetch_routing_table
    new_routing_info = self.fetch_routing_info(
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 791, in fetch_routing_info
    cx = self._acquire(address, auth, deadline, None)
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 416, in _acquire
    return connection_creator()
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 231, in connection_creator
    connection = self.opener(
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 710, in opener
    return Bolt.open(
  File "/<neo4j-install-path>/neo4j/_sync/io/_bolt.py", line 364, in open
    s, protocol_version = BoltSocket.connect(
  File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 371, in connect
    raise ServiceUnavailable(
neo4j.exceptions.ServiceUnavailable: Couldn't connect to [::1]:7687 (resolved to ('[::1]:7687',)):
[SSLEOFError] Connection Failed. Please ensure that your database is listening on the correct host and port and that you have enabled encryption if required. Note that the default encryption setting has changed in Neo4j 4.0. See the docs for more information. Failed to establish encrypted connection. (code 8: Exec format error)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 439, in _connect_secure
    s = ssl_context.wrap_socket(s, server_hostname=sni_host)
  File "/usr/lib/python3.10/ssl.py", line 513, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/lib/python3.10/ssl.py", line 1100, in _create
    self.do_handshake()
  File "/usr/lib/python3.10/ssl.py", line 1371, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLEOFError: [SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1007)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 324, in connect
    s = cls._connect_secure(
  File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 441, in _connect_secure
    raise BoltSecurityError(
neo4j._exceptions.BoltSecurityError: [SSLEOFError] Connection Failed. Please ensure that your database is listening on the correct host and port and that you have enabled encryption if required. Note that the default encryption setting has changed in Neo4j 4.0. See the docs for more information. Failed to establish encrypted connection. (code 8: Exec format error)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 832, in fetch_routing_table
    new_routing_info = self.fetch_routing_info(
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 791, in fetch_routing_info
    cx = self._acquire(address, auth, deadline, None)
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 416, in _acquire
    return connection_creator()
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 231, in connection_creator
    connection = self.opener(
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 710, in opener
    return Bolt.open(
  File "/<neo4j-install-path>/neo4j/_sync/io/_bolt.py", line 364, in open
    s, protocol_version = BoltSocket.connect(
  File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 371, in connect
    raise ServiceUnavailable(
neo4j.exceptions.ServiceUnavailable: Couldn't connect to 127.0.0.1:7687 (resolved to ('127.0.0.1:7687',)):
[SSLEOFError] Connection Failed. Please ensure that your database is listening on the correct host and port and that you have enabled encryption if required. Note that the default encryption setting has changed in Neo4j 4.0. See the docs for more information. Failed to establish encrypted connection. (code 8: Exec format error)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 324, in connect
    s = cls._connect_secure(
  File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 415, in _connect_secure
    raise ServiceUnavailable(
neo4j.exceptions.ServiceUnavailable: Timed out trying to establish connection to ResolvedIPv4Address(('172.0.0.1', 7687))

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 832, in fetch_routing_table
    new_routing_info = self.fetch_routing_info(
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 791, in fetch_routing_info
    cx = self._acquire(address, auth, deadline, None)
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 416, in _acquire
    return connection_creator()
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 231, in connection_creator
    connection = self.opener(
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 710, in opener
    return Bolt.open(
  File "/<neo4j-install-path>/neo4j/_sync/io/_bolt.py", line 364, in open
    s, protocol_version = BoltSocket.connect(
  File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 371, in connect
    raise ServiceUnavailable(
neo4j.exceptions.ServiceUnavailable: Couldn't connect to 172.0.0.1:7687 (resolved to ('172.0.0.1:7687',)):
Timed out trying to establish connection to ResolvedIPv4Address(('172.0.0.1', 7687))

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 439, in _connect_secure
    s = ssl_context.wrap_socket(s, server_hostname=sni_host)
  File "/usr/lib/python3.10/ssl.py", line 513, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/lib/python3.10/ssl.py", line 1100, in _create
    self.do_handshake()
  File "/usr/lib/python3.10/ssl.py", line 1371, in do_handshake
    self._sslobj.do_handshake()
ConnectionResetError: [Errno 104] Connection reset by peer

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 324, in connect
    s = cls._connect_secure(
  File "/<neo4j-install-path>/neo4j/_async_compat/network/_bolt_socket.py", line 441, in _connect_secure
    raise BoltSecurityError(
neo4j._exceptions.BoltSecurityError: [ConnectionResetError] Connection Failed. Please ensure that your database is listening on the correct host and port and that you have enabled encryption if required. Note that the default encryption setting has changed in Neo4j 4.0. See the docs for more information. Failed to establish encrypted connection. (code 104: Connection reset by peer)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 832, in fetch_routing_table
    new_routing_info = self.fetch_routing_info(
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 791, in fetch_routing_info
    cx = self._acquire(address, auth, deadline, None)
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 416, in _acquire
    return connection_creator()
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 231, in connection_creator
    connection = self.opener(
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 710, in opener
    return Bolt.open(
  File "/<neo4j-install-path>/neo4j/_sync/io/_bolt.py", line 364, in open
    s, protocol_version = BoltSocket.connect(
  File "/<neo4j-install-path>/neo4j/_sync/io/_bolt_socket.py", line 371, in connect
    raise ServiceUnavailable(
neo4j.exceptions.ServiceUnavailable: Couldn't connect to 34.78.76.49:7687 (resolved to ('34.78.76.49:7687',)):
[ConnectionResetError] Connection Failed. Please ensure that your database is listening on the correct host and port and that you have enabled encryption if required. Note that the default encryption setting has changed in Neo4j 4.0. See the docs for more information. Failed to establish encrypted connection. (code 104: Connection reset by peer)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "//home/alice/main.py", line 180, in <module>
    main()
  File "//home/alice/main.py", line 50, in main
    driver.verify_connectivity()
  File "/<neo4j-install-path>/neo4j/_sync/driver.py", line 1054, in verify_connectivity
    self._get_server_info(session_config)
  File "/<neo4j-install-path>/neo4j/_sync/driver.py", line 1283, in _get_server_info
    return session._get_server_info()
  File "/<neo4j-install-path>/neo4j/_sync/work/session.py", line 173, in _get_server_info
    self._connect(
  File "/<neo4j-install-path>/neo4j/_sync/work/session.py", line 126, in _connect
    super()._connect(
  File "/<neo4j-install-path>/neo4j/_sync/work/workspace.py", line 160, in _connect
    target_db = self._get_routing_target_database(
  File "/<neo4j-install-path>/neo4j/_sync/work/workspace.py", line 234, in _get_routing_target_database
    self._pool.update_routing_table(
  File "/<neo4j-install-path>/neo4j/_sync/io/_pool.py", line 1075, in update_routing_table
    raise ServiceUnavailable(
neo4j.exceptions.ServiceUnavailable: Unable to retrieve routing information
```

</details>
