### PR TITLE
Make driver's default SSL context respect SSLKEYLOGFILE env var

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -848,7 +848,7 @@ There are different *mutually exclusive* ways of configuring TLS/SSL encryption 
 All options except for configuring a custom :ref:`ssl-context-ref` will check the
 environment variable ``SSLKEYLOGFILE``.
 If the variable is set, its value will be assinged to
-:attr:`ssl.SSLContext.keylog_filename` to enable keyfile logging.
+:attr:`ssl.SSLContext.keylog_filename` to enable key logging.
 
 
 Driver Object Lifetime

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -845,6 +845,10 @@ There are different *mutually exclusive* ways of configuring TLS/SSL encryption 
   * or set :ref:`ssl-context-ref` to gain full control (and responsibility) over the TLS configuration.
   * or set ``encrypted=False`` (default) to disable TLS.
 
+All options except for configuring a custom :ref:`ssl-context-ref` will check the
+environment variable ``SSLKEYLOGFILE``.
+If the variable is set, it's value will be assinged to
+:attr:`ssl.SSLContext.keylog_filename` to enable keyfile logging.
 
 
 Driver Object Lifetime

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -847,7 +847,7 @@ There are different *mutually exclusive* ways of configuring TLS/SSL encryption 
 
 All options except for configuring a custom :ref:`ssl-context-ref` will check the
 environment variable ``SSLKEYLOGFILE``.
-If the variable is set, it's value will be assinged to
+If the variable is set, its value will be assinged to
 :attr:`ssl.SSLContext.keylog_filename` to enable keyfile logging.
 
 

--- a/src/neo4j/_async/config.py
+++ b/src/neo4j/_async/config.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+import os
+
 from .. import _typing as t
 from .._async_compat.concurrency import AsyncLock
 from .._conf import (
@@ -153,6 +155,12 @@ class AsyncPoolConfig(Config):
             # For recommended security options see
             # https://docs.python.org/3.10/library/ssl.html#protocol-versions
             ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+
+            # Follow Python's `create_default_context` and respect the
+            # `SSLKEYLOGFILE` environment variable for key logging if present.
+            ssl_keylog_file = os.getenv("SSLKEYLOGFILE")
+            if ssl_keylog_file:
+                ssl_context.keylog_filename = ssl_keylog_file
 
             if isinstance(self.trusted_certificates, TrustAll):
                 # trust any certificate

--- a/src/neo4j/_sync/config.py
+++ b/src/neo4j/_sync/config.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+import os
+
 from .. import _typing as t
 from .._async_compat.concurrency import Lock
 from .._conf import (
@@ -153,6 +155,12 @@ class PoolConfig(Config):
             # For recommended security options see
             # https://docs.python.org/3.10/library/ssl.html#protocol-versions
             ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+
+            # Follow Python's `create_default_context` and respect the
+            # `SSLKEYLOGFILE` environment variable for key logging if present.
+            ssl_keylog_file = os.getenv("SSLKEYLOGFILE")
+            if ssl_keylog_file:
+                ssl_context.keylog_filename = ssl_keylog_file
 
             if isinstance(self.trusted_certificates, TrustAll):
                 # trust any certificate


### PR DESCRIPTION
This aligns the driver with Python's `ssl.create_default_context()` behavior:

> When `keylog_filename` is supported and the environment variable
> `SSLKEYLOGFILE` is set, `create_default_context()` enables key logging.
>
> -- https://docs.python.org/3.14/library/ssl.html#ssl.create_default_context

The same behavior could previously be achieved by passing a custom SSLContext. However, this is much more work. Supporting the env var `SSLKEYLOGFILE` is a common practice for software using SSL.

Closes: DRIVERS-442