### PR TITLE
[5.28] Fix: connection_acquisition_timeout now covers TLS handshake

### DIFF
--- a/src/neo4j/_async/io/_bolt_socket.py
+++ b/src/neo4j/_async/io/_bolt_socket.py
@@ -326,7 +326,11 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
             s = None
             try:
                 s = await cls._connect_secure(
-                    resolved_address, tcp_timeout, keep_alive, ssl_context
+                    resolved_address,
+                    tcp_timeout,
+                    deadline,
+                    keep_alive,
+                    ssl_context,
                 )
                 agreed_version, handshake, response = await s._handshake(
                     resolved_address, deadline

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -170,13 +170,14 @@ class AsyncBoltSocketBase(abc.ABC):
 
     @classmethod
     async def _connect_secure(
-        cls, resolved_address, timeout, keep_alive, ssl_context
+        cls, resolved_address, timeout, deadline, keep_alive, ssl_context
     ) -> te.Self:
         """
         Connect to the address and return the socket.
 
         :param resolved_address:
         :param timeout: seconds
+        :param deadline: deadline for the whole operation
         :param keep_alive: True or False
         :param ssl_context: SSLContext or None
 
@@ -207,7 +208,11 @@ class AsyncBoltSocketBase(abc.ABC):
             if ssl_context is not None:
                 hostname = resolved_address._host_name or None
                 sni_host = hostname if HAS_SNI and hostname else None
-                ssl_kwargs.update(ssl=ssl_context, server_hostname=sni_host)
+                ssl_kwargs.update(
+                    ssl=ssl_context,
+                    server_hostname=sni_host,
+                    ssl_handshake_timeout=deadline.to_timeout(),
+                )
                 log.debug("[#%04X]  C: <SECURE> %s", local_port, hostname)
 
             reader = asyncio.StreamReader(
@@ -374,13 +379,14 @@ class BoltSocketBase:
 
     @classmethod
     def _connect_secure(
-        cls, resolved_address, timeout, keep_alive, ssl_context
+        cls, resolved_address, timeout, deadline, keep_alive, ssl_context
     ):
         """
         Connect to the address and return the socket.
 
         :param resolved_address:
         :param timeout: seconds
+        :param deadline: deadline for the whole operation
         :param keep_alive: True or False
         :returns: socket object
         """
@@ -436,7 +442,11 @@ class BoltSocketBase:
                 sni_host = hostname if HAS_SNI and hostname else None
                 log.debug("[#%04X]  C: <SECURE> %s", local_port, hostname)
                 try:
+                    t = s.gettimeout()
+                    if timeout:
+                        s.settimeout(deadline.to_timeout())
                     s = ssl_context.wrap_socket(s, server_hostname=sni_host)
+                    s.settimeout(t)
                 except (OSError, SSLError, CertificateError) as cause:
                     raise BoltSecurityError(
                         message="Failed to establish encrypted connection.",

--- a/src/neo4j/_sync/io/_bolt_socket.py
+++ b/src/neo4j/_sync/io/_bolt_socket.py
@@ -326,7 +326,11 @@ class BoltSocket(BoltSocketBase):
             s = None
             try:
                 s = cls._connect_secure(
-                    resolved_address, tcp_timeout, keep_alive, ssl_context
+                    resolved_address,
+                    tcp_timeout,
+                    deadline,
+                    keep_alive,
+                    ssl_context,
                 )
                 agreed_version, handshake, response = s._handshake(
                     resolved_address, deadline


### PR DESCRIPTION
Part of: DRIVERS-233

Backport of https://github.com/neo4j/neo4j-python-driver/pull/1274