### PR TITLE
[5.28] Add .semgrepignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@ docs/build
 dist
 *.egg-info
 build
-venv
+/.venv*/
+/venv*/
 
 run
 */run

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,7 @@
+:include .gitignore
+
+/benchkit/
+/docs/
+/testkit/
+/testkitbackend/
+/tests/


### PR DESCRIPTION
Closes: DRIVERS-208

Backport of https://github.com/neo4j/neo4j-python-driver/pull/1270