### PR TITLE
[5.28] Fix up TestKit time warp backend

### DIFF
--- a/testkit/.dockerignore
+++ b/testkit/.dockerignore
@@ -1,2 +1,1 @@
 *.py
-!backend.py

--- a/testkit/Dockerfile
+++ b/testkit/Dockerfile
@@ -4,31 +4,48 @@ FROM ubuntu:20.04 AS base
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y locales && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ENV LANG=en_US.UTF-8
 
 # Using apt-get update alone in a RUN statement causes caching issues and subsequent apt-get install instructions fail.
-RUN apt-get --quiet update && apt-get --quiet install -y \
-    software-properties-common \
-    bash \
-    python3 \
-    python3-pip \
-    git \
-    curl \
-    tar \
-    wget \
- && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y \
+        software-properties-common \
+        bash \
+        python3 \
+        python3-pip \
+        git \
+        curl \
+        tar \
+        wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Build Tools
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
-        libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev \
-        libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+        make \
+        build-essential \
+        libssl-dev \
+        zlib1g-dev \
+        libbz2-dev \
+        libreadline-dev\
+        libsqlite3-dev \
+        wget \
+        curl \
+        llvm \
+        libncurses5-dev \
+        xz-utils \
+        tk-dev\
+        libxml2-dev \
+        libxmlsec1-dev \
+        libffi-dev \
+        liblzma-dev\
         ca-certificates && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install pyenv
 RUN git clone https://github.com/pyenv/pyenv.git .pyenv
@@ -62,20 +79,22 @@ RUN for version in $PYTHON_VERSIONS; do \
         python$version -m pip install -U coverage tox; \
     done
 
+ARG TIME_WARP
+ENV DRIVER_TIME_WARP=$TIME_WARP
+
 
 FROM base-py-install AS backend-timewarp
 WORKDIR /home/root/testkit
 COPY requirements*.txt .
-COPY testkit/backend.py testkit/build.py testkit/_common.py .
+COPY testkit/backend.py testkit/build.py testkit/_common.py testkit/
 RUN sed -i 's|-e \..*$||' requirements*.txt
 
-ARG TIME_WARP
 RUN for version in $PYTHON_VERSIONS; do \
-        TEST_BACKEND_VERSION="python$version" python build.py && \
-        python$version -m pip install --force-reinstall neo4j==${TIME_WARP}; \
+        TEST_BACKEND_VERSION="python$version" python testkit/build.py && \
+        python$version -m pip install --force-reinstall neo4j==$TIME_WARP; \
     done
 COPY testkitbackend ./testkitbackend
-ENTRYPOINT ["python", "backend.py"]
+ENTRYPOINT ["python", "testkit/backend.py"]
 
 
 FROM base-py-install AS backend
@@ -88,7 +107,6 @@ RUN update-ca-certificates
 
 
 FROM backend${TIME_WARP:+"-timewarp"} AS final
-ARG TIME_WARP
-ENV DRIVER_TIME_WARP=$TIME_WARP
+RUN env
 WORKDIR /home/root/testkit
 EXPOSE 9876/tcp

--- a/testkit/_common.py
+++ b/testkit/_common.py
@@ -21,6 +21,7 @@ import sys
 
 
 TEST_BACKEND_VERSION = os.getenv("TEST_BACKEND_VERSION", "python")
+DRIVER_TIME_WARP = os.getenv("DRIVER_TIME_WARP")
 
 
 def run(args, env=None):

--- a/testkit/build.py
+++ b/testkit/build.py
@@ -16,15 +16,20 @@
 
 """Building driver and test backend inside driver container."""
 
-from _common import run_python
+from _common import (
+    DRIVER_TIME_WARP,
+    run_python,
+)
 
 
 if __name__ == "__main__":
-    run_python(
-        ["-m", "pip", "install", "-U", "pip", "build"],
-        warning_as_error=False,
-    )
-    run_python(["-m", "build", "."], warning_as_error=True)
+    if not DRIVER_TIME_WARP:
+        run_python(
+            ["-m", "pip", "install", "-U", "pip", "build"],
+            warning_as_error=False,
+        )
+        run_python(["-m", "build", "."], warning_as_error=True)
+
     run_python(
         ["-m", "pip", "install", "-Ur", "requirements-dev.txt"],
         warning_as_error=False,

--- a/testkitbackend/time_warp_compat.py
+++ b/testkitbackend/time_warp_compat.py
@@ -136,15 +136,15 @@ def _get_blocked_testkit_features() -> frozenset[str]:
 
 def _get_extra_testkit_features() -> frozenset[str]:
     extra: list[str] = []
-    if VERSION < (5, 28):
-        extra.extend(("Feature:Bolt:4.0",))
     return frozenset(extra)
 
 
 BLOCKED_TESTKIT_FEATURES: te.Final[frozenset[str]] = (
     _get_blocked_testkit_features()
 )
-EXTRA_TESTKIT_FEATURES: te.Final[frozenset[str]] = frozenset()
+EXTRA_TESTKIT_FEATURES: te.Final[frozenset[str]] = (
+    _get_extra_testkit_features()
+)
 
 
 if GQL_ERROR_SUPPORT:


### PR DESCRIPTION
Closes DRIVERS-69

Including insights from porting the time warp functionality to the 6.x branch. This includes:
 * Docker file formatting
 * Docker file simplification
 * Fixing infinite loop in time warped backend build process

Amends https://github.com/neo4j/neo4j-python-driver/pull/1245