### PR TITLE
[5.28] Fix async driver waiting for OS on closing half-open socket

### DIFF
--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -192,7 +192,6 @@ class AsyncBoltSocketBase(abc.ABC):
 
     async def close(self):
         self._writer.close()
-        await self._writer.wait_closed()
 
     def kill(self):
         self._writer.close()


### PR DESCRIPTION
This change aligns the async driver better with the sync driver. When a socket is closed, we don't want to wait until the OS acknowledges that the channel has been fully torn down. It's sufficient to initiate the closure. The rest we'll leave to the OS's TCP stack (and potentially other intermediates such as TLS wrappers) or the async runtime to figure out in the background.

Closes: #1309
Closes: DRIVERS-404

Backport of: #1311

This backport is limited to the minimal change required for the desired change in behavior. All the auxiliary clean-up work of the original PR has been omitted in favor of code stability.