### PR TITLE
API docs: fix server version needed for vectors

### DIFF
--- a/src/neo4j/vector.py
+++ b/src/neo4j/vector.py
@@ -77,7 +77,7 @@ class Vector:
     Internally, a vector is stored as a contiguous block of memory
     (:class:`bytes`), containing homogeneous values encoded in big-endian
     order. Support for this feature requires a DBMS supporting Bolt version
-    6.0 or later. This corresponds to Neo4j 2025.08 or later.
+    6.0 or later.
 
     :param data:
         The data from which the vector will be constructed.


### PR DESCRIPTION
At the time of writing (and very likely the next release), no server with non-experimental Bolt 6.0 support has been released. Therefore, this note needs to go for now.