### PR TITLE
Fix Python 3.10 dev env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,9 @@ typing = [
 ]
 # generate documentation
 docs = [
-    "Sphinx >= 8.2.3",
+    "Sphinx >= 8.1.3; python_version <= '3.10'",  # dropped support for Python 3.10 in 8.2.0
+    "Sphinx >= 9.0.4; python_version == '3.11'",  # dropped support for Python 3.11 in 9.1.0
+    "Sphinx >= 9.1.0; python_version >= '3.12'",
     {include-group = "dep-typing-extensions"},
     {include-group = "dep-project-dependencies"},
 ]


### PR DESCRIPTION
Sphinx dropped support for some Python versions we still want to support. In CI we'll still use the latest Python version the driver supports to build the docs. Therefore, we can be sure we're building our docs with the latest available version of Sphinx.

Closes: DRIVERS-262