### PR TITLE
Improve repr string representation of spatial types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
 - The driver incorrectly applied a timeout hint received from the server to both read and write I/O operations.
   It is now only applied to read I/O operations.  
   In turn, a new configuration option `connection_write_timeout` with a default value of `30 seconds` is introduced.
+- Adjust `repr` string representation of spatial types to conform with Python's recommendations.
 
 
 ## Version 5.28

--- a/src/neo4j/spatial/__init__.py
+++ b/src/neo4j/spatial/__init__.py
@@ -69,7 +69,7 @@ class Point(tuple[float, ...]):
         return tuple.__new__(cls, map(float, iterable))
 
     def __repr__(self) -> str:
-        return f"POINT({' '.join(map(str, self))})"
+        return f"{self.__class__.__name__}({', '.join(map(repr, self))})"
 
     def __eq__(self, other: object) -> bool:
         try:

--- a/tests/integration/examples/test_geospatial_types_example.py
+++ b/tests/integration/examples/test_geospatial_types_example.py
@@ -49,7 +49,7 @@ def test_cartesian_point(driver):
 
     # Reading a 2D point from a record
     point2d: CartesianPoint = record_with_2d_point.get("fieldName")
-    str(point2d)  # POINT(1.0 5.1)
+    str(point2d)  # CartesianPoint(1.0, 5.1)
     _ = point2d.x  # 1.0
     _ = point2d.y  # 5.1
     # point2d.z raises AttributeError
@@ -58,7 +58,7 @@ def test_cartesian_point(driver):
 
     # Reading a 3D point from a record
     point3d: CartesianPoint = record_with_3d_point.get("fieldName")
-    str(point3d)  # POINT(1.0 -2.0 3.1)
+    str(point3d)  # CartesianPoint(1.0, -2.0, 3.1)
     _ = point3d.x  # 1.0
     _ = point3d.y  # -2.0
     _ = point3d.z  # 3.1
@@ -66,7 +66,7 @@ def test_cartesian_point(driver):
     len(point2d)  # 3
     # end::geospatial-types-cartesian[]
 
-    assert str(point2d) == "POINT(1.0 5.1)"
+    assert str(point2d) == "CartesianPoint(1.0, 5.1)"
     assert isinstance(point2d.x, float) and point2d.x == 1.0
     assert isinstance(point2d.y, float) and point2d.y == 5.1
     with pytest.raises(AttributeError):
@@ -75,7 +75,7 @@ def test_cartesian_point(driver):
     assert len(point2d) == 2
     assert point2d == in_point2d
 
-    assert str(point3d) == "POINT(1.0 -2.0 3.1)"
+    assert str(point3d) == "CartesianPoint(1.0, -2.0, 3.1)"
     assert isinstance(point3d.x, float) and point3d.x == 1.0
     assert isinstance(point3d.y, float) and point3d.y == -2.0
     assert isinstance(point3d.z, float) and point3d.z == 3.1
@@ -110,7 +110,7 @@ def test_wgs84_point(driver):
 
     # Reading a 2D point from a record
     point2d: WGS84Point = record_with_2d_point.get("fieldName")
-    str(point2d)  # POINT(1.0 5.1)
+    str(point2d)  # WGS84Point(1.0, 5.1)
     _ = point2d.longitude  # 1.0 (point2d.x is an alias for longitude)
     _ = point2d.latitude  # 5.1 (point2d.y is an alias for latitude)
     # point2d.height raises AttributeError (same with point2d.z)
@@ -119,7 +119,7 @@ def test_wgs84_point(driver):
 
     # Reading a 3D point from a record
     point3d = record_with_3d_point.get("fieldName")  # type: WGS84Point
-    str(point3d)  # POINT(1.0 -2.0 3.1)
+    str(point3d)  # WGS84Point(1.0, -2.0, 3.1)
     _ = point3d.longitude  # 1.0 (point3d.x is an alias for longitude)
     _ = point3d.latitude  # -2.0 (point3d.y is an alias for latitude)
     _ = point3d.height  # 3.1 (point3d.z is an alias for height)
@@ -127,7 +127,7 @@ def test_wgs84_point(driver):
     len(point2d)  # 3
     # end::geospatial-types-wgs84[]
 
