### PR TITLE
[5.28] Bump dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ pyarrow = ["pyarrow >= 1.0.0"]
 requires = [
     "setuptools == 68.0.0; python_version <= '3.7'",  # dropped support for Python 3.7 in 68.1.0
     "setuptools == 75.3.0; python_version == '3.8'",  # dropped support for Python 3.8 in 75.4.0
-    "setuptools == 80.9.0; python_version >= '3.9'",
+    "setuptools == 82.0.1; python_version >= '3.9'",
     # TODO: 6.0 - can be removed once `setup.py` is simplified
     "tomlkit == 0.12.5",  # dropped support (at least CI testing) for Python 3.7 in 0.13.0
 ]

--- a/tests/unit/common/codec/packstream/v1/test_packstream.py
+++ b/tests/unit/common/codec/packstream/v1/test_packstream.py
@@ -16,6 +16,7 @@
 
 import struct
 import sys
+import typing
 from io import BytesIO
 from math import (
     isnan,
@@ -24,7 +25,6 @@ from math import (
 from uuid import uuid4
 
 import numpy as np
-import pandas as pd
 import pytest
 
 from neo4j._codec.packstream import Structure
@@ -36,10 +36,21 @@ from neo4j._codec.packstream.v1 import (
 )
 
 
+HAS_PD = True
+if typing.TYPE_CHECKING:
+    import pandas as pd
+else:
+    try:
+        import pandas as pd
+    except ImportError:
+        pd = None
+        HAS_PD = False
+
 standard_ascii = [chr(i) for i in range(128)]
 not_ascii = "♥O◘♦♥O◘♦"
 SKIP_PANDAS_INT_AS_INT64 = (
-    pd.Series([], dtype=int).dtype.itemsize < 8
+    HAS_PD
+    and pd.Series([], dtype=int).dtype.itemsize < 8
     and sys.version_info < (3, 9)
     and sys.platform == "win32"
 )
@@ -179,10 +190,23 @@ def str_type(request):
 
 
 @pytest.fixture(
-    params=(list, tuple, np.array, pd.Series, pd.array, pd.arrays.SparseArray)
+    params=(
+        list,
+        tuple,
+        np.array,
+        *(
+            (
+                pd.Series,
+                pd.array,
+                pd.arrays.SparseArray,
+            )
+            if HAS_PD
+            else ()
+        ),
+    )
 )
 def sequence_type(request):
-    if request.param is pd.Series:
+    if HAS_PD and request.param is pd.Series:
 
         def constructor(value):
             if not value:
@@ -194,7 +218,10 @@ def sequence_type(request):
 
 
 class TestPackStream:
-    @pytest.mark.parametrize("value", (None, pd.NA))
+    @pytest.mark.parametrize(
+        "value",
+        (None, *((pd.NA,) if HAS_PD else ())),
+    )
     def test_none(self, value, assert_packable):
         assert_packable(value, b"\xc0", None)
 
@@ -202,7 +229,11 @@ class TestPackStream:
         assert_packable(bool_type(True), b"\xc3")
         assert_packable(bool_type(False), b"\xc2")
 
-    @pytest.mark.parametrize("dtype", (bool, pd.BooleanDtype()))
+    @pytest.mark.skipif(pd is None, reason="pandas not installed")
+    @pytest.mark.parametrize(
+        "dtype",
+        (bool, *((pd.BooleanDtype(),) if HAS_PD else ())),
+    )
     def test_boolean_pandas_series(self, dtype, assert_packable):
         value = [True, False]
         value_series = pd.Series(value, dtype=dtype)
@@ -215,19 +246,26 @@ class TestPackStream:
                 continue  # not representable
             assert_packable(z_typed, bytes(bytearray([z + 0x100])))
 
+    @pytest.mark.skipif(pd is None, reason="pandas not installed")
     @pytest.mark.parametrize(
         "dtype",
         (
             int,
-            pd.Int8Dtype(),
-            pd.Int16Dtype(),
-            pd.Int32Dtype(),
-            pd.Int64Dtype(),
             np.int8,
             np.int16,
             np.int32,
             np.int64,
             np.longlong,
+            *(
+                (
+                    pd.Int8Dtype(),
+                    pd.Int16Dtype(),
+                    pd.Int32Dtype(),
+                    pd.Int64Dtype(),
+                )
+                if HAS_PD
+                else ()
+            ),
         ),
     )
     def test_negative_tiny_int_pandas_series(self, dtype, assert_packable):
@@ -292,6 +330,7 @@ class TestPackStream:
             expected = b"\xcb" + struct.pack(">q", z)
             assert_packable(z_typed, expected)
 
+    @pytest.mark.skipif(pd is None, reason="pandas not installed")
     @pytest.mark.parametrize(
         "dtype",
         (
@@ -302,12 +341,18 @@ class TestPackStream:
                     reason="Legacy pandas treating int as int32",
                 ),
             ),
-            pd.Int64Dtype(),
-            pd.UInt64Dtype(),
             np.int64,
             np.longlong,
             np.uint64,
             np.ulonglong,
+            *(
+                (
+                    pd.Int64Dtype(),
+                    pd.UInt64Dtype(),
+                )
+                if HAS_PD
+                else ()
+            ),
         ),
     )
     def test_positive_int64_pandas_series(self, dtype, assert_packable):
