### PR TITLE
Tests: fix deprecations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ test = [
     "pytest-benchmark >= 5.1.0",
     "pytest-cov >= 7.0.0",
     "pytest-mock >= 3.15.1",
+    "pytest-timeout >= 2.4.0",
     "mock >= 5.2.0",
     "tzdata >= 2026.2",
 ]
@@ -213,6 +214,7 @@ use_parentheses = true
 mock_use_standalone_module = true
 asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope="function"
+timeout = 120
 
 
 [tool.mypy]

--- a/src/neo4j/_typing.py
+++ b/src/neo4j/_typing.py
@@ -36,6 +36,7 @@ from collections.abc import (
 )
 from contextlib import AbstractContextManager
 from importlib.util import find_spec as _find_spec
+from types import EllipsisType
 from typing import (
     Any,
     cast,
@@ -69,6 +70,7 @@ __all__: tuple[str, ...] = (
     "Collection",
     "Concatenate",
     "Coroutine",
+    "EllipsisType",
     "Final",
     "Generator",
     "Generic",

--- a/tests/_async_compat/mark_decorator.py
+++ b/tests/_async_compat/mark_decorator.py
@@ -14,11 +14,27 @@
 # limitations under the License.
 
 
+import sys
+
 import pytest
 import pytest_asyncio
 
+from ..env import (
+    IS_GHA,
+    IS_WIN,
+)
 
-mark_async_test = pytest.mark.asyncio
+
+# On Windows + Python 3.14 a per-test asyncio event loop exhausts the ephemeral
+# port range. Heavily parametrized async tests churn thousands of short-lived
+# sockets into TIME_WAIT (OSError WinError 10055 / WSAENOBUFS),
+# which manifests as a hung or failing Windows CI job. Sharing one event loop
+# per module on that platform removes the churn; every other platform keeps the
+# default per-test loop.
+if IS_GHA and IS_WIN and (3, 14) <= sys.version_info < (3, 15):
+    mark_async_test = pytest.mark.asyncio(loop_scope="module")
+else:
+    mark_async_test = pytest.mark.asyncio
 
 async_fixture = pytest_asyncio.fixture
 

--- a/tests/env.py
+++ b/tests/env.py
@@ -98,7 +98,7 @@ NEO4J_SERVER_URI = _LazyEvalFunc(
     )
 )
 IS_WIN = sys.platform in {"win32", "cygwin"}
-IS_GHA = _LazyEvalEnv("GITHUB_ACTIONS", bool, default=False)
+IS_GHA = _LazyEvalEnv("GITHUB_ACTIONS", bool, default="false")
 
 
 __all__ = (

--- a/tests/env.py
+++ b/tests/env.py
@@ -14,9 +14,20 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
 import abc
 import sys
 from os import environ
+
+from neo4j import _typing as t
+
+
+if t.TYPE_CHECKING:
+    from types import ModuleType
+
+
+_TRUE_ENV_VALUES = {"1", "y", "yes", "true", "t", "on"}
 
 
 class _LazyEval(abc.ABC):
@@ -26,7 +37,7 @@ class _LazyEval(abc.ABC):
 
 
 class _LazyEvalEnv(_LazyEval):
-    def __init__(self, env_key, type_: type = str, default=...):
+    def __init__(self, env_key, type_: type = str, default: t.Any = ...):
         self.env_key = env_key
         self.type_ = type_
         self.default = default
@@ -42,7 +53,7 @@ class _LazyEvalEnv(_LazyEval):
                     f"Missing environment variable {self.env_key}"
                 ) from e
         if self.type_ is bool:
-            return value.lower() in {"yes", "y", "1", "on", "true"}
+            return value.lower() in _TRUE_ENV_VALUES
         return self.type_(value)
 
 
@@ -55,6 +66,8 @@ class _LazyEvalFunc(_LazyEval):
 
 
 class _Module:
+    _module: ModuleType
+
     def __init__(self, module):
         self._module = module
 
@@ -84,9 +97,13 @@ NEO4J_SERVER_URI = _LazyEvalFunc(
         f"{_module.NEO4J_SCHEME}://{_module.NEO4J_HOST}:{_module.NEO4J_PORT}"
     )
 )
