### PR TITLE
Amend notification APIs deprecation in favor of GQL status APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,8 @@ See also https://github.com/neo4j/neo4j-python-driver/wiki for a full changelog.
     - `neo4j.SummaryNotification`
     - `neo4j.NotificationCategory`
     - `neo4j.NotificationDisabledCategory`
+    - `notifications_disabled_categories` driver and session configuration option
+      in favor of `notifications_disabled_classifications`
   - Stabilize GQL status objects (use this instead of notifications):
     - `ResultSummary.gql_status_objects`
     - `neo4j.GqlStatusObject`

--- a/src/neo4j/_api.py
+++ b/src/neo4j/_api.py
@@ -272,6 +272,9 @@ class NotificationDisabledCategory(str, Enum):
 
     .. versionchanged:: 5.24
         Added category :attr:`.SCHEMA`.
+
+    .. deprecated:: 6.0
+        Use :class:`.NotificationDisabledClassification` instead.
     """
 
     HINT = "HINT"
@@ -294,12 +297,6 @@ class NotificationDisabledClassification(str, Enum):
     This alternative is provided for a consistent naming with
     :attr:`.GqlStatusObject.classification`.
 
-    **This is a preview**.
-    It might be changed without following the deprecation policy.
-
-    See also
-    https://github.com/neo4j/neo4j-python-driver/wiki/preview-features
-
     .. seealso::
         driver config
         :ref:`driver-notifications-disabled-classifications-ref`,
@@ -310,6 +307,8 @@ class NotificationDisabledClassification(str, Enum):
 
     .. versionchanged:: 5.24
         Added classification :attr:`.SCHEMA`.
+
+    .. versionchanged:: 6.0 Stabilized from preview.
     """
 
     HINT = "HINT"
@@ -326,7 +325,7 @@ class NotificationDisabledClassification(str, Enum):
 
 
 if t.TYPE_CHECKING:
-    T_NotificationDisabledCategory = (
+    T_NotificationDisabledClassification = (
         NotificationDisabledCategory
         | NotificationDisabledClassification
         | t.Literal[
@@ -341,7 +340,7 @@ if t.TYPE_CHECKING:
             "SCHEMA",
         ]
     )
-    __all__.append("T_NotificationDisabledCategory")
+    __all__.append("T_NotificationDisabledClassification")
 
 
 class NotificationCategory(str, Enum):

--- a/src/neo4j/_async/driver.py
+++ b/src/neo4j/_async/driver.py
@@ -96,7 +96,7 @@ if t.TYPE_CHECKING:
     from enum import Enum
 
     from .._api import (
-        T_NotificationDisabledCategory,
+        T_NotificationDisabledClassification,
         T_NotificationMinimumSeverity,
         T_RoutingControl,
     )
@@ -143,11 +143,12 @@ class AsyncGraphDatabase:
             notifications_min_severity: (
                 T_NotificationMinimumSeverity | None
             ) = ...,
+            # deprecated in favor of notifications_disabled_classifications
             notifications_disabled_categories: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             notifications_disabled_classifications: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             warn_notification_severity: (
                 T_NotificationMinimumSeverity | None
@@ -542,11 +543,12 @@ class AsyncDriver:
             notifications_min_severity: (
                 T_NotificationMinimumSeverity | None
             ) = ...,
+            # deprecated in favor of notifications_disabled_classifications
             notifications_disabled_categories: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             notifications_disabled_classifications: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             # undocumented/unsupported options
             # they may be change or removed any time without prior notice
@@ -572,7 +574,10 @@ class AsyncDriver:
             :raises DriverError: if the driver has been closed.
 
             .. versionchanged:: 6.0
-                Raise :exc:`DriverError` if the driver has been closed.
+
+                * Raise :exc:`DriverError` if the driver has been closed.
+                * Deprecated ``notifications_disabled_categories`` in favor of
+                  ``notifications_disabled_classifications``.
             """
             # Would work just fine, but we don't want to introduce yet
             # another undocumented/unsupported config option.
@@ -1001,10 +1006,10 @@ class AsyncDriver:
                 T_NotificationMinimumSeverity | None
             ) = ...,
             notifications_disabled_categories: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             notifications_disabled_classifications: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             # undocumented/unsupported options
             initial_retry_delay: float = ...,
@@ -1078,10 +1083,10 @@ class AsyncDriver:
                 T_NotificationMinimumSeverity | None
             ) = ...,
             notifications_disabled_categories: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             notifications_disabled_classifications: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             # undocumented/unsupported options
             initial_retry_delay: float = ...,

--- a/src/neo4j/_sync/driver.py
+++ b/src/neo4j/_sync/driver.py
@@ -95,7 +95,7 @@ if t.TYPE_CHECKING:
     from enum import Enum
 
     from .._api import (
-        T_NotificationDisabledCategory,
+        T_NotificationDisabledClassification,
         T_NotificationMinimumSeverity,
         T_RoutingControl,
     )
@@ -142,11 +142,12 @@ class GraphDatabase:
             notifications_min_severity: (
                 T_NotificationMinimumSeverity | None
             ) = ...,
+            # deprecated in favor of notifications_disabled_classifications
             notifications_disabled_categories: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             notifications_disabled_classifications: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             warn_notification_severity: (
                 T_NotificationMinimumSeverity | None
@@ -541,11 +542,12 @@ class Driver:
             notifications_min_severity: (
                 T_NotificationMinimumSeverity | None
             ) = ...,
+            # deprecated in favor of notifications_disabled_classifications
             notifications_disabled_categories: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             notifications_disabled_classifications: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             # undocumented/unsupported options
             # they may be change or removed any time without prior notice
@@ -571,7 +573,10 @@ class Driver:
             :raises DriverError: if the driver has been closed.
 
             .. versionchanged:: 6.0
-                Raise :exc:`DriverError` if the driver has been closed.
+
+                * Raise :exc:`DriverError` if the driver has been closed.
+                * Deprecated ``notifications_disabled_categories`` in favor of
+                  ``notifications_disabled_classifications``.
             """
             # Would work just fine, but we don't want to introduce yet
             # another undocumented/unsupported config option.
@@ -1000,10 +1005,10 @@ class Driver:
                 T_NotificationMinimumSeverity | None
             ) = ...,
             notifications_disabled_categories: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             notifications_disabled_classifications: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             # undocumented/unsupported options
             initial_retry_delay: float = ...,
@@ -1077,10 +1082,10 @@ class Driver:
                 T_NotificationMinimumSeverity | None
             ) = ...,
             notifications_disabled_categories: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             notifications_disabled_classifications: (
-                t.Iterable[T_NotificationDisabledCategory] | None
+                t.Iterable[T_NotificationDisabledClassification] | None
             ) = ...,
             # undocumented/unsupported options
             initial_retry_delay: float = ...,


### PR DESCRIPTION
This PR fixes some docs that were missed in https://github.com/neo4j/neo4j-python-driver/pull/1209