### PR TITLE
[5.28] CI: explicitly set GitHub Actions permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,5 @@
 name: Tests
+permissions: {}
 
 on:
   push:


### PR DESCRIPTION
Backport of:
 * https://github.com/neo4j/neo4j-python-driver/pull/1289

Closes: DRIVERS-254