### PR TITLE
Fix AttributeError when pool is None in Bolt3 error handling

### DIFF
--- a/src/neo4j/_async/io/_bolt3.py
+++ b/src/neo4j/_async/io/_bolt3.py
@@ -588,7 +588,8 @@ class AsyncBolt3(AsyncBolt):
                     )
                 raise
             except Neo4jError as e:
-                await self.pool.on_neo4j_error(e, self)
+                if self.pool:
+                    await self.pool.on_neo4j_error(e, self)
                 raise
         else:
             sig_int = ord(summary_signature)

--- a/src/neo4j/_sync/io/_bolt3.py
+++ b/src/neo4j/_sync/io/_bolt3.py
@@ -588,7 +588,8 @@ class Bolt3(Bolt):
                     )
                 raise
             except Neo4jError as e:
-                self.pool.on_neo4j_error(e, self)
+                if self.pool:
+                    self.pool.on_neo4j_error(e, self)
                 raise
         else:
             sig_int = ord(summary_signature)


### PR DESCRIPTION
## Fix AttributeError when pool is None in Bolt3 error handling

### Problem
When a Neo4jError is raised in Bolt3 connections, the error handler attempts to call self.pool.on_neo4j_error() without checking if self.pool exists. This causes an AttributeError when the connection pool is None or not available.

### Solution
Added a null check for self.pool before calling on_neo4j_error(), consistent with the existing error handling pattern used for ServiceUnavailable, DatabaseUnavailable, NotALeader, and ForbiddenOnReadOnlyDatabase exceptions in the same method.

### Changes
- src/neo4j/_async/io/_bolt3.py: Added if self.pool: check before await self.pool.on_neo4j_error()
- src/neo4j/_sync/io/_bolt3.py: Auto-generated sync version with the same fix

This prevents crashes when handling Neo4j errors in scenarios where the connection pool is not initialized or has been cleared.

*Note:*
I am a first-time contributor and have just signed the CLA