+IS_WIN = sys.platform in {"win32", "cygwin"}
+IS_GHA = _LazyEvalEnv("GITHUB_ACTIONS", bool, default=False)
 
 
 __all__ = (
+    "IS_GHA",
+    "IS_WIN",
     "NEO4J_EDITION",
     "NEO4J_HOST",
     "NEO4J_IS_CLUSTER",

--- a/tests/integration/mixed/test_async_cancellation.py
+++ b/tests/integration/mixed/test_async_cancellation.py
@@ -107,7 +107,7 @@ REPETITIONS = 250
 @mark_async_test
 @pytest.mark.parametrize(
     ("i", "read_func", "waits", "cancel_count"),
-    (
+    tuple(
         (
             f"{i + 1:0{len(str(REPETITIONS))}}/{REPETITIONS}",
             random.choice(

--- a/tests/unit/async_/io/test_class_bolt3.py
+++ b/tests/unit/async_/io/test_class_bolt3.py
@@ -246,13 +246,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -444,13 +446,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -522,18 +526,24 @@ def raises_if_db(db):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x0.py
+++ b/tests/unit/async_/io/test_class_bolt4x0.py
@@ -351,13 +351,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -549,13 +551,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -613,18 +617,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x1.py
+++ b/tests/unit/async_/io/test_class_bolt4x1.py
@@ -373,13 +373,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -571,13 +573,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -635,18 +639,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x2.py
+++ b/tests/unit/async_/io/test_class_bolt4x2.py
@@ -373,13 +373,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -571,13 +573,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -635,18 +639,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x3.py
+++ b/tests/unit/async_/io/test_class_bolt4x3.py
@@ -402,13 +402,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -600,13 +602,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -664,18 +668,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x4.py
+++ b/tests/unit/async_/io/test_class_bolt4x4.py
@@ -428,13 +428,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -626,18 +628,24 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x0.py
+++ b/tests/unit/async_/io/test_class_bolt5x0.py
@@ -428,13 +428,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -626,13 +628,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -690,18 +694,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x1.py
+++ b/tests/unit/async_/io/test_class_bolt5x1.py
@@ -680,13 +680,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -745,18 +747,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x2.py
+++ b/tests/unit/async_/io/test_class_bolt5x2.py
@@ -519,11 +519,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -717,13 +721,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -782,18 +788,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x3.py
+++ b/tests/unit/async_/io/test_class_bolt5x3.py
@@ -406,11 +406,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -604,13 +608,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -669,18 +675,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x4.py
+++ b/tests/unit/async_/io/test_class_bolt5x4.py
@@ -411,11 +411,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -609,13 +613,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -674,18 +680,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x5.py
+++ b/tests/unit/async_/io/test_class_bolt5x5.py
@@ -411,11 +411,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -609,13 +613,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -681,20 +687,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x6.py
+++ b/tests/unit/async_/io/test_class_bolt5x6.py
@@ -411,11 +411,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -609,13 +613,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -681,20 +687,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x7.py
+++ b/tests/unit/async_/io/test_class_bolt5x7.py
@@ -412,11 +412,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -610,13 +614,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -682,20 +688,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))
@@ -769,21 +785,31 @@ async def test_enriches_statuses(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        lower_limit=1,
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            lower_limit=1,
+            upper_limit=3,
+        )
     ),
 )
 @mark_async_test

--- a/tests/unit/async_/io/test_class_bolt5x8.py
+++ b/tests/unit/async_/io/test_class_bolt5x8.py
@@ -412,11 +412,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -610,13 +614,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -682,20 +688,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))
@@ -769,21 +785,31 @@ async def test_enriches_statuses(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        lower_limit=1,
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            lower_limit=1,
+            upper_limit=3,
+        )
     ),
 )
 @mark_async_test

--- a/tests/unit/async_/io/test_class_bolt6x0.py
+++ b/tests/unit/async_/io/test_class_bolt6x0.py
@@ -412,11 +412,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -610,13 +614,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -682,20 +688,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))
@@ -769,21 +785,31 @@ async def test_enriches_statuses(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        lower_limit=1,
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            lower_limit=1,
+            upper_limit=3,
+        )
     ),
 )
 @mark_async_test

