### PR TITLE
API Docs: remove Bolt 4.4 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
     - `ColourFormatter`
     - `TaskIdFilter`
     - all other indirectly exposed items from imports (e.g. `asyncio` as `neo4j.debug.asyncio`)
-- Deprecate ClockTime and its accessors
+- Deprecate `ClockTime` and its accessors
   - For each `neo4j.time.Date`, `neo4j.time.DateTime`, `neo4j.time.Time`
     - `from_clock_time` and `to_clock_time` methods
   - `neo4j.time.ClockTime` itself

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,6 @@ Bolt protocol versions supported:
 
 * Bolt 6.0
 * Bolt 5.0 - 5.8
-* Bolt 4.4
 
 See https://7687.org/bolt-compatibility/ for what Neo4j DBMS versions support which Bolt versions.
 See https://neo4j.com/developer/kb/neo4j-supported-versions/ for a driver-server compatibility matrix.


### PR DESCRIPTION
6.x drivers may or may not implement Bolt 4.4. If they do, it might get removed anytime if it becomes a maintenance burden. It's an undocumented and unsupported feature.