### PR TITLE
Migrate from deprecated `__package__` to `__spec__`

### DIFF
--- a/src/neo4j/_async/work/result.py
+++ b/src/neo4j/_async/work/result.py
@@ -75,8 +75,9 @@ notification_log = getLogger("neo4j.notifications")
 
 
 _driver_dir = Path(__file__)
-for _ in range(__package__.count(".") + 1):
-    _driver_dir = _driver_dir.parent
+if __spec__ is not None and __spec__.parent is not None:
+    for _ in range(__spec__.parent.count(".") + 1):
+        _driver_dir = _driver_dir.parent
 
 _T = t.TypeVar("_T")
 _TResultKey: t.TypeAlias = int | str

--- a/src/neo4j/_sync/work/result.py
+++ b/src/neo4j/_sync/work/result.py
@@ -75,8 +75,9 @@ notification_log = getLogger("neo4j.notifications")
 
 
 _driver_dir = Path(__file__)
-for _ in range(__package__.count(".") + 1):
-    _driver_dir = _driver_dir.parent
+if __spec__ is not None and __spec__.parent is not None:
+    for _ in range(__spec__.parent.count(".") + 1):
+        _driver_dir = _driver_dir.parent
 
 _T = t.TypeVar("_T")
 _TResultKey: t.TypeAlias = int | str

--- a/tests/unit/async_/work/test_result.py
+++ b/tests/unit/async_/work/test_result.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import datetime
+import inspect
 import logging
 import typing as t
 import uuid
@@ -1381,6 +1382,9 @@ async def test_notification_warning(
             ]
         },
     )
+    result_frame = inspect.currentframe()
+    assert result_frame is not None
+    result_frame_info = inspect.getframeinfo(result_frame)
     result = AsyncResult(
         connection, 1, warn_notification_severity, noop, noop, None
     )
@@ -1396,7 +1400,10 @@ async def test_notification_warning(
             await result._run("CYPHER", {}, None, None, "r", None, None, None)
             await result.consume()
         assert len(recording.list) == 1
-        assert recording.list[0].category is expected_warning
+        warning = recording.list[0]
+        assert warning.category is expected_warning
+        assert warning.filename == result_frame_info.filename
+        assert warning.lineno == result_frame_info.lineno + 1
 
 
 @pytest.mark.parametrize("notification_severity", ("INFORMATION", "WARNING"))

--- a/tests/unit/sync/work/test_result.py
+++ b/tests/unit/sync/work/test_result.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import datetime
+import inspect
 import logging
 import typing as t
 import uuid
@@ -1381,6 +1382,9 @@ def test_notification_warning(
             ]
         },
     )
+    result_frame = inspect.currentframe()
+    assert result_frame is not None
+    result_frame_info = inspect.getframeinfo(result_frame)
     result = Result(
         connection, 1, warn_notification_severity, noop, noop, None
     )
@@ -1396,7 +1400,10 @@ def test_notification_warning(
             result._run("CYPHER", {}, None, None, "r", None, None, None)
             result.consume()
         assert len(recording.list) == 1
-        assert recording.list[0].category is expected_warning
+        warning = recording.list[0]
+        assert warning.category is expected_warning
+        assert warning.filename == result_frame_info.filename
+        assert warning.lineno == result_frame_info.lineno + 1
 
 
 @pytest.mark.parametrize("notification_severity", ("INFORMATION", "WARNING"))


### PR DESCRIPTION
`__package__` has been deprecated since Python 3.13 and is scheduled for removal in Python 3.15.

See also:
 * [https://docs.python.org/3/reference/datamodel.html#module.\_\_package\_\_](https://docs.python.org/3/reference/datamodel.html#module.__package__)
 * [https://docs.python.org/3/reference/datamodel.html#module.\_\_spec\_\_](https://docs.python.org/3/reference/datamodel.html#module.__spec__)

Closes: DRIVERS-263