### PR TITLE
[5.28] Make mypy happy again

### DIFF
--- a/src/neo4j/api.py
+++ b/src/neo4j/api.py
@@ -444,7 +444,7 @@ class Version(_version_base):
         return bytes(b)
 
     @classmethod
-    def from_bytes(cls, b: bytes) -> Version:
+    def from_bytes(cls, b: bytes | bytearray) -> Version:
         b = bytearray(b)
         if len(b) != 4:
             raise ValueError("Byte representation must be exactly four bytes")


### PR DESCRIPTION
This method is public-ish, i.e., reachable without accessing any `_xyz`, but it's undocumented. The driver stopped using it a while ago. This change is just to please the type-checker.