### PR TITLE
Improve repr string representation of `Duration` and `ClockTime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
 - The driver incorrectly applied a timeout hint received from the server to both read and write I/O operations.
   It is now only applied to read I/O operations.  
   In turn, a new configuration option `connection_write_timeout` with a default value of `30 seconds` is introduced.
+- Adjust `repr` string representation of `Duration` and `ClockTime` to be more consistent with other temporal driver types.
 
 
 ## Version 5.28

--- a/src/neo4j/time/__init__.py
+++ b/src/neo4j/time/__init__.py
@@ -274,7 +274,7 @@ class ClockTime(tuple):
 
     def __repr__(self):
         s, ns = self
-        return f"ClockTime(seconds={s!r}, nanoseconds={ns!r})"
+        return f"neo4j.time.ClockTime(seconds={s!r}, nanoseconds={ns!r})"
 
     @property
     def seconds(self):
@@ -655,8 +655,12 @@ class Duration(  # type: ignore[misc]
     def __repr__(self) -> str:
         mo, day, sec, ns = self
         return (
-            f"Duration(months={mo!r}, days={day!r}, seconds={sec!r}, "
-            f"nanoseconds={ns!r})"
+            "neo4j.time.Duration("
+            f"months={mo!r}, "
+            f"days={day!r}, "
+            f"seconds={sec!r}, "
+            f"nanoseconds={ns!r}"
+            ")"
         )
 
     def __str__(self) -> str:

--- a/tests/unit/common/time/test_clocktime.py
+++ b/tests/unit/common/time/test_clocktime.py
@@ -96,4 +96,4 @@ class TestClockTime:
 
     def test_repr(self):
         ct = _ClockTime(123456.789)
-        assert repr(ct).startswith("ClockTime")
+        assert repr(ct).startswith("neo4j.time.ClockTime")

--- a/tests/unit/common/time/test_duration.py
+++ b/tests/unit/common/time/test_duration.py
@@ -356,7 +356,9 @@ class TestDuration:
     def test_repr(self) -> None:
         d = Duration(months=2, days=3, seconds=5.7)
         assert repr(d) == (
-            "Duration(months=2, days=3, seconds=5, nanoseconds=700000000)"
+            "neo4j.time.Duration("
+            "months=2, days=3, seconds=5, nanoseconds=700000000"
+            ")"
         )
 
     def test_iso_format(self) -> None:


### PR DESCRIPTION
Instead of for example `Duration(months=1, days=2, seconds=3, nanoseconds=4)` the `repr` string representation is now `neo4j.time.Duration(months=1, days=2, seconds=3, nanoseconds=4)` or similar.

Both are fine in regards to Python's recommendations. However, the latter is more consistent with all other types defined in `neo4j.time`.

`ClockTime`'s `repr` was changed in the same way.