### PR TITLE
[5.28] Fix AttributeError when pool is None in Bolt3 error handling

### DIFF
--- a/src/neo4j/_async/io/_bolt3.py
+++ b/src/neo4j/_async/io/_bolt3.py
@@ -591,7 +591,8 @@ class AsyncBolt3(AsyncBolt):
                     )
                 raise
             except Neo4jError as e:
-                await self.pool.on_neo4j_error(e, self)
+                if self.pool:
+                    await self.pool.on_neo4j_error(e, self)
                 raise
         else:
             sig_int = ord(summary_signature)

--- a/src/neo4j/_sync/io/_bolt3.py
+++ b/src/neo4j/_sync/io/_bolt3.py
@@ -591,7 +591,8 @@ class Bolt3(Bolt):
                     )
                 raise
             except Neo4jError as e:
-                self.pool.on_neo4j_error(e, self)
+                if self.pool:
+                    self.pool.on_neo4j_error(e, self)
                 raise
         else:
             sig_int = ord(summary_signature)


### PR DESCRIPTION
Add null check for self.pool before calling on_neo4j_error() in async Bolt3 implementation to prevent AttributeError when the connection pool is not available during Neo4jError handling.

Backport of https://github.com/neo4j/neo4j-python-driver/pull/1267