### PR TITLE
[5.28] Bump setuptools to 84.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,8 @@ pyarrow = ["pyarrow >= 1.0.0"]
 requires = [
     "setuptools == 68.0.0; python_version <= '3.7'",  # dropped support for Python 3.7 in 68.1.0
     "setuptools == 75.3.0; python_version == '3.8'",  # dropped support for Python 3.8 in 75.4.0
-    "setuptools == 82.0.1; python_version >= '3.9'",
+    "setuptools == 82.0.1; python_version == '3.9'",  # dropped support for Python 3.9 in 83.0.0
+    "setuptools == 84.0.0; python_version >= '3.10'",
     # TODO: 6.0 - can be removed once `setup.py` is simplified
     "tomlkit == 0.12.5",  # dropped support (at least CI testing) for Python 3.7 in 0.13.0
 ]


### PR DESCRIPTION
Partial back port of: https://github.com/neo4j/neo4j-python-driver/pull/1327

Part of: DRIVERS-526