### PR TITLE
[5.28] Fix driver factory type hints suggesting unsupported options

### DIFF
--- a/src/neo4j/_async/driver.py
+++ b/src/neo4j/_async/driver.py
@@ -164,10 +164,10 @@ class AsyncGraphDatabase:
                 T_NotificationMinimumSeverity | None
             ) = ...,
             telemetry_disabled: bool = ...,
+            max_transaction_retry_time: float = ...,
+            connection_acquisition_timeout: float = ...,
             # undocumented/unsupported options
             # they may be changed or removed any time without prior notice
-            connection_acquisition_timeout: float = ...,
-            max_transaction_retry_time: float = ...,
             initial_retry_delay: float = ...,
             retry_delay_multiplier: float = ...,
             retry_delay_jitter_factor: float = ...,

--- a/src/neo4j/_sync/driver.py
+++ b/src/neo4j/_sync/driver.py
@@ -163,10 +163,10 @@ class GraphDatabase:
                 T_NotificationMinimumSeverity | None
             ) = ...,
             telemetry_disabled: bool = ...,
+            max_transaction_retry_time: float = ...,
+            connection_acquisition_timeout: float = ...,
             # undocumented/unsupported options
             # they may be changed or removed any time without prior notice
-            connection_acquisition_timeout: float = ...,
-            max_transaction_retry_time: float = ...,
             initial_retry_delay: float = ...,
             retry_delay_multiplier: float = ...,
             retry_delay_jitter_factor: float = ...,


### PR DESCRIPTION
The type hints of the driver factory incorrectly suggested that the config options `max_transaction_retry_time` and `connection_acquisition_timeout` are unsupported.

Backport of #1255