### PR TITLE
Improve repr string for `OrderedSet` and `RoutingTable`

### DIFF
--- a/src/neo4j/_routing.py
+++ b/src/neo4j/_routing.py
@@ -32,6 +32,13 @@ class OrderedSet(MutableSet):
         self._current = None
 
     def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(("
+            f"{', '.join(map(repr, self._elements))}"
+            f"))"
+        )
+
+    def __str__(self):
         return f"{{{', '.join(map(repr, self._elements))}}}"
 
     def __contains__(self, element):
@@ -118,10 +125,14 @@ class RoutingTable:
 
     def __repr__(self):
         return (
-            f"RoutingTable(database={self.database!r}, "
-            f"routers={self.routers!r}, readers={self.readers!r}, "
-            f"writers={self.writers!r}, "
-            f"last_updated_time={self.last_updated_time!r}, ttl={self.ttl!r})"
+            "RoutingTable("
+            f"database={self.database!r}, "
+            f"routers={tuple(self.routers)!r}, "
+            f"readers={tuple(self.readers)!r}, "
+            f"writers={tuple(self.writers)!r}, "
+            f"last_updated_time={self.last_updated_time!r}, "
+            f"ttl={self.ttl!r}"
+            ")"
         )
 
     def __contains__(self, address):

--- a/tests/unit/common/io/test_routing.py
+++ b/tests/unit/common/io/test_routing.py
@@ -58,10 +58,6 @@ VALID_ROUTING_RECORD_WITH_EXTRA_ROLE = {
 
 
 class TestOrderedSet:
-    def test_should_repr_as_set(self):
-        s = OrderedSet([1, 2, 3])
-        assert repr(s) == "{1, 2, 3}"
-
     def test_should_contain_element(self):
         s = OrderedSet([1, 2, 3])
         assert 2 in s
@@ -133,6 +129,17 @@ class TestOrderedSet:
         s = OrderedSet([1, 2, 3])
         s.replace([3, 4, 5])
         assert list(s) == [3, 4, 5]
+
+    def test_repr(self):
+        s = OrderedSet([1, 2, 3, "abc"])
+        expected_repr = "OrderedSet((1, 2, 3, 'abc'))"
+        assert repr(s) == expected_repr
+        assert eval(repr(s)) == s
+
+    def test_str(self):
+        s = OrderedSet([1, 2, 3, "abc"])
+        expected_repr = "{1, 2, 3, 'abc'}"
+        assert str(s) == expected_repr
 
 
 class TestRoutingTableConstruction:


### PR DESCRIPTION
Both types are not public. Therefore, this change won't affect public driver API. It might, however, show up in driver logs.