-    assert str(point2d) == "POINT(1.0 5.1)"
+    assert str(point2d) == "WGS84Point(1.0, 5.1)"
     assert isinstance(point2d.longitude, float) and point2d.longitude == 1.0
     assert isinstance(point2d.x, float) and point2d.x == 1.0
     assert isinstance(point2d.latitude, float) and point2d.latitude == 5.1
@@ -140,7 +140,7 @@ def test_wgs84_point(driver):
     assert len(point2d) == 2
     assert point2d == in_point2d
 
-    assert str(point3d) == "POINT(1.0 -2.0 3.1)"
+    assert str(point3d) == "WGS84Point(1.0, -2.0, 3.1)"
     assert isinstance(point3d.longitude, float) and point3d.longitude == 1.0
     assert isinstance(point3d.x, float) and point3d.x == 1.0
     assert isinstance(point3d.latitude, float) and point3d.latitude == -2.0

--- a/tests/unit/common/spatial/test_cartesian_point.py
+++ b/tests/unit/common/spatial/test_cartesian_point.py
@@ -80,3 +80,20 @@ class TestCartesianPoint:
         assert expected is not actual
         assert expected.foo == actual.foo
         assert expected.foo is not actual.foo
+
+    @pytest.mark.parametrize(
+        ("args", "expected"),
+        (
+            ((), "CartesianPoint()"),
+            ((0,), "CartesianPoint(0.0)"),
+            ((1, 2), "CartesianPoint(1.0, 2.0)"),
+            ((1, 2, 3), "CartesianPoint(1.0, 2.0, 3.0)"),
+            (
+                (1.23, 2.34, 3.45, 4.56),
+                "CartesianPoint(1.23, 2.34, 3.45, 4.56)",
+            ),
+        ),
+    )
+    def test_repr(self, args, expected):
+        p = CartesianPoint(args)
+        assert repr(p) == expected

--- a/tests/unit/common/spatial/test_point.py
+++ b/tests/unit/common/spatial/test_point.py
@@ -93,3 +93,17 @@ class TestPoint:
         assert expected is not actual
         assert expected.foo == actual.foo
         assert expected.foo is not actual.foo
+
+    @pytest.mark.parametrize(
+        ("args", "expected"),
+        (
+            ((), "Point()"),
+            ((0,), "Point(0.0)"),
+            ((1, 2), "Point(1.0, 2.0)"),
+            ((1, 2, 3), "Point(1.0, 2.0, 3.0)"),
+            ((1.23, 2.34, 3.45, 4.56), "Point(1.23, 2.34, 3.45, 4.56)"),
+        ),
+    )
+    def test_repr(self, args, expected):
+        p = Point(args)
+        assert repr(p) == expected

--- a/tests/unit/common/spatial/test_wgs84_point.py
+++ b/tests/unit/common/spatial/test_wgs84_point.py
@@ -98,3 +98,17 @@ class TestWGS84Point:
         assert expected is not actual
         assert expected.foo == actual.foo
         assert expected.foo is not actual.foo
+
+    @pytest.mark.parametrize(
+        ("args", "expected"),
+        (
+            ((), "WGS84Point()"),
+            ((0,), "WGS84Point(0.0)"),
+            ((1, 2), "WGS84Point(1.0, 2.0)"),
+            ((1, 2, 3), "WGS84Point(1.0, 2.0, 3.0)"),
+            ((1.23, 2.34, 3.45, 4.56), "WGS84Point(1.23, 2.34, 3.45, 4.56)"),
+        ),
+    )
+    def test_repr(self, args, expected):
+        p = WGS84Point(args)
+        assert repr(p) == expected


### PR DESCRIPTION
Instead of `POINT(1.0 2.0 3.0)` (regardless of the sub-type) the `repr` string representation is now `WGS84Point(1.0, 2.0, 3.0)` or similar.

This is more in line with Python's recommendations:

>  If at all possible, this should look like a valid Python expression that could be used to recreate an object with the same value (given an appropriate environment). If this is not possible, a string of the form <...some useful description...> should be returned.
> 
> -- [https://docs.python.org/3/reference/datamodel.html#object.\_\_repr\_\_](https://docs.python.org/3/reference/datamodel.html#object.__repr__)

