### PR TITLE
Fix async driver waiting for OS on closing half-open socket

### DIFF
--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -331,7 +331,7 @@ class AsyncBolt:
         except (ServiceUnavailable, SessionExpired, BoltHandshakeError):
             return None
         else:
-            await AsyncBoltSocket.close_socket(s)
+            AsyncBoltSocket.close_socket(s)
             return protocol_version
 
     @staticmethod
@@ -377,7 +377,7 @@ class AsyncBolt:
         bolt_cls = protocol_handlers.get(protocol_version)
         if bolt_cls is None:
             log.debug("[#%04X]  C: <CLOSE>", s.getsockname()[1])
-            await AsyncBoltSocket.close_socket(s)
+            AsyncBoltSocket.close_socket(s)
             raise UnsupportedServerProduct(
                 "The neo4j server does not support communication with this "
                 "driver. This driver has support for Bolt protocols "

--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -386,7 +386,7 @@ class AsyncBolt:
 
         try:
             auth = await AsyncUtil.callback(auth_manager.get_auth)
-        except Exception as e:
+        except (Exception, asyncio.CancelledError) as e:
             log.debug(
                 "[#%04X]  C: <CLOSE> open auth manager failed: %r",
                 s.getsockname()[1],

--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -386,21 +386,13 @@ class AsyncBolt:
 
         try:
             auth = await AsyncUtil.callback(auth_manager.get_auth)
-        except asyncio.CancelledError as e:
-            log.debug(
-                "[#%04X]  C: <KILL> open auth manager failed: %r",
-                s.getsockname()[1],
-                e,
-            )
-            s.kill()
-            raise
         except Exception as e:
             log.debug(
                 "[#%04X]  C: <CLOSE> open auth manager failed: %r",
                 s.getsockname()[1],
                 e,
             )
-            await s.close()
+            s.close()
             raise
 
         connection = bolt_cls(
@@ -998,17 +990,20 @@ class AsyncBolt:
             self.goodbye()
             try:
                 await self._send_all()
-            except (OSError, BoltError, DriverError) as exc:
+            except (
+                OSError,
+                BoltError,
+                DriverError,
+                SocketDeadlineExceededError,
+            ) as exc:
                 log.debug(
-                    "[#%04X]  _: <CONNECTION> ignoring failed close %r",
+                    "[#%04X]  _: <CONNECTION> ignoring failed final flush %r",
                     self.local_port,
                     exc,
                 )
         log.debug("[#%04X]  C: <CLOSE>", self.local_port)
         try:
-            await self.socket.close()
-        except OSError:
-            pass
+            self.socket.close()
         finally:
             self._closed = True
 
@@ -1019,13 +1014,7 @@ class AsyncBolt:
         log.debug("[#%04X]  C: <KILL>", self.local_port)
         self._closing = True
         try:
-            self.socket.kill()
-        except OSError as exc:
-            log.debug(
-                "[#%04X]  _: <CONNECTION> ignoring failed kill %r",
-                self.local_port,
-                exc,
-            )
+            self.socket.close()
         finally:
             self._closed = True
 

--- a/src/neo4j/_async/io/_bolt_socket.py
+++ b/src/neo4j/_async/io/_bolt_socket.py
@@ -350,7 +350,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
                     err_str,
                 )
                 if s:
-                    await cls.close_socket(s)
+                    cls.close_socket(s)
                 errors.append(error)
                 failed_addresses.append(resolved_address)
             except asyncio.CancelledError:
@@ -366,7 +366,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
                 raise
             except Exception:
                 if s:
-                    await cls.close_socket(s)
+                    cls.close_socket(s)
                 raise
         address_strs = tuple(map(str, failed_addresses))
         # TODO: 7.0 - when Python 3.11+ is the minimum, use exception groups

--- a/src/neo4j/_async/io/_bolt_socket.py
+++ b/src/neo4j/_async/io/_bolt_socket.py
@@ -177,7 +177,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
             # If no data is returned after a successful select
             # response, the server has closed the connection
             log.debug("[#%04X]  S: <CLOSE>", ctx.local_port)
-            await self.close()
+            self.close()
             raise ServiceUnavailable(
                 f"Connection to {ctx.resolved_address} closed with incomplete "
                 f"handshake response"
@@ -185,7 +185,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
         if data_size != n:
             # Some garbled data has been received
             log.debug("[#%04X]  S: @*#!", ctx.local_port)
-            await self.close()
+            self.close()
             raise BoltProtocolError(
                 f"Expected {ctx.ctx} from {ctx.resolved_address!r}, received "
                 f"{response!r} instead (so far {ctx.full_response!r}); "
@@ -264,7 +264,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
 
         if response == b"HTTP":
             log.debug("[#%04X]  C: <CLOSE> (received b'HTTP')", local_port)
-            await self.close()
+            self.close()
             raise ServiceUnavailable(
                 f"Cannot to connect to Bolt service on {resolved_address!r} "
                 "(looks like HTTP)"
@@ -362,8 +362,7 @@ class AsyncBoltSocket(AsyncBoltSocketBase):
                     "[#%04X]  C: <CANCELED> %s", local_port, resolved_address
                 )
                 if s:
-                    with suppress(OSError):
-                        s.kill()
+                    s.close()
                 raise
             except Exception:
                 if s:

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -227,7 +227,7 @@ class AsyncBoltSocketBase(abc.ABC):
         self._writer.write(data)
         return await self._wait_for_write(self._writer.drain)
 
-    def close(self):
+    def close(self) -> None:
         # Simulate `SO_LINGER` off:
         # flush data and close socket in the background, don't block
         with suppress(OSError):
@@ -383,14 +383,14 @@ class AsyncBoltSocketBase(abc.ABC):
     ) -> tuple[t.Self, BoltProtocolVersion]: ...
 
     @classmethod
-    async def close_socket(cls, socket_):
+    def close_socket(cls, socket_: t.Self | socket) -> None:
         if isinstance(socket_, AsyncBoltSocketBase):
             socket_.close()
         else:
             cls._kill_raw_socket(socket_)
 
     @classmethod
-    def _kill_raw_socket(cls, socket_):
+    def _kill_raw_socket(cls, socket_: socket) -> None:
         with suppress(OSError):
             socket_.shutdown(SHUT_RDWR)
         with suppress(OSError):
@@ -506,7 +506,7 @@ class BoltSocketBase(abc.ABC):
     def sendall(self, data):
         return self._wait_for_write(self._socket.sendall, data)
 
-    def close(self):
+    def close(self) -> None:
         self.close_socket(self._socket)
 
     @classmethod
@@ -642,13 +642,14 @@ class BoltSocketBase(abc.ABC):
     ) -> tuple[t.Self, BoltProtocolVersion]: ...
 
     @classmethod
-    def close_socket(cls, socket_):
+    def close_socket(cls, socket_: t.Self | socket) -> None:
         if isinstance(socket_, BoltSocketBase):
-            socket_ = socket_._socket
-        cls._kill_raw_socket(socket_)
+            cls._kill_raw_socket(socket_._socket)
+        else:
+            cls._kill_raw_socket(socket_)
 
     @classmethod
-    def _kill_raw_socket(cls, socket_):
+    def _kill_raw_socket(cls, socket_: socket) -> None:
         with suppress(OSError):
             socket_.shutdown(SHUT_RDWR)
         with suppress(OSError):

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -228,7 +228,8 @@ class AsyncBoltSocketBase(abc.ABC):
 
     async def close(self):
         self._writer.close()
-        await self._wait_for_write(self._writer.drain)
+        with suppress(OSError, SocketDeadlineExceededError):
+            await self._wait_for_write(self._writer.drain)
 
     def kill(self):
         self._writer.close()

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -88,7 +88,7 @@ def _validate_timeout(timeout):
         raise ValueError("Timeout value out of range")
 
 
-def _deadline_timeout_fail_fast(
+def _non_expired_timeout(
     deadline: Deadline | None,
     operation: str,
 ) -> float | None:
@@ -147,7 +147,7 @@ class AsyncBoltSocketBase(abc.ABC):
         **kwargs: _P.kwargs,
     ) -> _R:
         to_raise: type[Exception] = TimeoutError
-        deadline_timeout = _deadline_timeout_fail_fast(deadline, name)
+        deadline_timeout = _non_expired_timeout(deadline, name)
         if deadline_timeout is not None and (
             timeout is None or deadline_timeout <= timeout
         ):
@@ -302,7 +302,7 @@ class AsyncBoltSocketBase(abc.ABC):
 
             try:
                 if ssl_context is not None:
-                    ssl_timeout = _deadline_timeout_fail_fast(
+                    ssl_timeout = _non_expired_timeout(
                         deadline, "SSL handshake"
                     )
                     if ssl_timeout is not None:
@@ -430,7 +430,7 @@ class BoltSocketBase(abc.ABC):
             "read",
             self._read_timeout,
             self._read_deadline,
-            _deadline_timeout_fail_fast,
+            _non_expired_timeout,
             func,
             *args,
             **kwargs,
@@ -441,7 +441,7 @@ class BoltSocketBase(abc.ABC):
             "write",
             self._write_timeout,
             self._write_deadline,
-            _deadline_timeout_fail_fast,
+            _non_expired_timeout,
             func,
             *args,
             **kwargs,
@@ -572,7 +572,7 @@ class BoltSocketBase(abc.ABC):
                 log.debug("[#%04X]  C: <SECURE> %s", local_port, hostname)
                 try:
                     t = s.gettimeout()
-                    ssl_timeout = _deadline_timeout_fail_fast(
+                    ssl_timeout = _non_expired_timeout(
                         deadline, "SSL handshake"
                     )
                     if ssl_timeout is not None:

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -506,7 +506,8 @@ class BoltSocketBase(abc.ABC):
         return self._wait_for_write(self._socket.sendall, data)
 
     def close(self):
-        self.close_socket(self._socket)
+        with suppress(SocketDeadlineExceededError):
+            self._wait_for_write(self.close_socket, self._socket)
 
     def kill(self):
         self._socket.close()

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -102,20 +102,6 @@ def _deadline_timeout_fail_fast(
     return timeout
 
 
-def _deadline_timeout_safe_expiration(
-    deadline: Deadline | None,
-    _operation: str,
-) -> float | None:
-    if deadline is None:
-        return None
-    timeout = deadline.to_timeout()
-    if timeout is None:
-        return None
-    if timeout <= 0:
-        return 0.001  # use a very brief timeout instead
-    return timeout
-
-
 class AsyncBoltSocketBase(abc.ABC):
     Bolt: t.Final[type[AsyncBolt]] = None  # type: ignore[assignment]
 
@@ -241,13 +227,11 @@ class AsyncBoltSocketBase(abc.ABC):
         self._writer.write(data)
         return await self._wait_for_write(self._writer.drain)
 
-    async def close(self):
-        self._writer.close()
-        with suppress(OSError, SocketDeadlineExceededError):
-            await self._wait_for_write(self._writer.drain)
-
-    def kill(self):
-        self._writer.close()
+    def close(self):
+        # Simulate `SO_LINGER` off:
+        # flush data and close socket in the background, don't block
+        with suppress(OSError):
+            self._writer.close()
 
     @classmethod
     async def _connect_secure(
@@ -401,8 +385,7 @@ class AsyncBoltSocketBase(abc.ABC):
     @classmethod
     async def close_socket(cls, socket_):
         if isinstance(socket_, AsyncBoltSocketBase):
-            with suppress(OSError):
-                await socket_.close()
+            socket_.close()
         else:
             cls._kill_raw_socket(socket_)
 
@@ -459,17 +442,6 @@ class BoltSocketBase(abc.ABC):
             self._write_timeout,
             self._write_deadline,
             _deadline_timeout_fail_fast,
-            func,
-            *args,
-            **kwargs,
-        )
-
-    def _wait_for_guaranteed_write(self, func, *args, **kwargs):
-        return self._wait_for_io(
-            "write",
-            self._write_timeout,
-            self._write_deadline,
-            _deadline_timeout_safe_expiration,
             func,
             *args,
             **kwargs,
@@ -535,11 +507,7 @@ class BoltSocketBase(abc.ABC):
         return self._wait_for_write(self._socket.sendall, data)
 
     def close(self):
-        with suppress(SocketDeadlineExceededError):
-            self._wait_for_guaranteed_write(self.close_socket, self._socket)
-
-    def kill(self):
-        self._socket.close()
+        self.close_socket(self._socket)
 
     @classmethod
     def _connect_secure(

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -228,7 +228,7 @@ class AsyncBoltSocketBase(abc.ABC):
 
     async def close(self):
         self._writer.close()
-        await self._writer.wait_closed()
+        await self._wait_for_write(self._writer.drain)
 
     def kill(self):
         self._writer.close()

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -60,6 +60,7 @@ if t.TYPE_CHECKING:
     from ..._sync.io import Bolt
 
     _P = t.ParamSpec("_P")
+    _R = t.TypeVar("_R")
 
 
 log = logging.getLogger("neo4j.io")
@@ -87,7 +88,7 @@ def _validate_timeout(timeout):
         raise ValueError("Timeout value out of range")
 
 
-def _non_expired_timeout(
+def _deadline_timeout_fail_fast(
     deadline: Deadline | None,
     operation: str,
 ) -> float | None:
@@ -98,6 +99,20 @@ def _non_expired_timeout(
         return None
     if timeout <= 0:
         raise SocketDeadlineExceededError(f"{operation} timed out")
+    return timeout
+
+
+def _deadline_timeout_safe_expiration(
+    deadline: Deadline | None,
+    _operation: str,
+) -> float | None:
+    if deadline is None:
+        return None
+    timeout = deadline.to_timeout()
+    if timeout is None:
+        return None
+    if timeout <= 0:
+        return 0.001  # use a very brief timeout instead
     return timeout
 
 
@@ -141,12 +156,12 @@ class AsyncBoltSocketBase(abc.ABC):
         name: str,
         timeout: float | None,
         deadline: Deadline | None,
-        io_async_fn: t.Callable[_P, t.Coroutine],
+        io_async_fn: t.Callable[_P, t.Coroutine[t.Any, t.Any, _R]],
         *args: _P.args,
         **kwargs: _P.kwargs,
-    ) -> None:
+    ) -> _R:
         to_raise: type[Exception] = TimeoutError
-        deadline_timeout = _non_expired_timeout(deadline, name)
+        deadline_timeout = _deadline_timeout_fail_fast(deadline, name)
         if deadline_timeout is not None and (
             timeout is None or deadline_timeout <= timeout
         ):
@@ -303,7 +318,7 @@ class AsyncBoltSocketBase(abc.ABC):
 
             try:
                 if ssl_context is not None:
-                    ssl_timeout = _non_expired_timeout(
+                    ssl_timeout = _deadline_timeout_fail_fast(
                         deadline, "SSL handshake"
                     )
                     if ssl_timeout is not None:
@@ -432,6 +447,7 @@ class BoltSocketBase(abc.ABC):
             "read",
             self._read_timeout,
             self._read_deadline,
+            _deadline_timeout_fail_fast,
             func,
             *args,
             **kwargs,
@@ -442,6 +458,18 @@ class BoltSocketBase(abc.ABC):
             "write",
             self._write_timeout,
             self._write_deadline,
+            _deadline_timeout_fail_fast,
+            func,
+            *args,
+            **kwargs,
+        )
+
+    def _wait_for_guaranteed_write(self, func, *args, **kwargs):
+        return self._wait_for_io(
+            "write",
+            self._write_timeout,
+            self._write_deadline,
+            _deadline_timeout_safe_expiration,
             func,
             *args,
             **kwargs,
@@ -452,12 +480,13 @@ class BoltSocketBase(abc.ABC):
         name: str,
         timeout: float | None,
         deadline: Deadline | None,
-        func: t.Callable[_P, t.Any],
+        deadline_conversion: t.Callable[[Deadline | None, str], float | None],
+        func: t.Callable[_P, _R],
         *args: _P.args,
         **kwargs: _P.kwargs,
-    ) -> None:
+    ) -> _R:
         rewrite_error = False
-        deadline_timeout = _non_expired_timeout(deadline, name)
+        deadline_timeout = deadline_conversion(deadline, name)
         if deadline_timeout is not None and (
             timeout is None or deadline_timeout <= timeout
         ):
@@ -507,7 +536,7 @@ class BoltSocketBase(abc.ABC):
 
     def close(self):
         with suppress(SocketDeadlineExceededError):
-            self._wait_for_write(self.close_socket, self._socket)
+            self._wait_for_guaranteed_write(self.close_socket, self._socket)
 
     def kill(self):
         self._socket.close()
@@ -575,7 +604,7 @@ class BoltSocketBase(abc.ABC):
                 log.debug("[#%04X]  C: <SECURE> %s", local_port, hostname)
                 try:
                     t = s.gettimeout()
-                    ssl_timeout = _non_expired_timeout(
+                    ssl_timeout = _deadline_timeout_fail_fast(
                         deadline, "SSL handshake"
                     )
                     if ssl_timeout is not None:

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -386,14 +386,6 @@ class Bolt:
 
         try:
             auth = Util.callback(auth_manager.get_auth)
-        except asyncio.CancelledError as e:
-            log.debug(
-                "[#%04X]  C: <KILL> open auth manager failed: %r",
-                s.getsockname()[1],
-                e,
-            )
-            s.kill()
-            raise
         except Exception as e:
             log.debug(
                 "[#%04X]  C: <CLOSE> open auth manager failed: %r",
@@ -998,17 +990,20 @@ class Bolt:
             self.goodbye()
             try:
                 self._send_all()
-            except (OSError, BoltError, DriverError) as exc:
+            except (
+                OSError,
+                BoltError,
+                DriverError,
+                SocketDeadlineExceededError,
+            ) as exc:
                 log.debug(
-                    "[#%04X]  _: <CONNECTION> ignoring failed close %r",
+                    "[#%04X]  _: <CONNECTION> ignoring failed final flush %r",
                     self.local_port,
                     exc,
                 )
         log.debug("[#%04X]  C: <CLOSE>", self.local_port)
         try:
             self.socket.close()
-        except OSError:
-            pass
         finally:
             self._closed = True
 
@@ -1019,13 +1014,7 @@ class Bolt:
         log.debug("[#%04X]  C: <KILL>", self.local_port)
         self._closing = True
         try:
-            self.socket.kill()
-        except OSError as exc:
-            log.debug(
-                "[#%04X]  _: <CONNECTION> ignoring failed kill %r",
-                self.local_port,
-                exc,
-            )
+            self.socket.close()
         finally:
             self._closed = True
 

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -386,7 +386,7 @@ class Bolt:
 
         try:
             auth = Util.callback(auth_manager.get_auth)
-        except Exception as e:
+        except (Exception, asyncio.CancelledError) as e:
             log.debug(
                 "[#%04X]  C: <CLOSE> open auth manager failed: %r",
                 s.getsockname()[1],

--- a/src/neo4j/_sync/io/_bolt_socket.py
+++ b/src/neo4j/_sync/io/_bolt_socket.py
@@ -362,8 +362,7 @@ class BoltSocket(BoltSocketBase):
                     "[#%04X]  C: <CANCELED> %s", local_port, resolved_address
                 )
                 if s:
-                    with suppress(OSError):
-                        s.kill()
+                    s.close()
                 raise
             except Exception:
                 if s:

--- a/tests/unit/async_/io/conftest.py
+++ b/tests/unit/async_/io/conftest.py
@@ -92,10 +92,7 @@ class AsyncFakeSocket2:
         if callable(self.on_send):
             self.on_send(data)
 
-    async def close(self):
-        return
-
-    def kill(self):
+    def close(self):
         return
 
     def inject(self, data):

--- a/tests/unit/async_/io/test_class_bolt.py
+++ b/tests/unit/async_/io/test_class_bolt.py
@@ -273,7 +273,7 @@ async def test_cancel_auth_manager_in_open(mocker):
     with pytest.raises(asyncio.CancelledError):
         await AsyncBolt.open(address, auth_manager=auth_manager)
 
-    socket_mock.kill.assert_called_once_with()
+    socket_mock.close.assert_called_once_with()
 
 
 @AsyncTestDecorators.mark_async_only_test
@@ -324,11 +324,7 @@ async def test_error_handler_bubbling(
         await handler(error)
     assert exc.value is error
 
-    if isinstance(error, asyncio.CancelledError):
-        connection.socket.kill.assert_called_once()
-        connection.socket.close.assert_not_called()
-    else:
-        connection.socket.close.assert_awaited_once()
+    connection.socket.close.assert_called_once()
 
     assert connection.closed()
     assert connection.defunct()
@@ -368,7 +364,7 @@ async def test_error_handler_rewritten(
     with pytest.raises(expected_error) as exc:
         await handler(error)
     assert exc.value.__cause__ is error
-    connection.socket.close.assert_awaited_once()
+    connection.socket.close.assert_called_once()
 
     assert connection.closed()
     assert connection.defunct()

--- a/tests/unit/async_/io/test_neo4j_pool.py
+++ b/tests/unit/async_/io/test_neo4j_pool.py
@@ -314,7 +314,7 @@ async def test_closes_stale_connections(opener, break_on_close):
     if break_on_close:
         cx1.close.assert_called()
     else:
-        cx1.close.assert_called_once()
+        cx1.close.assert_awaited_once()
     assert cx2 is not cx1
     assert cx2.unresolved_address == cx1.unresolved_address
     assert cx1 not in pool.connections[cx1.unresolved_address]
@@ -344,7 +344,7 @@ async def test_does_not_close_stale_connections_in_use(opener):
 
     cx3 = await pool.acquire(READ_ACCESS, 30, TEST_DB1, None, None, None)
     await pool.release(cx3)
-    cx1.close.assert_called_once()
+    cx1.close.assert_awaited_once()
     assert cx2 is cx3
     assert cx3.unresolved_address == cx1.unresolved_address
     assert cx1 not in pool.connections[cx1.unresolved_address]

--- a/tests/unit/sync/io/conftest.py
+++ b/tests/unit/sync/io/conftest.py
@@ -95,9 +95,6 @@ class FakeSocket2:
     def close(self):
         return
 
-    def kill(self):
-        return
-
     def inject(self, data):
         self.recv_buffer += data
 

--- a/tests/unit/sync/io/test_class_bolt.py
+++ b/tests/unit/sync/io/test_class_bolt.py
@@ -273,7 +273,7 @@ def test_cancel_auth_manager_in_open(mocker):
     with pytest.raises(asyncio.CancelledError):
         Bolt.open(address, auth_manager=auth_manager)
 
-    socket_mock.kill.assert_called_once_with()
+    socket_mock.close.assert_called_once_with()
 
 
 @TestDecorators.mark_async_only_test
@@ -324,11 +324,7 @@ def test_error_handler_bubbling(
         handler(error)
     assert exc.value is error
 
-    if isinstance(error, asyncio.CancelledError):
-        connection.socket.kill.assert_called_once()
-        connection.socket.close.assert_not_called()
-    else:
-        connection.socket.close.assert_called_once()
+    connection.socket.close.assert_called_once()
 
     assert connection.closed()
     assert connection.defunct()


### PR DESCRIPTION
This change aligns the async driver better with the sync driver. When a socket is closed, we don't want to wait until the OS acknowledges that the channel has been fully torn down. It's sufficient to initiate the closure. The rest we'll leave to the OS's TCP stack (and potentially other intermediates such as TLS wrappers) or the async runtime to figure out in the background.

Closes: #1309
Part of: DRIVERS-404

<details>

<summary>Reproducer</summary>

Assumes Ubuntu/Debian base.

0. Install dependencies `apt-get install iptables build-essential python3-venv python3-dev libnetfilter-queue-dev`
1. Start neo4j in docker, enable SSL for bolt, expose port 7687.
2. Create `filter.py`:
    ```python
    # requires
    # NetfilterQueue==1.1.0
    # scapy==2.7.0
    
    import signal
    import sys
    from netfilterqueue import NetfilterQueue
    from scapy.layers.inet import IP, TCP
    
    SERVER_IPS = {
        "127.0.0.1",
        "172.24.0.2",  # ADJUST: neo4j docker container IP
    }
    SERVER_PORT = 7687
    
    seen_syn_conns: set = set()  # client ports whose SYN was observed
    
    
    def conn_key(ip_pkt, tcp_pkt):
        if ip_pkt.dport == SERVER_PORT:
            return ip_pkt.sport
        return ip_pkt.dport
    
    
    def handle(pkt):
        raw = IP(pkt.get_payload())
        if not raw.haslayer(TCP):
            pkt.accept()
            return
    
        ip  = raw[IP]
        tcp = raw[TCP]
        key = conn_key(ip, tcp)
    
        if not (
            (ip.dst in SERVER_IPS or ip.src in SERVER_IPS)
            and (ip.dport == SERVER_PORT or ip.sport == SERVER_PORT)
        ):
            print(f"{raw} (unrelated)")
            pkt.accept()
            return
    
        print(f"{raw}")
    
        # Register the connection on the client's initial SYN.
        if "S" in tcp.flags:
            print(f"    [  syn] {key}")
            seen_syn_conns.add(key)
            pkt.accept()
            return
    
        # Drop any packet whose connection was never opened through us.
        if key not in seen_syn_conns:
            print(f"    [ drop] no SYN seen  {key}")
            pkt.drop()
            return
    
        pkt.accept()
    
    
    def shutdown(sig, _frame):
        print("\nShutting down.")
        sys.exit(0)
    
    
    signal.signal(signal.SIGINT,  shutdown)
    signal.signal(signal.SIGTERM, shutdown)
    
    nfq = NetfilterQueue()
    nfq.bind(1, handle)
    print("Running — Ctrl-C to stop.")
    try:
        nfq.run()
    finally:
        nfq.unbind()
    ```
3. Create venv for `filter.py` filter rule
   1. `python -m venv .venv`
   2. `source .venv/bin/activate`
   4. `pip install NetfilterQueue==1.1.0 scapy==2.7.0`
4. Start `sudo .venv/bin/python filter.py`
5. *Inside another* python environment with the driver and its dependencies available, run the following reproducer:
    ```python
    import sys
    import time
    import subprocess
    
    import asyncio
    from neo4j import AsyncGraphDatabase, GraphDatabase
    from neo4j.debug import watch
    
    watch("neo4j")
    
    URI = "bolt+ssc://localhost:7687"
    AUTH = ("neo4j", "pass")
    
    SPORT_FILTER = ("--sport", "7687")
    DPORT_FILTER = ("--dport", "7687")
    
    
    def _iptables_rule(port_filter):
        return (
            "INPUT", "-p", "tcp", *port_filter, "-j", "NFQUEUE", "--queue-num", "1"
        )
    
    
    def _clear_iptables():
        for port_filter in (SPORT_FILTER, DPORT_FILTER):
            subprocess.run(
                ["sudo", "iptables", "-D", *_iptables_rule(port_filter)],
                stderr=sys.stderr,
                stdout=sys.stdout,
            )
    
    
    def _setup_iptables():
        for port_filter in (SPORT_FILTER, DPORT_FILTER):
            subprocess.run(
                ["sudo", "iptables", "-I", *_iptables_rule(port_filter)],
                stderr=sys.stderr,
                stdout=sys.stdout,
                check=True,
            )
    
    
    async def main():
        _clear_iptables()
    
        async with AsyncGraphDatabase.driver(
            URI,
            auth=AUTH,
            max_connection_pool_size=1,
            connection_acquisition_timeout=3,
            liveness_check_timeout=1,
            max_connection_lifetime=5,
        ) as driver:
            t0 = time.time()
    
            try:
                async with driver.session() as session:
                    await (await session.run("RETURN 1 AS n")).to_eager_result()
            finally:
                print(f"\n  >>>>> took: {time.time() - t0:.2f} seconds\n")
    
            _setup_iptables()
            await asyncio.sleep(6)  # exceed connection lifetime
    
            t0 = time.time()
    
            try:
                async with driver.session() as session:
                    await (await session.run("RETURN 1 AS n")).to_eager_result()
            finally:
                print(f"\n  >>>>> took: {time.time() - t0:.2f} seconds\n")
    
    
    def main_sync():
        _clear_iptables()
    
        with GraphDatabase.driver(
            URI,
            auth=AUTH,
            max_connection_pool_size=1,
            connection_acquisition_timeout=3,
            liveness_check_timeout=1,
            max_connection_lifetime=5,
        ) as driver:
            t0 = time.time()
    
            try:
                with driver.session() as session:
                    session.run("RETURN 1 AS n").to_eager_result()
            finally:
                print(f"\n  >>>>> took: {time.time() - t0:.2f} seconds\n")
    
            _setup_iptables()
            time.sleep(1)  # exceed liveness check timeout
    
            t0 = time.time()
    
            try:
                with driver.session() as session:
                    session.run("RETURN 1 AS n").to_eager_result()
            finally:
                print(f"\n  >>>>> took: {time.time() - t0:.2f} seconds\n")
    
    
    if __name__ == "__main__":
        try:
            asyncio.run(main())
            # main_sync()
        finally:
            _clear_iptables()
            print(" ====== DONE ====== ")
    ```

</details>