### PR TITLE
Make `UnsupportedServerProduct` subclass of `ConfigurationError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
     - Consistently check the value (also for non-routing drivers)
   - `neo4j.exceptions.UnsupportedServerProduct` if no common bolt protocol version could be negotiated with the server
    (instead of internal `neo4j._exceptions.BoltHandshakeError`).  
-    `UnsupportedServerProduct` is now a subclass of `ServiceUnavailable` (instead of `Exception` directly).
+    `UnsupportedServerProduct` is now a subclass of `ConfigurationError` (instead of `Exception` directly).
   - `connection_acquisition_timeout` configuration option
     - Raise `ValueError` on invalid values (instead of `ClientError`).
     - Consistently restrict the value to be strictly positive
@@ -71,7 +71,7 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
   If you were calling it directly, please use `Record.__getitem__(slice(...))` or simply `record[...]` instead.
 - Bookmarks
   - Remove deprecated class `neo4j.Bookmark` in favor of `neo4j.Bookmarks`.
-  - Remove deprecated class `session.last_bookmark()` in favor of `last_bookmarks()`.
+  - Remove deprecated method `session.last_bookmark()` in favor of `last_bookmarks()`.
   - Deprecate passing raw sting bookmarks as `initial_bookmarks` to `GraphDatabase.bookmark_manager()`.  
     Use a `neo4j.Bookmarks` object instead.
   - `Driver.session()` no longer accepts raw string bookmarks as `bookmarks` argument.  

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -2084,8 +2084,6 @@ Client-side errors
 
     * :class:`neo4j.exceptions.ReadServiceUnavailable`
 
-    * :class:`neo4j.exceptions.UnsupportedServerProduct`
-
     * :class:`neo4j.exceptions.IncompleteCommit`
 
   * :class:`neo4j.exceptions.ConfigurationError`
@@ -2093,6 +2091,8 @@ Client-side errors
     * :class:`neo4j.exceptions.AuthConfigurationError`
 
     * :class:`neo4j.exceptions.CertificateConfigurationError`
+
+    * :class:`neo4j.exceptions.UnsupportedServerProduct`
 
   * :class:`neo4j.exceptions.ConnectionPoolError`
 
@@ -2145,9 +2145,6 @@ Client-side errors
 .. autoexception:: neo4j.exceptions.ReadServiceUnavailable()
     :show-inheritance:
 
-.. autoexception:: neo4j.exceptions.UnsupportedServerProduct()
-    :show-inheritance:
-
 .. autoexception:: neo4j.exceptions.IncompleteCommit()
     :show-inheritance:
 
@@ -2158,6 +2155,9 @@ Client-side errors
     :show-inheritance:
 
 .. autoexception:: neo4j.exceptions.CertificateConfigurationError()
+    :show-inheritance:
+
+.. autoexception:: neo4j.exceptions.UnsupportedServerProduct()
     :show-inheritance:
 
 

--- a/src/neo4j/exceptions.py
+++ b/src/neo4j/exceptions.py
@@ -51,11 +51,11 @@ Driver API Errors
     + RoutingServiceUnavailable
     + WriteServiceUnavailable
     + ReadServiceUnavailable
-    + UnsupportedServerProduct
     + IncompleteCommit
   + ConfigurationError
     + AuthConfigurationError
     + CertificateConfigurationError
+    + UnsupportedServerProduct
   + ConnectionPoolError
     + ConnectionAcquisitionTimeoutError
 """
@@ -1028,20 +1028,6 @@ class ReadServiceUnavailable(ServiceUnavailable):
     """Raised when no read service is available."""
 
 
-# DriverError > ServiceUnavailable > UnsupportedServerProduct
-class UnsupportedServerProduct(ServiceUnavailable):
-    """
-    Raised when an unsupported server product is detected.
-
-    .. versionchanged:: 6.0
-        This exception is now a subclass of :class:`ServiceUnavailable`.
-        Before it was a subclass of :class:`Exception`.
-    """
-
-    def __init__(self, *args: object) -> None:
-        super().__init__(*args)
-
-
 # DriverError > ServiceUnavailable > IncompleteCommit
 class IncompleteCommit(ServiceUnavailable):
     """
@@ -1083,6 +1069,20 @@ class AuthConfigurationError(ConfigurationError):
 # DriverError > ConfigurationError > CertificateConfigurationError
 class CertificateConfigurationError(ConfigurationError):
     """Raised when there is an error with the certificate configuration."""
+
+
+# DriverError > ConfigurationError > UnsupportedServerProduct
+class UnsupportedServerProduct(ConfigurationError):
+    """
+    Raised when an unsupported server product is detected.
+
+    .. versionchanged:: 6.0
+        This exception is now a subclass of :class:`ConfigurationError`.
+        Before it was a subclass of :class:`Exception`.
+    """
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
 
 
 # DriverError > ConnectionPoolError


### PR DESCRIPTION
Amends https://github.com/neo4j/neo4j-python-driver/pull/1164

Reconsidered the change.
 * The error shouldn't be retryable. If driver and server cannot agree on a common bolt version, it's highly unlikely they will a short moment later.
 * `ServiceUnavailable` is used for connectivity issues (broken sockets, failed dial up, etc.). This error is not really in that category.