### PR TITLE
[5.28] Fix socket timeouts during connection establishment

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ isort>=5.11.5  # TODO: 6.0 - bump when support for Python 3.7 is dropped
 mypy>=1.4.1  # TODO: 6.0 - bump when support for Python 3.7 is dropped
 typing-extensions>=4.7.1
 types-pytz>=2023.3.1.1  # TODO: 6.0 - bump when support for Python 3.7 is dropped
+types-mock>=5.1.0.3  # TODO: 6.0 - bump when support for Python 3.7 is dropped
 ruff>=0.8.2
 
 # needed for running tests

--- a/src/neo4j/_async/io/_bolt_socket.py
+++ b/src/neo4j/_async/io/_bolt_socket.py
@@ -318,7 +318,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
         )
         async for resolved_address in resolved_addresses:
             deadline_timeout = deadline.to_timeout()
-            if (
+            if tcp_timeout is None or (
                 deadline_timeout is not None
                 and deadline_timeout <= tcp_timeout
             ):

--- a/src/neo4j/_async/io/_pool.py
+++ b/src/neo4j/_async/io/_pool.py
@@ -301,8 +301,7 @@ class AsyncIOPool(abc.ABC):
             )
         except Exception as exc:
             log.debug(
-                "[#%04X]  _: <POOL> check re_auth failed %r auth=%s "
-                "force=%s",
+                "[#%04X]  _: <POOL> check re_auth failed %r auth=%s force=%s",
                 connection.local_port,
                 exc,
                 log_auth,
@@ -879,8 +878,7 @@ class AsyncNeo4jPool(AsyncIOPool):
         # No readers
         if num_readers == 0:
             log.debug(
-                "[#0000]  _: <POOL> no read servers returned from "
-                "server %s",
+                "[#0000]  _: <POOL> no read servers returned from server %s",
                 address,
             )
             return None

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -391,13 +391,12 @@ class BoltSocketBase:
 
     def _wait_for_io(
         self,
-        deadline: Deadline | None,
         func: t.Callable[_P, t.Any],
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> None:
         timeout: float | None = self._socket.gettimeout()
-        deadline_timeout = _non_expired_timeout(deadline, "IO operation")
+        deadline_timeout = _non_expired_timeout(self._deadline, "IO operation")
         if deadline_timeout is not None and (
             timeout is None or deadline_timeout <= timeout
         ):

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -63,6 +63,8 @@ if t.TYPE_CHECKING:
     from ..._async.io import AsyncBolt
     from ..._sync.io import Bolt
 
+    _P = te.ParamSpec("_P")
+
 
 log = logging.getLogger("neo4j.io")
 
@@ -76,6 +78,25 @@ def _sanitize_deadline(deadline):
     return deadline
 
 
+def _validate_timeout(timeout):
+    if timeout is not None and timeout < 0:
+        raise ValueError("Timeout value out of range")
+
+
+def _non_expired_timeout(
+    deadline: Deadline | None,
+    operation: str,
+) -> float | None:
+    if deadline is None:
+        return None
+    timeout = deadline.to_timeout()
+    if timeout is None:
+        return None
+    if timeout <= 0:
+        raise SocketDeadlineExceededError(f"{operation} timed out")
+    return timeout
+
+
 class AsyncBoltSocketBase(abc.ABC):
     Bolt: te.Final[type[AsyncBolt]] = None  # type: ignore[assignment]
 
@@ -86,24 +107,28 @@ class AsyncBoltSocketBase(abc.ABC):
         # 0 - non-blocking
         # None infinitely blocking
         # int - seconds to wait for data
-        self._timeout = None
-        self._deadline = None
+        self._timeout: float | None = None
+        self._deadline: Deadline | None = None
 
-    async def _wait_for_io(self, io_async_fn, *args, **kwargs):
+    async def _wait_for_io(
+        self,
+        io_async_fn: t.Callable[_P, t.Coroutine],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> None:
         timeout = self._timeout
-        to_raise = SocketTimeout
-        if self._deadline is not None:
-            deadline_timeout = self._deadline.to_timeout()
-            if deadline_timeout <= 0:
-                raise SocketDeadlineExceededError("timed out")
-            if timeout is None or deadline_timeout <= timeout:
-                timeout = deadline_timeout
-                to_raise = SocketDeadlineExceededError
+        to_raise: type[Exception] = SocketTimeout
+        deadline_timeout = _non_expired_timeout(self._deadline, "IO operation")
+        if deadline_timeout is not None and (
+            timeout is None or deadline_timeout <= timeout
+        ):
+            timeout = deadline_timeout
+            to_raise = SocketDeadlineExceededError
 
-        io_fut = io_async_fn(*args, **kwargs)
+        io_fut: t.Awaitable
         if timeout is not None and timeout <= 0:
             # give the io-operation time for one loop cycle to do its thing
-            io_fut = asyncio.create_task(io_fut)
+            io_fut = asyncio.create_task(io_async_fn(*args, **kwargs))
             try:
                 await asyncio.sleep(0)
             except asyncio.CancelledError:
@@ -111,7 +136,11 @@ class AsyncBoltSocketBase(abc.ABC):
                 # Still, we don't want to silently swallow the cancellation.
                 # Hence, we flag this task as cancelled again, so that the next
                 # `await` will raise the CancelledError.
-                asyncio.current_task().cancel()
+                current_task = asyncio.current_task()
+                if current_task is not None:
+                    current_task.cancel()
+        else:
+            io_fut = io_async_fn(*args, **kwargs)
         try:
             return await wait_for(io_fut, timeout)
         except asyncio.TimeoutError as e:
@@ -197,6 +226,9 @@ class AsyncBoltSocketBase(abc.ABC):
                 raise ValueError(f"Unsupported address {resolved_address!r}")
             s.setblocking(False)  # asyncio + blocking = no-no!
             log.debug("[#0000]  C: <OPEN> %s", resolved_address)
+            _validate_timeout(timeout)
+            if timeout == 0:  # socket timeout of 0 => non-blocking
+                timeout = None
             await wait_for(loop.sock_connect(s, resolved_address), timeout)
             local_port = s.getsockname()[1]
 
@@ -208,11 +240,7 @@ class AsyncBoltSocketBase(abc.ABC):
             if ssl_context is not None:
                 hostname = resolved_address._host_name or None
                 sni_host = hostname if HAS_SNI and hostname else None
-                ssl_kwargs.update(
-                    ssl=ssl_context,
-                    server_hostname=sni_host,
-                    ssl_handshake_timeout=deadline.to_timeout(),
-                )
+                ssl_kwargs.update(ssl=ssl_context, server_hostname=sni_host)
                 log.debug("[#%04X]  C: <SECURE> %s", local_port, hostname)
 
             reader = asyncio.StreamReader(
@@ -220,6 +248,18 @@ class AsyncBoltSocketBase(abc.ABC):
                 loop=loop,
             )
             protocol = asyncio.StreamReaderProtocol(reader, loop=loop)
+            if ssl_context is not None:
+                try:
+                    ssl_timeout = _non_expired_timeout(
+                        deadline, "SSL handshake"
+                    )
+                except SocketDeadlineExceededError as error:
+                    raise BoltSecurityError(
+                        message="Failed to establish encrypted connection.",
+                        address=(hostname, local_port),
+                    ) from error
+                if ssl_timeout is not None:
+                    ssl_kwargs["ssl_handshake_timeout"] = ssl_timeout
             transport, _ = await loop.create_connection(
                 lambda: protocol, sock=s, **ssl_kwargs
             )
@@ -262,6 +302,16 @@ class AsyncBoltSocketBase(abc.ABC):
                 message="Failed to establish encrypted connection.",
                 address=(resolved_address._host_name, local_port),
             ) from error
+        except BoltSecurityError as error:
+            log.debug(
+                "[#0000]  S: <SECURE FAILURE> %s: %r",
+                resolved_address,
+                error,
+            )
+            if s:
+                log.debug("[#0000]  C: <CLOSE> %s", resolved_address)
+                cls._kill_raw_socket(s)
+            raise
         except Exception as error:
             log.debug(
                 "[#0000]  S: <ERROR> %s %s",
@@ -315,14 +365,14 @@ class BoltSocketBase:
 
     def __init__(self, socket_: socket):
         self._socket = socket_
-        self._deadline = None
+        self._deadline: Deadline | None = None
 
     @property
-    def _socket(self):
+    def _socket(self) -> socket | SSLSocket:
         return self.__socket
 
     @_socket.setter
-    def _socket(self, socket_: socket | SSLSocket):
+    def _socket(self, socket_: socket | SSLSocket) -> None:
         self.__socket = socket_
         self.getsockname = socket_.getsockname
         self.getpeername = socket_.getpeername
@@ -339,14 +389,18 @@ class BoltSocketBase:
     gettimeout: t.Callable = None  # type: ignore
     settimeout: t.Callable = None  # type: ignore
 
-    def _wait_for_io(self, func, *args, **kwargs):
-        if self._deadline is None:
-            return func(*args, **kwargs)
-        timeout = self._socket.gettimeout()
-        deadline_timeout = self._deadline.to_timeout()
-        if deadline_timeout <= 0:
-            raise SocketDeadlineExceededError("timed out")
-        if timeout is None or deadline_timeout <= timeout:
+    def _wait_for_io(
+        self,
+        deadline: Deadline | None,
+        func: t.Callable[_P, t.Any],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> None:
+        timeout: float | None = self._socket.gettimeout()
+        deadline_timeout = _non_expired_timeout(deadline, "IO operation")
+        if deadline_timeout is not None and (
+            timeout is None or deadline_timeout <= timeout
+        ):
             self._socket.settimeout(deadline_timeout)
             try:
                 return func(*args, **kwargs)
@@ -443,11 +497,19 @@ class BoltSocketBase:
                 log.debug("[#%04X]  C: <SECURE> %s", local_port, hostname)
                 try:
                     t = s.gettimeout()
-                    if timeout:
-                        s.settimeout(deadline.to_timeout())
+                    ssl_timeout = _non_expired_timeout(
+                        deadline, "SSL handshake"
+                    )
+                    if ssl_timeout is not None:
+                        s.settimeout(ssl_timeout)
                     s = ssl_context.wrap_socket(s, server_hostname=sni_host)
                     s.settimeout(t)
-                except (OSError, SSLError, CertificateError) as cause:
+                except (
+                    OSError,
+                    SSLError,
+                    CertificateError,
+                    SocketDeadlineExceededError,
+                ) as cause:
                     raise BoltSecurityError(
                         message="Failed to establish encrypted connection.",
                         address=(hostname, local_port),

--- a/src/neo4j/_deadline.py
+++ b/src/neo4j/_deadline.py
@@ -14,12 +14,22 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
+import typing as t
 from contextlib import contextmanager
 from time import monotonic
 
 
+if t.TYPE_CHECKING:
+    import typing_extensions as te
+
+    from ._async.io import AsyncBolt
+    from ._sync.io import Bolt
+
+
 class Deadline:
-    def __init__(self, timeout):
+    def __init__(self, timeout: float | None) -> None:
         if timeout is None or timeout == float("inf"):
             self._deadline = float("inf")
         else:
@@ -27,63 +37,74 @@ class Deadline:
         self._original_timeout = timeout
 
     @property
-    def original_timeout(self):
+    def original_timeout(self) -> float | None:
         return self._original_timeout
 
-    def expired(self):
+    def expired(self) -> bool:
         return self.to_timeout() == 0
 
-    def to_timeout(self):
+    def to_timeout(self) -> float | None:
         if self._deadline == float("inf"):
             return None
         timeout = self._deadline - monotonic()
         return max(0, timeout)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if isinstance(other, Deadline):
             return self._deadline == other._deadline
         return NotImplemented
 
-    def __gt__(self, other):
+    def __gt__(self, other) -> bool:
         if isinstance(other, Deadline):
             return self._deadline > other._deadline
         return NotImplemented
 
-    def __ge__(self, other):
+    def __ge__(self, other) -> bool:
         if isinstance(other, Deadline):
             return self._deadline >= other._deadline
         return NotImplemented
 
-    def __lt__(self, other):
+    def __lt__(self, other) -> bool:
         if isinstance(other, Deadline):
             return self._deadline < other._deadline
         return NotImplemented
 
-    def __le__(self, other):
+    def __le__(self, other) -> bool:
         if isinstance(other, Deadline):
             return self._deadline <= other._deadline
         return NotImplemented
 
     @classmethod
-    def from_timeout_or_deadline(cls, timeout):
-        if isinstance(timeout, cls):
-            return timeout
-        return cls(timeout)
+    def from_timeout_or_deadline(
+        cls, timeout: te.Self | float | None
+    ) -> te.Self:
+        if isinstance(timeout, (float, int)) or timeout is None:
+            return cls(timeout)
+        return timeout
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"Deadline(timeout={self._original_timeout})"
+
+    def __bool__(self) -> bool:
+        """Whether a deadline is set (:data:`True`) or not (:data:`False`)."""
+        return self._deadline != float("inf")
 
 
 merge_deadlines = min
 
 
-def merge_deadlines_and_timeouts(*deadline):
+def merge_deadlines_and_timeouts(
+    *deadline: Deadline | None,
+) -> Deadline:
     deadlines = map(Deadline.from_timeout_or_deadline, deadline)
     return merge_deadlines(deadlines)
 
 
 @contextmanager
-def connection_deadline(connection, deadline):
+def connection_deadline(
+    connection: AsyncBolt | Bolt,
+    deadline: Deadline | None,
+) -> t.Generator[None, None, None]:
     original_deadline = connection.socket.get_deadline()
     if deadline is None and original_deadline is not None:
         # nothing to do here

--- a/src/neo4j/_sync/io/_bolt_socket.py
+++ b/src/neo4j/_sync/io/_bolt_socket.py
@@ -318,7 +318,7 @@ class BoltSocket(BoltSocketBase):
         )
         for resolved_address in resolved_addresses:
             deadline_timeout = deadline.to_timeout()
-            if (
+            if tcp_timeout is None or (
                 deadline_timeout is not None
                 and deadline_timeout <= tcp_timeout
             ):

--- a/src/neo4j/_sync/io/_pool.py
+++ b/src/neo4j/_sync/io/_pool.py
@@ -298,8 +298,7 @@ class IOPool(abc.ABC):
             )
         except Exception as exc:
             log.debug(
-                "[#%04X]  _: <POOL> check re_auth failed %r auth=%s "
-                "force=%s",
+                "[#%04X]  _: <POOL> check re_auth failed %r auth=%s force=%s",
                 connection.local_port,
                 exc,
                 log_auth,
@@ -876,8 +875,7 @@ class Neo4jPool(IOPool):
         # No readers
         if num_readers == 0:
             log.debug(
-                "[#0000]  _: <POOL> no read servers returned from "
-                "server %s",
+                "[#0000]  _: <POOL> no read servers returned from server %s",
                 address,
             )
             return None

--- a/tests/unit/mixed/async_compat/test_network.py
+++ b/tests/unit/mixed/async_compat/test_network.py
@@ -17,25 +17,47 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import socket
 import typing as t
+from dataclasses import dataclass
+from ssl import (
+    SSLContext,
+    SSLSocket,
+)
 
 import freezegun
 import pytest
+from mock import mock  # noqa UP026 - to use same mock classes as `mocker`
 
+import neo4j._async_compat.network._bolt_socket
 from neo4j._async.io._bolt_socket import AsyncBoltSocket
-from neo4j._exceptions import SocketDeadlineExceededError
+from neo4j._deadline import Deadline
+from neo4j._exceptions import (
+    BoltError,
+    BoltSecurityError,
+    SocketDeadlineExceededError,
+)
+from neo4j._sync.io._bolt_socket import BoltSocket
+from neo4j.addressing import Address
+from neo4j.exceptions import ServiceUnavailable
 
-from ...._async_compat.mark_decorator import mark_async_test
+from ...._async_compat.mark_decorator import (
+    async_fixture,
+    mark_async_test,
+)
 
 
 if t.TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
     import typing_extensions as te
     from freezegun.api import (
         FrozenDateTimeFactory,
         StepTickTimeFactory,
         TickingDateTimeFactory,
     )
+    from pytest_mock import MockerFixture
 
     TFreezeTime: te.TypeAlias = t.Union[
         StepTickTimeFactory, TickingDateTimeFactory, FrozenDateTimeFactory
@@ -73,6 +95,85 @@ def reader(s: AsyncBoltSocket):
 
 def writer(s: AsyncBoltSocket):
     return s._writer
+
+
+class AwaitableMock(mock.NonCallableMock):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__async_mock = mock.AsyncMock()
+
+    def __await__(self):
+        return self.__async_mock().__await__()
+
+
+@dataclass
+class AsyncIoMock:
+    wait_for_mock: mock.AsyncMock
+    socket_socket_mock: mock.Mock
+    event_loop_mock: mock.Mock
+    transport_mock: mock.Mock
+    protocol_mock: mock.Mock
+    sock_connect_awaitable_mock: AwaitableMock
+    get_event_loop_mock: mock.Mock
+
+
+@async_fixture
+async def mocked_asyncio(mocker: MockerFixture) -> AsyncIoMock:
+    wait_for_mock = mocker.patch(
+        "neo4j._async_compat.network._bolt_socket.wait_for",
+        side_effect=neo4j._async_compat.network._bolt_socket.wait_for,
+    )
+    socket_socket_mock = mocker.patch(
+        "neo4j._async_compat.network._bolt_socket.socket", autospec=True
+    )
+    event_loop_mock = mocker.Mock(spec=asyncio.AbstractEventLoop)
+    transport_mock = mocker.Mock(spec=asyncio.Transport)
+    protocol_mock = mocker.Mock(spec=asyncio.Protocol)
+    event_loop_mock.create_connection.return_value = (
+        transport_mock,
+        protocol_mock,
+    )
+    sock_connect_awaitable_mock = AwaitableMock()
+    event_loop_mock.sock_connect = mocker.Mock(
+        return_value=sock_connect_awaitable_mock
+    )
+    get_event_loop_mock = mocker.patch(
+        "asyncio.get_event_loop", return_value=event_loop_mock
+    )
+
+    assert isinstance(wait_for_mock, mocker.AsyncMock)
+    assert isinstance(socket_socket_mock, mock.Mock)
+    assert isinstance(event_loop_mock, mock.Mock)
+    assert isinstance(transport_mock, mock.Mock)
+    assert isinstance(protocol_mock, mock.Mock)
+    assert isinstance(sock_connect_awaitable_mock, AwaitableMock)
+    assert isinstance(get_event_loop_mock, mock.Mock)
+
+    return AsyncIoMock(
+        wait_for_mock,
+        socket_socket_mock,
+        event_loop_mock,
+        transport_mock,
+        protocol_mock,
+        sock_connect_awaitable_mock,
+        get_event_loop_mock,
+    )
+
+
+@dataclass
+class IoMock:
+    socket_socket_mock: mock.Mock
+
+
+@pytest.fixture
+def mocked_io(mocker: MockerFixture) -> IoMock:
+    socket_socket_mock = mocker.patch(
+        "neo4j._async_compat.network._bolt_socket.socket", autospec=True
+    )
+
+    assert isinstance(socket_socket_mock, mock.Mock)
+
+    return IoMock(socket_socket_mock)
 
 
 @pytest.mark.parametrize(
@@ -162,3 +263,196 @@ async def test_async_bolt_socket_read_timeout(
                 await call_method(socket)
         else:
             await call_method(socket)
+
+
+@pytest.mark.parametrize("timeout", [None, 0, 0.1, -0.1])
+@pytest.mark.parametrize("raw_deadline", [None, 1000, 1e-4, -50, 0])
+@pytest.mark.parametrize("ssl", [True, False])
+@mark_async_test
+async def test_async_bolt_connection_timeout(
+    timeout: float | None,
+    raw_deadline: float | None,
+    ssl: bool,
+    mocker: MockerFixture,
+    mocked_asyncio: AsyncIoMock,
+) -> None:
+    ssl_context_mock = mocker.Mock(spec=SSLContext) if ssl else None
+
+    exc_expectation: AbstractContextManager = contextlib.nullcontext()
+    connect_fails = False
+    expected_timeout = timeout
+    if timeout == 0:  # sync io: 0 timeout means non-blocking socket operations
+        expected_timeout = None
+
+    if timeout is not None and timeout < 0:
+        exc_expectation = pytest.raises(
+            ValueError,
+            match=r"^Timeout value out of range$",
+        )
+        connect_fails = True
+    elif ssl and raw_deadline is not None and raw_deadline <= 0:
+        exc_expectation = pytest.raises(
+            (ServiceUnavailable, BoltError, OSError)
+        )
+
+    with freezegun.freeze_time():
+        deadline = Deadline(raw_deadline)
+
+        with exc_expectation:
+            await AsyncBoltSocket._connect_secure(
+                Address(("localhost", 7687)),
+                timeout,
+                deadline,
+                False,
+                ssl_context_mock,
+            )
+
+    if not connect_fails:
+        mocked_asyncio.wait_for_mock.assert_awaited_once_with(
+            mocked_asyncio.sock_connect_awaitable_mock, expected_timeout
+        )
+
+
+@pytest.mark.parametrize(
+    ("raw_deadline", "time_step"),
+    (
+        (None, None),
+        (None, 1_000_000),
+        (float("inf"), None),
+        (float("inf"), 1_000_000),
+        (-1, None),
+        (-1, 0.01),
+        (0, None),
+        (0, 0.0001),
+        (0.5, None),
+        (0.5, 0.4999),
+        (0.5, 0.5),
+        (0.5, 1_000_000),
+    ),
+)
+@pytest.mark.parametrize("timeout", [None, 0, 0.1])
+@mark_async_test
+async def test_async_bolt_ssl_timeout(
+    raw_deadline: float | None,
+    time_step: float | None,
+    timeout: float | None,
+    mocker: MockerFixture,
+    mocked_asyncio: AsyncIoMock,
+) -> None:
+    ssl_context_mock = mocker.Mock(spec=SSLContext)
+
+    fails = raw_deadline is not None and (
+        (time_step is not None and time_step >= raw_deadline)
+        or raw_deadline <= 0
+    )
+
+    exc_expectation: AbstractContextManager
+    if fails:
+        exc_expectation = pytest.raises(BoltSecurityError)
+    else:
+        exc_expectation = contextlib.nullcontext()
+
+    with freezegun.freeze_time() as frozen_time:
+        deadline = Deadline(raw_deadline)
+        if time_step is not None:
+            frozen_time.tick(time_step)
+        expected_timeout = deadline.to_timeout()
+
+        with exc_expectation as exc_capture:
+            await AsyncBoltSocket._connect_secure(
+                Address(("localhost", 7687)),
+                timeout,
+                deadline,
+                False,
+                ssl_context_mock,
+            )
+
+    con_mock = mocked_asyncio.event_loop_mock.create_connection
+    if fails:
+        con_mock.assert_not_called()
+        assert isinstance(exc_capture, pytest.ExceptionInfo)
+        assert isinstance(
+            exc_capture.value.__cause__, SocketDeadlineExceededError
+        )
+    else:
+        con_mock.assert_awaited_once()
+
+        # handshake timeout must be > 0 or None (causes `ValueError` otherwise)
+        con_kwargs = con_mock.call_args_list[0].kwargs
+        assert con_kwargs.get("ssl_handshake_timeout") == expected_timeout
+
+
+@pytest.mark.parametrize(
+    ("raw_deadline", "time_step"),
+    (
+        (None, None),
+        (None, 1_000_000),
+        (float("inf"), None),
+        (float("inf"), 1_000_000),
+        (-1, None),
+        (-1, 0.01),
+        (0.5, None),
+        (0.5, 0.49999),
+        (0.5, 0.5),
+        (0.5, 1_000_000),
+    ),
+)
+@pytest.mark.parametrize("timeout", [None, 0, 0.1])
+@mark_async_test
+async def test_bolt_ssl_timeout(
+    raw_deadline: float | None,
+    time_step: float | None,
+    timeout: float | None,
+    mocker: MockerFixture,
+    mocked_io: IoMock,
+) -> None:
+    last_ssl_timeout = None
+    ssl_socket_mock = mocker.Mock(spec=SSLSocket)
+
+    def ssl_wrap_side_effect(socket, *args, **kwargs):
+        nonlocal last_ssl_timeout
+        if socket.settimeout.call_args_list:
+            last_timeout = socket.settimeout.call_args_list[-1].args[0]
+            if not isinstance(last_timeout, mock.Mock):
+                last_ssl_timeout = last_timeout
+        return ssl_socket_mock
+
+    ssl_context_mock = mocker.Mock(spec=SSLContext)
+    ssl_context_mock.wrap_socket.side_effect = ssl_wrap_side_effect
+
+    fails = raw_deadline is not None and (
+        (time_step is not None and time_step >= raw_deadline)
+        or raw_deadline <= 0
+    )
+
+    exc_expectation: AbstractContextManager
+    if fails:
+        exc_expectation = pytest.raises(BoltSecurityError)
+    else:
+        exc_expectation = contextlib.nullcontext()
+
+    with freezegun.freeze_time() as frozen_time:
+        deadline = Deadline(raw_deadline)
+        if time_step is not None:
+            frozen_time.tick(time_step)
+        expected_timeout = deadline.to_timeout()
+
+        with exc_expectation as exc_capture:
+            BoltSocket._connect_secure(
+                Address(("localhost", 7687)),
+                timeout,
+                deadline,
+                False,
+                ssl_context_mock,
+            )
+
+    if fails:
+        ssl_context_mock.wrap_socket.assert_not_called()
+        assert isinstance(exc_capture, pytest.ExceptionInfo)
+        assert isinstance(
+            exc_capture.value.__cause__, SocketDeadlineExceededError
+        )
+    else:
+        ssl_context_mock.wrap_socket.assert_called_once()
+
+        assert last_ssl_timeout == expected_timeout


### PR DESCRIPTION
  * Prevent async socket from passing 0 as `ssl_handshake_timeout` leading to
    a `ValueError` being raised when the acquisition deadline has expired.
    Raise `ServiceUnavailable` instead.
  * Align async driver with sync driver:
    * (lazily) raise a `ValueError` when configured with a negative
      `connection_timeout`.
    * Treat `connection_timeout=0` as "no timeout".
  * Fix sync driver setting the socket timeout to `0` (non-blocking) on expired
    `connection_acquisition_timeout`.
  * Harden internal code against against `None` timeouts.
  
Closes: DRIVERS-331

Amends: https://github.com/neo4j/neo4j-python-driver/pull/1275
Backport of: https://github.com/neo4j/neo4j-python-driver/pull/1301