### PR TITLE
API docs: keep official support for Bolt 4.4

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Bolt protocol versions supported:
 
 * Bolt 6.0
 * Bolt 5.0 - 5.8
+* Bolt 4.4
 
 See https://7687.org/bolt-compatibility/ for what Neo4j DBMS versions support which Bolt versions.
 See https://neo4j.com/developer/kb/neo4j-supported-versions/ for a driver-server compatibility matrix.


### PR DESCRIPTION
Turns out we're committing to keeping support for Bolt 4.4 in the 6.x drivers.

Reverts: #1225

Reverts: 134be3e490416a5eb702c542f2e97e9dc4cf345a