@@ -326,6 +371,7 @@ class TestPackStream:
             expected = b"\xcb" + struct.pack(">q", z)
             assert_packable(z_typed, expected)
 
+    @pytest.mark.skipif(pd is None, reason="pandas not installed")
     @pytest.mark.parametrize(
         "dtype",
         (
@@ -336,9 +382,9 @@ class TestPackStream:
                     reason="Legacy pandas treating int as int32",
                 ),
             ),
-            pd.Int64Dtype(),
             np.int64,
             np.longlong,
+            *((pd.Int64Dtype(),) if HAS_PD else ()),
         ),
     )
     def test_negative_int64_pandas_series(self, dtype, assert_packable):
@@ -383,16 +429,23 @@ class TestPackStream:
             expected = b"\xc1" + struct.pack(">d", float(z_typed))
             assert_packable(z_typed, expected)
 
+    @pytest.mark.skipif(pd is None, reason="pandas not installed")
     @pytest.mark.parametrize(
         "dtype",
         (
             float,
-            pd.Float32Dtype(),
-            pd.Float64Dtype(),
             np.float16,
             np.float32,
             np.float64,
             np.longdouble,
+            *(
+                (
+                    pd.Float32Dtype(),
+                    pd.Float64Dtype(),
+                )
+                if HAS_PD
+                else ()
+            ),
         ),
     )
     def test_float_pandas_series(
@@ -441,6 +494,7 @@ class TestPackStream:
         b_typed = bytes_type(b)
         assert_packable(b_typed, b"\xce\x00\x01\x38\x80" + b)
 
+    @pytest.mark.skipif(pd is None, reason="pandas not installed")
     def test_bytes_pandas_series(self, assert_packable):
         for b, header in (
             (b"", b"\xcc\x00"),
@@ -489,13 +543,20 @@ class TestPackStream:
         t_typed = str_type(t)
         assert_packable(t_typed, bytes(bytearray([0x80 + len(b)])) + b)
 
+    @pytest.mark.skipif(pd is None, reason="pandas not installed")
     @pytest.mark.parametrize(
         "dtype",
         (
             str,
             np.str_,
-            pd.StringDtype("python"),
-            pd.StringDtype("pyarrow"),
+            *(
+                (
+                    pd.StringDtype("python"),
+                    pd.StringDtype("pyarrow"),
+                )
+                if HAS_PD
+                else ()
+            ),
         ),
     )
     def test_string_pandas_series(self, dtype, assert_packable):
@@ -555,6 +616,7 @@ class TestPackStream:
         l_typed = sequence_type([sequence_type([sequence_type([])])])
         assert_packable(l_typed, b"\x91\x91\x90", list_)
 
+    @pytest.mark.skipif(pd is None, reason="pandas not installed")
     @pytest.mark.parametrize("as_series", (True, False))
     def test_list_pandas_categorical(self, as_series, pack, assert_packable):
         animals = ["cat", "dog", "cat", "cat", "dog", "horse"]
@@ -637,10 +699,12 @@ class TestPackStream:
         data_out = b"\xa1\xd2\x00\x01\x38\x80" + key.encode("utf-8") + b"\x01"
         assert_packable(d, data_out)
 
+    @pytest.mark.skipif(pd is None, reason="pandas not installed")
     def test_empty_dataframe_maps(self, assert_packable):
         df = pd.DataFrame()
         assert_packable(df, b"\xa0", {})
 
+    @pytest.mark.skipif(pd is None, reason="pandas not installed")
     @pytest.mark.parametrize("size", range(0x10))
     def test_tiny_dataframes_maps(self, assert_packable, size):
         data_in = {}
@@ -661,10 +725,16 @@ class TestPackStream:
         ("map_", "exc_type"),
         (
             ({1: "1"}, TypeError),
-            (pd.DataFrame({1: ["1"]}), TypeError),
-            (pd.DataFrame({(1, 2): ["1"]}), TypeError),
             ({"x": {1: "eins", 2: "zwei", 3: "drei"}}, TypeError),
             ({"x": {(1, 2): "1+2i", (2, 0): "2"}}, TypeError),
+            *(
+                (
+                    (pd.DataFrame({1: ["1"]}), TypeError),
+                    (pd.DataFrame({(1, 2): ["1"]}), TypeError),
+                )
+                if HAS_PD
+                else ()
+            ),
         ),
     )
     def test_map_key_type(self, packer_with_buffer, map_, exc_type):


### PR DESCRIPTION
Part of: DRIVERS-343

Updated tests required for: https://github.com/neo4j/neo4j-python-driver-rust-ext/pull/83