### PR TITLE
[5.28] Fix overflow in `DateTime` + negative `Duration`

### DIFF
--- a/src/neo4j/time/__init__.py
+++ b/src/neo4j/time/__init__.py
@@ -2652,7 +2652,7 @@ class DateTime(date_time_base_class, metaclass=DateTimeType):
             t = self.time().to_clock_time() + ClockTime(
                 other.seconds, other.nanoseconds
             )
-            days, seconds = symmetric_divmod(t.seconds, 86400)
+            days, seconds = divmod(t.seconds, 86400)
             date_ = self.date() + Duration(
                 months=other.months, days=days + other.days
             )

--- a/tests/unit/common/time/test_datetime.py
+++ b/tests/unit/common/time/test_datetime.py
@@ -316,6 +316,11 @@ class TestDateTime:
                 DateTime(2024, 4, 1, 0, 30, 0),
             ),
             (
+                DateTime(2025, 1, 1, 13, 45, 30, 123456789),
+                Duration(seconds=-50400),
+                DateTime(2024, 12, 31, 23, 45, 30, 123456789),
+            ),
+            (
                 DateTime(2024, 3, 31, 0, 30, 0),
                 timedelta(microseconds=1),
                 DateTime(2024, 3, 31, 0, 30, 0, 1000),
@@ -324,6 +329,11 @@ class TestDateTime:
                 DateTime(2024, 3, 31, 0, 30, 0),
                 timedelta(hours=24),
                 DateTime(2024, 4, 1, 0, 30, 0),
+            ),
+            (
+                DateTime(2025, 1, 1, 13, 45, 30, 123456789),
+                timedelta(seconds=-50400),
+                DateTime(2024, 12, 31, 23, 45, 30, 123456789),
             ),
         ),
     )


### PR DESCRIPTION
Backport of:
 * https://github.com/neo4j/neo4j-python-driver/pull/1279

Fixes: DRIVERS-248