### PR TITLE
Fix new mypy version being unhappy with type annotations

### DIFF
--- a/tests/unit/common/work/test_summary.py
+++ b/tests/unit/common/work/test_summary.py
@@ -81,8 +81,8 @@ def test_summary_server(summary_args_kwargs) -> None:
     summary = ResultSummary(*args, **kwargs)
     server_info: ServerInfo = summary.server
 
-    assert server_info is server_info_mock
     assert not server_info_mock.method_calls
+    assert server_info is server_info_mock
 
 
 @pytest.mark.parametrize("exists", (True, False))


### PR DESCRIPTION
It seems that mypy learned a new trick: `assert x is y` now narrows the type of the variables if either is more general than the other. I like. For mocks, however, this is not helpful :upside_down_face: 