### PR TITLE
Pandas 3 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ Discord = "https://discord.com/invite/neo4j"
 [project.optional-dependencies]
 numpy = ["numpy >= 1.21.2, < 3.0.0"]
 pandas = [
-    "pandas >= 1.1.0, < 3.0.0",
+    "pandas[timezone] >= 1.1.0, < 4.0.0",
     "numpy >= 1.21.2, < 3.0.0",
 ]
 pyarrow = ["pyarrow >= 6.0.0, < 23.0.0"]
@@ -115,6 +115,7 @@ test = [
 typing = [
     "mypy >= 1.18.2",
     "types-pytz >= 2025.2.0.20250809",
+    "pandas-stubs >= 1.0.0, < 4.0.0",
     {include-group = "dep-typing-extensions"},
     {include-group = "dep-project-dependencies"},
     # tests are also type-checked
@@ -151,7 +152,7 @@ dep-freezegun = ["freezegun >= 1.5.5"]
 dep-project-dependencies = [
     "pytz",
     "numpy >= 1.7.0, < 3.0.0",
-    "pandas >= 1.1.0, < 3.0.0",
+    "pandas[timezone] >= 1.1.0, < 4.0.0",
     "pyarrow >= 6.0.0, < 23.0.0",
 ]
 
@@ -212,7 +213,6 @@ asyncio_default_fixture_loop_scope="function"
 
 [[tool.mypy.overrides]]
 module = [
-    "pandas.*",
     "pyarrow.*",
     "neo4j._rust",
     "neo4j._rust.*",

--- a/src/neo4j/_async/work/result.py
+++ b/src/neo4j/_async/work/result.py
@@ -60,14 +60,14 @@ from ..io import ConnectionErrorHandler
 
 
 if t.TYPE_CHECKING:
-    import pandas  # type: ignore[import]
+    import pandas
 
     from ..._addressing import Address
     from ...graph import Graph
 
 
 if False:
-    # Ugly work-around to make sphinx understand `@_t.overload`
+    # Ugly work-around to make sphinx understand `@t.overload`
     import typing as t  # type: ignore[no-redef]
 
 
@@ -908,7 +908,7 @@ class AsyncResult(AsyncNonConcurrentMethodChecker):
             was obtained has been closed or the Result has been explicitly
             consumed.
         """
-        import pandas as pd  # type: ignore[import]
+        import pandas as pd
         import pytz
 
         if not expand:

--- a/src/neo4j/_codec/hydration/v2/hydration_handler.py
+++ b/src/neo4j/_codec/hydration/v2/hydration_handler.py
@@ -48,7 +48,7 @@ from ..v1.hydration_handler import _GraphHydrator
 from . import temporal as temporal_v2
 
 
-class HydrationHandler(HydrationHandlerABC):  # type: ignore[no-redef]
+class HydrationHandler(HydrationHandlerABC):
     def __init__(self):
         super().__init__()
         self._created_scope = False

--- a/src/neo4j/_codec/hydration/v2/temporal.py
+++ b/src/neo4j/_codec/hydration/v2/temporal.py
@@ -30,7 +30,7 @@ from ...packstream import Structure
 from ..v1.temporal import get_date_unix_epoch_ordinal
 
 
-def hydrate_datetime(seconds, nanoseconds, tz=None):  # type: ignore[no-redef]
+def hydrate_datetime(seconds, nanoseconds, tz=None):
     """
     Hydrator for ``DateTime`` and ``LocalDateTime`` values.
 
@@ -59,7 +59,7 @@ def hydrate_datetime(seconds, nanoseconds, tz=None):  # type: ignore[no-redef]
     return t.as_timezone(zone)
 
 
-def dehydrate_datetime(value):  # type: ignore[no-redef]
+def dehydrate_datetime(value):
     """
     Dehydrator for ``datetime`` values.
 

--- a/src/neo4j/_codec/hydration/v3/hydration_handler.py
+++ b/src/neo4j/_codec/hydration/v3/hydration_handler.py
@@ -51,7 +51,7 @@ from . import (
 )
 
 
-class HydrationHandler(HydrationHandlerABC):  # type: ignore[no-redef]
+class HydrationHandler(HydrationHandlerABC):
     def __init__(self):
         super().__init__()
         self._created_scope = False

--- a/src/neo4j/_sync/work/result.py
+++ b/src/neo4j/_sync/work/result.py
@@ -60,14 +60,14 @@ from ..io import ConnectionErrorHandler
 
 
 if t.TYPE_CHECKING:
-    import pandas  # type: ignore[import]
+    import pandas
 
     from ..._addressing import Address
     from ...graph import Graph
 
 
 if False:
-    # Ugly work-around to make sphinx understand `@_t.overload`
+    # Ugly work-around to make sphinx understand `@t.overload`
     import typing as t  # type: ignore[no-redef]
 
 
@@ -908,7 +908,7 @@ class Result(NonConcurrentMethodChecker):
             was obtained has been closed or the Result has been explicitly
             consumed.
         """
-        import pandas as pd  # type: ignore[import]
+        import pandas as pd
         import pytz
 
         if not expand:

--- a/src/neo4j/time/__init__.py
+++ b/src/neo4j/time/__init__.py
@@ -1698,7 +1698,7 @@ class Time(_time_base_class, metaclass=_TimeType):
 
         :raises ValueError: if the string does not match the required format.
         """
-        from pytz import FixedOffset  # type: ignore
+        from pytz import FixedOffset
 
         m = _TIME_ISO_PATTERN.match(s)
         if m:

--- a/tests/unit/async_/work/test_result.py
+++ b/tests/unit/async_/work/test_result.py
@@ -74,6 +74,10 @@ if t.TYPE_CHECKING:
     )
 
 
+# https://pandas.pydata.org/docs/user_guide/migration-3-strings.html
+PD_STR_DTYPE = "object" if pd.__version__ < "3" else "string"
+
+
 class Records:
     def __init__(self, fields, records):
         self.fields = tuple(fields)
@@ -795,7 +799,7 @@ async def test_to_eager_result(records):
         (
             ["s"],
             list(zip(("foo", "bar", "baz", "foobar"), strict=True)),
-            ["object"],
+            [PD_STR_DTYPE],
             None,
         ),
         (["l"], list(zip(([1, 2], [3, 4]), strict=True)), ["object"], None),
@@ -909,7 +913,7 @@ async def test_to_df(keys, values, types, instances, test_default_expand):
             list(zip(("foo", "bar", "baz", "foobar"), strict=True)),
             ["s"],
             [["foo"], ["bar"], ["baz"], ["foobar"]],
-            ["object"],
+            [PD_STR_DTYPE],
         ),
         (
             ["l"],
@@ -963,7 +967,7 @@ async def test_to_df(keys, values, types, instances, test_default_expand):
             ),
             ["x[].0{}.foo", "x[].0{}.baz[].0", "x[].0{}.baz[].1", "x[].1"],
             [["bar", 42, 0.1, "foobar"]],
-            ["object", "int64", "float64", "object"],
+            [PD_STR_DTYPE, "int64", "float64", PD_STR_DTYPE],
         ),
         (
             ["n"],
@@ -1015,7 +1019,7 @@ async def test_to_df(keys, values, types, instances, test_default_expand):
                     3,
                 ],
             ],
-            ["object", "object", "object", "float64", "float64", "int64"],
+            [PD_STR_DTYPE, "object", "object", "float64", "float64", "int64"],
         ),
         (
             ["r"],
@@ -1060,7 +1064,14 @@ async def test_to_df(keys, values, types, instances, test_default_expand):
                 ["r-0", "r-1", "r-2", "TYPE", 1, False],
                 ["r-420", "r-1337", "r-69", "HYPE", None, True],
             ],
-            ["object", "object", "object", "object", "float64", "bool"],
+            [
+                PD_STR_DTYPE,
+                PD_STR_DTYPE,
+                PD_STR_DTYPE,
+                PD_STR_DTYPE,
+                "float64",
+                "bool",
+            ],
         ),
         (
             ["dt"],
@@ -1149,7 +1160,7 @@ DTS_AROUND_SWEDISH_DST_CHANGE: tuple[datetime.datetime, ...] = (
                 [
                     [
                         pytz.timezone("Europe/Stockholm").localize(
-                            pd.Timestamp("1970-01-01")
+                            pd.Timestamp("1970-01-01").as_unit("ns")
                         )
                     ]
                 ],

--- a/tests/unit/async_/work/test_result.py
+++ b/tests/unit/async_/work/test_result.py
@@ -75,7 +75,9 @@ if t.TYPE_CHECKING:
 
 
 # https://pandas.pydata.org/docs/user_guide/migration-3-strings.html
-PD_STR_DTYPE = "object" if pd.__version__ < "3" else "string"
+PD_STR_DTYPE = (
+    "object" if int(pd.__version__.split(".", 1)[0]) < 3 else "string"
+)
 
 
 class Records:

--- a/tests/unit/common/codec/hydration/v1/test_temporal_dehydration.py
+++ b/tests/unit/common/codec/hydration/v1/test_temporal_dehydration.py
@@ -189,13 +189,41 @@ class TestTimeDehydration(HydrationHandlerTestBase):
             dt, Structure(b"f", 1539344261, 474716000, "Europe/Stockholm")
         )
 
-    def test_pandas_date_time_zone_id(self, assert_transforms):
-        dt = pd.Timestamp(
-            "2018-10-12T11:37:41.474716862+0200", tz="Europe/Stockholm"
-        )
-        assert_transforms(
-            dt, Structure(b"f", 1539344261, 474716862, "Europe/Stockholm")
-        )
+    @pytest.mark.parametrize(
+        ("dt", "fields"),
+        (
+            (
+                pd.Timestamp(
+                    "2018-10-12T11:37:41.474716862+0200", tz="Europe/Stockholm"
+                ),
+                (1539344261, 474716862, "Europe/Stockholm"),
+            ),
+            (
+                pd.Timestamp(
+                    "2018-10-12T10:37:41.474716+0100", tz="Europe/Stockholm"
+                ),
+                (1539344261, 474716000, "Europe/Stockholm"),
+            ),
+            (
+                # 1972-10-29 02:00:01.001000001+0100 pre DST change
+                pd.Timestamp(
+                    (1032 * 24 + 2) * 3600 * 1000000000 + 1001000001,
+                    tz="Europe/London",
+                ),
+                ((1032 * 24 + 2) * 3600 + 1, 1000001, "Europe/London"),
+            ),
+            (
+                # 1972-10-29 02:00:01.001000001+0000 post DST change
+                pd.Timestamp(
+                    (1032 * 24 + 1) * 3600 * 1000000000 + 1001000001,
+                    tz="Europe/London",
+                ),
+                ((1032 * 24 + 2) * 3600 + 1, 1000001, "Europe/London"),
+            ),
+        ),
+    )
+    def test_pandas_date_time_zone_id(self, dt, fields, assert_transforms):
+        assert_transforms(dt, Structure(b"f", *fields))
 
     def test_duration(self, assert_transforms):
         duration = Duration(months=1, days=2, seconds=3, nanoseconds=4)
@@ -277,12 +305,22 @@ class TestTimeDehydration(HydrationHandlerTestBase):
         ("value", "expected_fields"),
         (
             (
-                pd.Timedelta(days=1, seconds=2, microseconds=3, nanoseconds=4),
+                pd.Timedelta(
+                    days=1,
+                    seconds=2,
+                    microseconds=3,
+                    # pandas stubs omit nanoseconds args
+                    nanoseconds=4,  # type: ignore[call-arg]
+                ),
                 (0, 0, _AVERAGE_SECONDS_IN_DAY + 2, 3004),
             ),
             (
                 pd.Timedelta(
-                    days=-1, seconds=2, microseconds=3, nanoseconds=4
+                    days=-1,
+                    seconds=2,
+                    microseconds=3,
+                    # pandas stubs omit nanoseconds args
+                    nanoseconds=4,  # type: ignore[call-arg]
                 ),
                 (
                     0,

--- a/tests/unit/common/codec/hydration/v2/test_temporal_dehydration.py
+++ b/tests/unit/common/codec/hydration/v2/test_temporal_dehydration.py
@@ -112,6 +112,12 @@ class TestTimeDehydration(_TestTemporalDehydration):
                 (1539337061, 474716862, "Europe/Stockholm"),
             ),
             (
+                pd.Timestamp(
+                    "2018-10-12T10:37:41.474716+0100", tz="Europe/Stockholm"
+                ),
+                (1539337061, 474716000, "Europe/Stockholm"),
+            ),
+            (
                 # 1972-10-29 02:00:01.001000001+0100 pre DST change
                 pd.Timestamp(
                     (1032 * 24 + 2) * 3600 * 1000000000 + 1001000001,

--- a/tests/unit/common/codec/packstream/v1/test_packstream.py
+++ b/tests/unit/common/codec/packstream/v1/test_packstream.py
@@ -15,6 +15,7 @@
 
 
 import struct
+from contextlib import suppress
 from io import BytesIO
 from math import (
     isnan,
@@ -24,6 +25,7 @@ from uuid import uuid4
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 from neo4j._codec.packstream import Structure
@@ -177,7 +179,26 @@ def str_type(request):
 
 
 @pytest.fixture(
-    params=(list, tuple, np.array, pd.Series, pd.array, pd.arrays.SparseArray)
+    params=(
+        list,
+        tuple,
+        np.array,
+        pd.Series,
+        pd.array,
+        pd.arrays.SparseArray,
+        pd.arrays.NumpyExtensionArray,
+        pd.arrays.ArrowExtensionArray,
+    ),
+    ids=(
+        "list",
+        "tuple",
+        "np.array",
+        "pd.Series",
+        "pd.array",
+        "pd.arrays.SparseArray",
+        "pd.arrays.NumpyExtensionArray",
+        "pd.arrays.ArrowExtensionArray",
+    ),
 )
 def sequence_type(request):
     if request.param is pd.Series:
@@ -187,8 +208,35 @@ def sequence_type(request):
                 return pd.Series(dtype=object)
             return pd.Series(value)
 
-        return constructor
-    return request.param
+    elif request.param is pd.array and pd.__version__ >= "3":
+
+        def constructor(value):
+            with suppress(ValueError):
+                return pd.array(value)
+            return pd.array(value, dtype=object)
+
+    elif request.param is pd.arrays.NumpyExtensionArray:
+
+        def constructor(value):
+            return pd.arrays.NumpyExtensionArray(np.array(value))
+
+    elif request.param is pd.arrays.ArrowExtensionArray:
+
+        def constructor(value):
+            def _map_value(v):
+                if isinstance(v, pd.arrays.ArrowExtensionArray):
+                    v = pa.array(v)
+                if isinstance(v, pa.Array):
+                    v = v.to_pylist()
+                return v
+
+            value = map(_map_value, value)
+            return pd.arrays.ArrowExtensionArray(pa.array(value))
+
+    else:
+        constructor = request.param
+
+    return constructor
 
 
 class TestPackStream:
@@ -536,9 +584,13 @@ class TestPackStream:
             nums_typed, b"\xd6\x00\x01\x38\x80" + (b"\x01" * 80000), nums
         )
 
-    def test_nested_lists(self, sequence_type, assert_packable):
+    @pytest.mark.parametrize("inner_as_list", (True, False))
+    def test_nested_lists(self, sequence_type, inner_as_list, assert_packable):
         list_ = [[[]]]
-        l_typed = sequence_type([sequence_type([sequence_type([])])])
+        if inner_as_list:
+            l_typed = sequence_type(list_)
+        else:
+            l_typed = sequence_type([sequence_type([sequence_type([])])])
         assert_packable(l_typed, b"\x91\x91\x90", list_)
 
     @pytest.mark.parametrize("as_series", (True, False))

--- a/tests/unit/sync/work/test_result.py
+++ b/tests/unit/sync/work/test_result.py
@@ -75,7 +75,9 @@ if t.TYPE_CHECKING:
 
 
 # https://pandas.pydata.org/docs/user_guide/migration-3-strings.html
-PD_STR_DTYPE = "object" if pd.__version__ < "3" else "string"
+PD_STR_DTYPE = (
+    "object" if int(pd.__version__.split(".", 1)[0]) < 3 else "string"
+)
 
 
 class Records:

--- a/tests/unit/sync/work/test_result.py
+++ b/tests/unit/sync/work/test_result.py
@@ -74,6 +74,10 @@ if t.TYPE_CHECKING:
     )
 
 
+# https://pandas.pydata.org/docs/user_guide/migration-3-strings.html
+PD_STR_DTYPE = "object" if pd.__version__ < "3" else "string"
+
+
 class Records:
     def __init__(self, fields, records):
         self.fields = tuple(fields)
@@ -795,7 +799,7 @@ def test_to_eager_result(records):
         (
             ["s"],
             list(zip(("foo", "bar", "baz", "foobar"), strict=True)),
-            ["object"],
+            [PD_STR_DTYPE],
             None,
         ),
         (["l"], list(zip(([1, 2], [3, 4]), strict=True)), ["object"], None),
@@ -909,7 +913,7 @@ def test_to_df(keys, values, types, instances, test_default_expand):
             list(zip(("foo", "bar", "baz", "foobar"), strict=True)),
             ["s"],
             [["foo"], ["bar"], ["baz"], ["foobar"]],
-            ["object"],
+            [PD_STR_DTYPE],
         ),
         (
             ["l"],
@@ -963,7 +967,7 @@ def test_to_df(keys, values, types, instances, test_default_expand):
             ),
             ["x[].0{}.foo", "x[].0{}.baz[].0", "x[].0{}.baz[].1", "x[].1"],
             [["bar", 42, 0.1, "foobar"]],
-            ["object", "int64", "float64", "object"],
+            [PD_STR_DTYPE, "int64", "float64", PD_STR_DTYPE],
         ),
         (
             ["n"],
@@ -1015,7 +1019,7 @@ def test_to_df(keys, values, types, instances, test_default_expand):
                     3,
                 ],
             ],
-            ["object", "object", "object", "float64", "float64", "int64"],
+            [PD_STR_DTYPE, "object", "object", "float64", "float64", "int64"],
         ),
         (
             ["r"],
@@ -1060,7 +1064,14 @@ def test_to_df(keys, values, types, instances, test_default_expand):
                 ["r-0", "r-1", "r-2", "TYPE", 1, False],
                 ["r-420", "r-1337", "r-69", "HYPE", None, True],
             ],
-            ["object", "object", "object", "object", "float64", "bool"],
+            [
+                PD_STR_DTYPE,
+                PD_STR_DTYPE,
+                PD_STR_DTYPE,
+                PD_STR_DTYPE,
+                "float64",
+                "bool",
+            ],
         ),
         (
             ["dt"],
@@ -1149,7 +1160,7 @@ DTS_AROUND_SWEDISH_DST_CHANGE: tuple[datetime.datetime, ...] = (
                 [
                     [
                         pytz.timezone("Europe/Stockholm").localize(
-                            pd.Timestamp("1970-01-01")
+                            pd.Timestamp("1970-01-01").as_unit("ns")
                         )
                     ]
                 ],


### PR DESCRIPTION
Adding support for [`pandas`](https://pandas.pydata.org/) 3.x.

The driver might indirectly behave differently when used with pandas 3. For example, calling `Result.to_df` on a `Result` containing a string-only column produces a `pandas.DataFrame` with `dtype` `object` for this column. When using `pandas` 3, the `dtype` will be `StringDtype` instead.

Closes: DRIVERS-250