--- a/tests/unit/async_/io/test_neo4j_pool.py
+++ b/tests/unit/async_/io/test_neo4j_pool.py
@@ -749,9 +749,9 @@ async def test_failed_discovery_chains_errors(custom_routing_opener) -> None:
 
 @pytest.mark.parametrize(
     "error",
-    map(
-        lambda args: Neo4jError._hydrate_neo4j(code=args[0], message=args[1]),
-        (
+    tuple(
+        Neo4jError._hydrate_neo4j(code=code, message=message)
+        for code, message in (
             ("Neo.ClientError.Database.DatabaseNotFound", "message"),
             ("Neo.ClientError.Transaction.InvalidBookmark", "message"),
             ("Neo.ClientError.Transaction.InvalidBookmarkMixture", "message"),
@@ -764,7 +764,7 @@ async def test_failed_discovery_chains_errors(custom_routing_opener) -> None:
             ("Neo.ClientError.Security.TokenExpired", "message"),
             ("Neo.ClientError.Security.Unauthorized", "message"),
             ("Neo.ClientError.Security.MadeUpError", "message"),
-        ),
+        )
     ),
 )
 @mark_async_test
@@ -798,7 +798,7 @@ async def test_fast_failing_discovery(custom_routing_opener, error):
 
 @pytest.mark.parametrize(
     ("error", "marks_unauthenticated", "fetches_new"),
-    (
+    tuple(
         (Neo4jError._hydrate_neo4j(code=args[0], message="message"), *args[1:])
         for args in (
             ("Neo.ClientError.Database.DatabaseNotFound", False, False),

--- a/tests/unit/async_/test_auth_management.py
+++ b/tests/unit/async_/test_auth_management.py
@@ -116,7 +116,7 @@ async def test_static_manager(
 
 @mark_async_test
 @pytest.mark.parametrize(
-    ("auth1", "auth2"), list(itertools.product(SAMPLE_AUTHS, repeat=2))
+    ("auth1", "auth2"), tuple(itertools.product(SAMPLE_AUTHS, repeat=2))
 )
 @pytest.mark.parametrize("error", SAMPLE_ERRORS)
 async def test_basic_manager_manual_expiry(

--- a/tests/unit/async_/test_auth_management.py
+++ b/tests/unit/async_/test_auth_management.py
@@ -141,7 +141,7 @@ async def test_basic_manager_manual_expiry(
 
 @mark_async_test
 @pytest.mark.parametrize(
-    ("auth1", "auth2"), itertools.product(SAMPLE_AUTHS, repeat=2)
+    ("auth1", "auth2"), tuple(itertools.product(SAMPLE_AUTHS, repeat=2))
 )
 @pytest.mark.parametrize("error", SAMPLE_ERRORS)
 @pytest.mark.parametrize("expires_at", (None, 0.001, 1, 1000.0))
@@ -170,7 +170,7 @@ async def test_bearer_manager_manual_expiry(
 
 @mark_async_test
 @pytest.mark.parametrize(
-    ("auth1", "auth2"), itertools.product(SAMPLE_AUTHS, repeat=2)
+    ("auth1", "auth2"), tuple(itertools.product(SAMPLE_AUTHS, repeat=2))
 )
 @pytest.mark.parametrize("expires_at", (None, -1, 1.0, 1, 1000.0))
 async def test_bearer_manager_time_expiry(

--- a/tests/unit/async_/work/test_session.py
+++ b/tests/unit/async_/work/test_session.py
@@ -660,7 +660,7 @@ async def test_session_custom_api_telemetry(async_fake_pool, mode):
 
 @pytest.mark.parametrize(
     ("db", "pool_ssr", "pool_routing", "expect_cache_usage"),
-    (
+    tuple(
         (db, ssr, routing, ssr and routing and not db)
         for ssr in (True, False)
         for routing in (True, False)
@@ -740,7 +740,7 @@ async def test_uses_home_db_cache_when_expected(
 
 @pytest.mark.parametrize(
     ("db", "pool_ssr", "pool_routing", "expect_cache_usage"),
-    (
+    tuple(
         (db, ssr, routing, ssr and routing and not db)
         for ssr in (True, False)
         for routing in (True, False)

--- a/tests/unit/common/codec/hydration/v1/test_temporal_dehydration.py
+++ b/tests/unit/common/codec/hydration/v1/test_temporal_dehydration.py
@@ -106,7 +106,7 @@ class TestTimeDehydration(HydrationHandlerTestBase):
 
     @pytest.mark.skipif(not HAS_NP, reason="numpy not installed")
     def test_numpy_nat_local_date_time(self, assert_transforms):
-        dt = np.datetime64("NaT")
+        dt = np.datetime64("NaT", "ns")
         assert_transforms(dt, None)
 
     @pytest.mark.skipif(not HAS_NP, reason="numpy not installed")
@@ -309,7 +309,7 @@ class TestTimeDehydration(HydrationHandlerTestBase):
 
     @pytest.mark.skipif(not HAS_NP, reason="numpy not installed")
     def test_numpy_nat_duration(self, assert_transforms):
-        duration = np.timedelta64("NaT")
+        duration = np.timedelta64("NaT", "ns")
         assert_transforms(duration, None)
 
     @pytest.mark.skipif(not HAS_NP, reason="numpy not installed")

--- a/tests/unit/common/test_api.py
+++ b/tests/unit/common/test_api.py
@@ -108,7 +108,7 @@ def test_bookmarks_repr(values, expected_repr) -> None:
 
 @pytest.mark.parametrize(
     ("values1", "values2"),
-    (
+    tuple(
         values
         for values in itertools.combinations_with_replacement(
             (

--- a/tests/unit/common/test_types.py
+++ b/tests/unit/common/test_types.py
@@ -97,7 +97,7 @@ def test_node_with_null_properties():
 
 @pytest.mark.parametrize(
     ("g1", "id1", "eid1", "props1", "g2", "id2", "eid2", "props2"),
-    (
+    tuple(
         (*n1, *n2)
         for n1, n2 in product(
             (  # type: ignore

--- a/tests/unit/common/time/test_datetime.py
+++ b/tests/unit/common/time/test_datetime.py
@@ -1007,32 +1007,38 @@ def test_inequality(dt1, dt2) -> None:
 
 @pytest.mark.parametrize(
     ("dt1", "dt2"),
-    itertools.product(
-        (
-            datetime(2022, 11, 25, 12, 34, 56, 789123),
-            DateTime(2022, 11, 25, 12, 34, 56, 789123000),
-            datetime(2022, 11, 25, 12, 34, 56, 789123, FixedOffset(0)),
-            DateTime(2022, 11, 25, 12, 34, 56, 789123456, FixedOffset(0)),
-            datetime(2022, 11, 25, 12, 35, 56, 789123, FixedOffset(1)),
-            DateTime(2022, 11, 25, 12, 35, 56, 789123456, FixedOffset(1)),
-            datetime(2022, 11, 25, 12, 34, 56, 789123, FixedOffset(-1)),
-            DateTime(2022, 11, 25, 12, 34, 56, 789123456, FixedOffset(-1)),
-            datetime(2022, 11, 25, 12, 34, 56, 789123, FixedOffset(60 * -16)),
-            DateTime(
-                2022, 11, 25, 12, 34, 56, 789123000, FixedOffset(60 * -16)
+    tuple(
+        itertools.product(
+            (
+                datetime(2022, 11, 25, 12, 34, 56, 789123),
+                DateTime(2022, 11, 25, 12, 34, 56, 789123000),
+                datetime(2022, 11, 25, 12, 34, 56, 789123, FixedOffset(0)),
+                DateTime(2022, 11, 25, 12, 34, 56, 789123456, FixedOffset(0)),
+                datetime(2022, 11, 25, 12, 35, 56, 789123, FixedOffset(1)),
+                DateTime(2022, 11, 25, 12, 35, 56, 789123456, FixedOffset(1)),
+                datetime(2022, 11, 25, 12, 34, 56, 789123, FixedOffset(-1)),
+                DateTime(2022, 11, 25, 12, 34, 56, 789123456, FixedOffset(-1)),
+                datetime(
+                    2022, 11, 25, 12, 34, 56, 789123, FixedOffset(60 * -16)
+                ),
+                DateTime(
+                    2022, 11, 25, 12, 34, 56, 789123000, FixedOffset(60 * -16)
+                ),
+                datetime(
+                    2022, 11, 25, 11, 34, 56, 789123, FixedOffset(60 * -17)
+                ),
+                DateTime(
+                    2022, 11, 25, 11, 34, 56, 789123000, FixedOffset(60 * -17)
+                ),
+                DateTime(
+                    2022, 11, 25, 12, 34, 56, 789123456, FixedOffset(60 * -16)
+                ),
+                DateTime(
+                    2022, 11, 25, 11, 34, 56, 789123456, FixedOffset(60 * -17)
+                ),
             ),
-            datetime(2022, 11, 25, 11, 34, 56, 789123, FixedOffset(60 * -17)),
-            DateTime(
-                2022, 11, 25, 11, 34, 56, 789123000, FixedOffset(60 * -17)
-            ),
-            DateTime(
-                2022, 11, 25, 12, 34, 56, 789123456, FixedOffset(60 * -16)
-            ),
-            DateTime(
-                2022, 11, 25, 11, 34, 56, 789123456, FixedOffset(60 * -17)
-            ),
-        ),
-        repeat=2,
+            repeat=2,
+        )
     ),
 )
 def test_hashed_equality(dt1, dt2) -> None:
@@ -1054,7 +1060,7 @@ def test_hashed_equality(dt1, dt2) -> None:
 
 @pytest.mark.parametrize(
     ("dt1", "dt2"),
-    (
+    tuple(
         itertools.product(
             (
                 datetime(2022, 11, 25, 12, 34, 56, 789123),
@@ -1081,13 +1087,15 @@ def test_comparison_with_only_one_naive_fails(dt1, dt2, tz, op) -> None:
 
 @pytest.mark.parametrize(
     ("dt1", "dt2"),
-    itertools.product(
-        (
-            datetime(2022, 11, 25, 12, 34, 56, 789123),
-            DateTime(2022, 11, 25, 12, 34, 56, 789123000),
-            DateTime(2022, 11, 25, 12, 34, 56, 789123001),
-        ),
-        repeat=2,
+    tuple(
+        itertools.product(
+            (
+                datetime(2022, 11, 25, 12, 34, 56, 789123),
+                DateTime(2022, 11, 25, 12, 34, 56, 789123000),
+                DateTime(2022, 11, 25, 12, 34, 56, 789123001),
+            ),
+            repeat=2,
+        )
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/unit/common/time/test_time.py
+++ b/tests/unit/common/time/test_time.py
@@ -389,24 +389,26 @@ class TestTime:
 
     @pytest.mark.parametrize(
         ("t1", "t2"),
-        itertools.product(
-            (
-                time(12, 34, 56, 789123),
-                Time(12, 34, 56, 789123000),
-                time(12, 34, 56, 789123, FixedOffset(0)),
-                Time(12, 34, 56, 789123456, FixedOffset(0)),
-                time(12, 35, 56, 789123, FixedOffset(1)),
-                Time(12, 35, 56, 789123456, FixedOffset(1)),
-                time(12, 34, 56, 789123, FixedOffset(-1)),
-                Time(12, 34, 56, 789123456, FixedOffset(-1)),
-                time(12, 34, 56, 789123, FixedOffset(60 * -16)),
-                Time(12, 34, 56, 789123000, FixedOffset(60 * -16)),
-                time(11, 34, 56, 789123, FixedOffset(60 * -17)),
-                Time(11, 34, 56, 789123000, FixedOffset(60 * -17)),
-                Time(12, 34, 56, 789123456, FixedOffset(60 * -16)),
-                Time(11, 34, 56, 789123456, FixedOffset(60 * -17)),
-            ),
-            repeat=2,
+        tuple(
+            itertools.product(
+                (
+                    time(12, 34, 56, 789123),
+                    Time(12, 34, 56, 789123000),
+                    time(12, 34, 56, 789123, FixedOffset(0)),
+                    Time(12, 34, 56, 789123456, FixedOffset(0)),
+                    time(12, 35, 56, 789123, FixedOffset(1)),
+                    Time(12, 35, 56, 789123456, FixedOffset(1)),
+                    time(12, 34, 56, 789123, FixedOffset(-1)),
+                    Time(12, 34, 56, 789123456, FixedOffset(-1)),
+                    time(12, 34, 56, 789123, FixedOffset(60 * -16)),
+                    Time(12, 34, 56, 789123000, FixedOffset(60 * -16)),
+                    time(11, 34, 56, 789123, FixedOffset(60 * -17)),
+                    Time(11, 34, 56, 789123000, FixedOffset(60 * -17)),
+                    Time(12, 34, 56, 789123456, FixedOffset(60 * -16)),
+                    Time(11, 34, 56, 789123456, FixedOffset(60 * -17)),
+                ),
+                repeat=2,
+            )
         ),
     )
     def test_hashed_equality(self, t1, t2) -> None:
@@ -427,7 +429,7 @@ class TestTime:
 
     @pytest.mark.parametrize(
         ("t1", "t2"),
-        (
+        tuple(
             itertools.product(
                 (
                     time(12, 34, 56, 789123),
@@ -465,13 +467,15 @@ class TestTime:
 
     @pytest.mark.parametrize(
         ("t1", "t2"),
-        itertools.product(
-            (
-                time(12, 34, 56, 789123),
-                Time(12, 34, 56, 789123000),
-                Time(12, 34, 56, 789123001),
-            ),
-            repeat=2,
+        tuple(
+            itertools.product(
+                (
+                    time(12, 34, 56, 789123),
+                    Time(12, 34, 56, 789123000),
+                    Time(12, 34, 56, 789123001),
+                ),
+                repeat=2,
+            )
         ),
     )
     @pytest.mark.parametrize(

--- a/tests/unit/sync/io/test_class_bolt3.py
+++ b/tests/unit/sync/io/test_class_bolt3.py
@@ -246,13 +246,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -444,13 +446,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -522,18 +526,24 @@ def raises_if_db(db):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x0.py
+++ b/tests/unit/sync/io/test_class_bolt4x0.py
@@ -351,13 +351,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -549,13 +551,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -613,18 +617,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x1.py
+++ b/tests/unit/sync/io/test_class_bolt4x1.py
@@ -373,13 +373,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -571,13 +573,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -635,18 +639,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x2.py
+++ b/tests/unit/sync/io/test_class_bolt4x2.py
@@ -373,13 +373,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -571,13 +573,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -635,18 +639,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x3.py
+++ b/tests/unit/sync/io/test_class_bolt4x3.py
@@ -402,13 +402,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -600,13 +602,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -664,18 +668,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x4.py
+++ b/tests/unit/sync/io/test_class_bolt4x4.py
@@ -428,13 +428,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -626,18 +628,24 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x0.py
+++ b/tests/unit/sync/io/test_class_bolt5x0.py
@@ -428,13 +428,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -626,13 +628,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -690,18 +694,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x1.py
+++ b/tests/unit/sync/io/test_class_bolt5x1.py
@@ -680,13 +680,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -745,18 +747,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x2.py
+++ b/tests/unit/sync/io/test_class_bolt5x2.py
@@ -519,11 +519,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -717,13 +721,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -782,18 +788,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x3.py
+++ b/tests/unit/sync/io/test_class_bolt5x3.py
@@ -406,11 +406,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -604,13 +608,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -669,18 +675,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x4.py
+++ b/tests/unit/sync/io/test_class_bolt5x4.py
@@ -411,11 +411,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -609,13 +613,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -674,18 +680,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x5.py
+++ b/tests/unit/sync/io/test_class_bolt5x5.py
@@ -411,11 +411,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -609,13 +613,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -681,20 +687,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x6.py
+++ b/tests/unit/sync/io/test_class_bolt5x6.py
@@ -411,11 +411,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -609,13 +613,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -681,20 +687,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x7.py
+++ b/tests/unit/sync/io/test_class_bolt5x7.py
@@ -412,11 +412,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -610,13 +614,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -682,20 +688,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))
@@ -769,21 +785,31 @@ def test_enriches_statuses(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        lower_limit=1,
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            lower_limit=1,
+            upper_limit=3,
+        )
     ),
 )
 @mark_sync_test

--- a/tests/unit/sync/io/test_class_bolt5x8.py
+++ b/tests/unit/sync/io/test_class_bolt5x8.py
@@ -412,11 +412,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -610,13 +614,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -682,20 +688,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))
@@ -769,21 +785,31 @@ def test_enriches_statuses(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        lower_limit=1,
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            lower_limit=1,
+            upper_limit=3,
+        )
     ),
 )
 @mark_sync_test

--- a/tests/unit/sync/io/test_class_bolt6x0.py
+++ b/tests/unit/sync/io/test_class_bolt6x0.py
@@ -412,11 +412,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -610,13 +614,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -682,20 +688,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))
@@ -769,21 +785,31 @@ def test_enriches_statuses(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        lower_limit=1,
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            lower_limit=1,
+            upper_limit=3,
+        )
     ),
 )
 @mark_sync_test

--- a/tests/unit/sync/io/test_neo4j_pool.py
+++ b/tests/unit/sync/io/test_neo4j_pool.py
@@ -749,9 +749,9 @@ def test_failed_discovery_chains_errors(custom_routing_opener) -> None:
 
 @pytest.mark.parametrize(
     "error",
-    map(
-        lambda args: Neo4jError._hydrate_neo4j(code=args[0], message=args[1]),
-        (
+    tuple(
+        Neo4jError._hydrate_neo4j(code=code, message=message)
+        for code, message in (
             ("Neo.ClientError.Database.DatabaseNotFound", "message"),
             ("Neo.ClientError.Transaction.InvalidBookmark", "message"),
             ("Neo.ClientError.Transaction.InvalidBookmarkMixture", "message"),
@@ -764,7 +764,7 @@ def test_failed_discovery_chains_errors(custom_routing_opener) -> None:
             ("Neo.ClientError.Security.TokenExpired", "message"),
             ("Neo.ClientError.Security.Unauthorized", "message"),
             ("Neo.ClientError.Security.MadeUpError", "message"),
-        ),
+        )
     ),
 )
 @mark_sync_test
@@ -798,7 +798,7 @@ def test_fast_failing_discovery(custom_routing_opener, error):
 
 @pytest.mark.parametrize(
     ("error", "marks_unauthenticated", "fetches_new"),
-    (
+    tuple(
         (Neo4jError._hydrate_neo4j(code=args[0], message="message"), *args[1:])
         for args in (
             ("Neo.ClientError.Database.DatabaseNotFound", False, False),

--- a/tests/unit/sync/test_auth_management.py
+++ b/tests/unit/sync/test_auth_management.py
@@ -141,7 +141,7 @@ def test_basic_manager_manual_expiry(
 
 @mark_sync_test
 @pytest.mark.parametrize(
-    ("auth1", "auth2"), itertools.product(SAMPLE_AUTHS, repeat=2)
+    ("auth1", "auth2"), tuple(itertools.product(SAMPLE_AUTHS, repeat=2))
 )
 @pytest.mark.parametrize("error", SAMPLE_ERRORS)
 @pytest.mark.parametrize("expires_at", (None, 0.001, 1, 1000.0))
@@ -170,7 +170,7 @@ def test_bearer_manager_manual_expiry(
 
 @mark_sync_test
 @pytest.mark.parametrize(
-    ("auth1", "auth2"), itertools.product(SAMPLE_AUTHS, repeat=2)
+    ("auth1", "auth2"), tuple(itertools.product(SAMPLE_AUTHS, repeat=2))
 )
 @pytest.mark.parametrize("expires_at", (None, -1, 1.0, 1, 1000.0))
 def test_bearer_manager_time_expiry(

--- a/tests/unit/sync/test_auth_management.py
+++ b/tests/unit/sync/test_auth_management.py
@@ -116,7 +116,7 @@ def test_static_manager(
 
 @mark_sync_test
 @pytest.mark.parametrize(
-    ("auth1", "auth2"), list(itertools.product(SAMPLE_AUTHS, repeat=2))
+    ("auth1", "auth2"), tuple(itertools.product(SAMPLE_AUTHS, repeat=2))
 )
 @pytest.mark.parametrize("error", SAMPLE_ERRORS)
 def test_basic_manager_manual_expiry(

--- a/tests/unit/sync/work/test_session.py
+++ b/tests/unit/sync/work/test_session.py
@@ -660,7 +660,7 @@ def test_session_custom_api_telemetry(fake_pool, mode):
 
 @pytest.mark.parametrize(
     ("db", "pool_ssr", "pool_routing", "expect_cache_usage"),
-    (
+    tuple(
         (db, ssr, routing, ssr and routing and not db)
         for ssr in (True, False)
         for routing in (True, False)
@@ -740,7 +740,7 @@ def test_uses_home_db_cache_when_expected(
 
 @pytest.mark.parametrize(
     ("db", "pool_ssr", "pool_routing", "expect_cache_usage"),
-    (
+    tuple(
         (db, ssr, routing, ssr and routing and not db)
         for ssr in (True, False)
         for routing in (True, False)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py{310,314}-{unit,integration,performance}-noextras
 
 [testenv]
-passenv = TEST_*
+passenv = TEST_*, GITHUB_ACTIONS
 dependency_groups =
     test
 extras =


### PR DESCRIPTION
* `pytest` deprecated using generators (lazy) for test parametrization. Instead a collection (eager) such as tuple, or list is expected.
* `numpy` deprecated instantiating temporal type values without providing an explicit unit.