### PR TITLE
[5.28] Fix deprecations is tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ use_parentheses = true
 [tool.pytest.ini_options]
 mock_use_standalone_module = true
 asyncio_mode = "strict"
+timeout = 120
 
 
 [tool.mypy]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,6 +24,7 @@ pytest-asyncio~=0.21.2  # TODO: 6.0 - bump when support for Python 3.7 is droppe
 pytest-benchmark>=4.0.0
 pytest-cov>=4.1.0  # TODO: 6.0 - bump when support for Python 3.7 is dropped
 pytest-mock>=3.11.1  # TODO: 6.0 - bump when support for Python 3.7 is dropped
+pytest-timeout>=2.4.0    # TODO: 6.0 - bump when support for Python 3.7 is dropped
 tox>=4.8.0  # TODO: 6.0 - bump when support for Python 3.7 is dropped
 
 # needed for building docs

--- a/tests/_async_compat/mark_decorator.py
+++ b/tests/_async_compat/mark_decorator.py
@@ -17,8 +17,19 @@
 import pytest
 import pytest_asyncio
 
+from ..env import IS_WIN
 
-mark_async_test = pytest.mark.asyncio
+
+# On Windows a per-test asyncio event loop exhausts the ephemeral
+# port range. Heavily parametrized async tests churn thousands of short-lived
+# sockets into TIME_WAIT (OSError WinError 10055 / WSAENOBUFS),
+# which manifests as a hung or failing Windows CI job. Sharing one event loop
+# per module on that platform removes the churn; every other platform keeps the
+# default per-test loop.
+if IS_WIN:
+    mark_async_test = pytest.mark.asyncio(loop_scope="module")
+else:
+    mark_async_test = pytest.mark.asyncio
 
 async_fixture = pytest_asyncio.fixture
 

--- a/tests/_async_compat/mark_decorator.py
+++ b/tests/_async_compat/mark_decorator.py
@@ -17,19 +17,8 @@
 import pytest
 import pytest_asyncio
 
-from ..env import IS_WIN
 
-
-# On Windows a per-test asyncio event loop exhausts the ephemeral
-# port range. Heavily parametrized async tests churn thousands of short-lived
-# sockets into TIME_WAIT (OSError WinError 10055 / WSAENOBUFS),
-# which manifests as a hung or failing Windows CI job. Sharing one event loop
-# per module on that platform removes the churn; every other platform keeps the
-# default per-test loop.
-if IS_WIN:
-    mark_async_test = pytest.mark.asyncio(loop_scope="module")
-else:
-    mark_async_test = pytest.mark.asyncio
+mark_async_test = pytest.mark.asyncio
 
 async_fixture = pytest_asyncio.fixture
 

--- a/tests/_pandas_util.py
+++ b/tests/_pandas_util.py
@@ -1,0 +1,40 @@
+# Copyright (c) "Neo4j"
+# Neo4j Sweden AB [https://neo4j.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+
+from neo4j._meta import copy_signature
+
+
+warnings.filterwarnings(
+    "ignore",
+    "The 'generic' unit for NumPy timedelta is deprecated",
+    DeprecationWarning,
+    __name__,
+)
+
+
+@copy_signature(pd.Timedelta)
+def pd_timedelta(*args, **kwargs):
+    # Pandas is using a deprecated numpy API.
+    # However, we can't mute the error for pandas only as the offending line
+    # reported is the one calling pandas. Not sure why, maybe it's a
+    # Cython thing.
+    return pd.Timedelta(*args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import typing as t
 from functools import wraps
 
 import pytest
@@ -31,6 +32,10 @@ from neo4j.debug import watch
 
 from . import env
 from ._teamcity import *  # noqa - needed for pytest to pick up the hooks
+
+
+if t.TYPE_CHECKING:
+    import typing_extensions as te
 
 
 # from neo4j.debug import watch
@@ -204,10 +209,21 @@ def watcher():
         yield
 
 
+# On Windows a per-test asyncio event loop exhausts the ephemeral
+# port range. Heavily parametrized async tests churn thousands of short-lived
+# sockets into TIME_WAIT (OSError WinError 10055 / WSAENOBUFS),
+# which manifests as a hung or failing Windows CI job. Sharing one event loop
+# per module on that platform removes the churn; every other platform keeps the
+# default per-test loop.
+_LOOP_SCOPE: te.Literal["module", "function"] = (
+    "module" if env.IS_WIN else "function"
+)
+
+
 # TODO: 6.0 -
 #       when support for Python 3.7 is dropped and pytest-asyncio is bumped
 #       check if this fixture is still needed
-@pytest.fixture
+@pytest.fixture(scope=_LOOP_SCOPE)
 def event_loop():
     # Overwriting the default event loop injected by pytest-asyncio
     # because its implementation doesn't properly shut down the loop

--- a/tests/env.py
+++ b/tests/env.py
@@ -20,6 +20,9 @@ import typing as t
 from os import environ
 
 
+_TRUE_ENV_VALUES = {"1", "y", "yes", "true", "t", "on"}
+
+
 class _LazyEval(abc.ABC):
     @abc.abstractmethod
     def eval(self):
@@ -43,7 +46,7 @@ class _LazyEvalEnv(_LazyEval):
                     f"Missing environment variable {self.env_key}"
                 ) from e
         if self.type_ is bool:
-            return value.lower() in {"yes", "y", "1", "on", "true"}
+            return value.lower() in _TRUE_ENV_VALUES
         return self.type_(value)
 
 
@@ -86,9 +89,10 @@ NEO4J_SERVER_URI = _LazyEvalFunc(
         f"{_module.NEO4J_PORT}"
     )
 )
-
+IS_WIN = sys.platform in {"win32", "cygwin"}
 
 __all__ = (
+    "IS_WIN",
     "NEO4J_EDITION",
     "NEO4J_HOST",
     "NEO4J_IS_CLUSTER",

--- a/tests/integration/mixed/test_async_cancellation.py
+++ b/tests/integration/mixed/test_async_cancellation.py
@@ -107,7 +107,7 @@ REPETITIONS = 250
 @mark_async_test
 @pytest.mark.parametrize(
     ("i", "read_func", "waits", "cancel_count"),
-    (
+    tuple(
         (
             f"{i + 1:0{len(str(REPETITIONS))}}/{REPETITIONS}",
             random.choice(

--- a/tests/unit/async_/io/test_class_bolt3.py
+++ b/tests/unit/async_/io/test_class_bolt3.py
@@ -245,13 +245,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -443,13 +445,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -521,18 +525,24 @@ def raises_if_db(db):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x0.py
+++ b/tests/unit/async_/io/test_class_bolt4x0.py
@@ -350,13 +350,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -548,13 +550,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -612,18 +616,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x1.py
+++ b/tests/unit/async_/io/test_class_bolt4x1.py
@@ -372,13 +372,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -570,13 +572,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -634,18 +638,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x2.py
+++ b/tests/unit/async_/io/test_class_bolt4x2.py
@@ -372,13 +372,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -570,13 +572,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -634,18 +638,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x3.py
+++ b/tests/unit/async_/io/test_class_bolt4x3.py
@@ -401,13 +401,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -599,13 +601,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -663,18 +667,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt4x4.py
+++ b/tests/unit/async_/io/test_class_bolt4x4.py
@@ -425,13 +425,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -623,18 +625,24 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x0.py
+++ b/tests/unit/async_/io/test_class_bolt5x0.py
@@ -425,13 +425,15 @@ async def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -623,13 +625,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -687,18 +691,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x1.py
+++ b/tests/unit/async_/io/test_class_bolt5x1.py
@@ -676,13 +676,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -741,18 +743,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x2.py
+++ b/tests/unit/async_/io/test_class_bolt5x2.py
@@ -515,11 +515,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -713,13 +717,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -778,18 +784,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x3.py
+++ b/tests/unit/async_/io/test_class_bolt5x3.py
@@ -402,11 +402,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -600,13 +604,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -665,18 +671,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x4.py
+++ b/tests/unit/async_/io/test_class_bolt5x4.py
@@ -407,11 +407,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -605,13 +609,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -670,18 +676,24 @@ async def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x5.py
+++ b/tests/unit/async_/io/test_class_bolt5x5.py
@@ -407,11 +407,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -605,13 +609,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -677,20 +683,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x6.py
+++ b/tests/unit/async_/io/test_class_bolt5x6.py
@@ -407,11 +407,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -605,13 +609,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -677,20 +683,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/async_/io/test_class_bolt5x7.py
+++ b/tests/unit/async_/io/test_class_bolt5x7.py
@@ -408,11 +408,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -606,13 +610,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -678,20 +684,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))
@@ -765,21 +781,31 @@ async def test_enriches_statuses(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        lower_limit=1,
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            lower_limit=1,
+            upper_limit=3,
+        )
     ),
 )
 @mark_async_test

--- a/tests/unit/async_/io/test_class_bolt5x8.py
+++ b/tests/unit/async_/io/test_class_bolt5x8.py
@@ -408,11 +408,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_async_test
 async def test_supports_notification_filters(
@@ -606,13 +610,15 @@ async def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_async_test
@@ -678,20 +684,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))
@@ -765,21 +781,31 @@ async def test_enriches_statuses(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        lower_limit=1,
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            lower_limit=1,
+            upper_limit=3,
+        )
     ),
 )
 @mark_async_test

--- a/tests/unit/async_/io/test_neo4j_pool.py
+++ b/tests/unit/async_/io/test_neo4j_pool.py
@@ -658,9 +658,9 @@ async def test_discovery_is_retried(custom_routing_opener, error):
 
 @pytest.mark.parametrize(
     "error",
-    map(
-        lambda args: Neo4jError._hydrate_neo4j(code=args[0], message=args[1]),
-        (
+    tuple(
+        Neo4jError._hydrate_neo4j(code=code, message=message)
+        for code, message in (
             ("Neo.ClientError.Database.DatabaseNotFound", "message"),
             ("Neo.ClientError.Transaction.InvalidBookmark", "message"),
             ("Neo.ClientError.Transaction.InvalidBookmarkMixture", "message"),
@@ -673,7 +673,7 @@ async def test_discovery_is_retried(custom_routing_opener, error):
             ("Neo.ClientError.Security.TokenExpired", "message"),
             ("Neo.ClientError.Security.Unauthorized", "message"),
             ("Neo.ClientError.Security.MadeUpError", "message"),
-        ),
+        )
     ),
 )
 @mark_async_test
@@ -707,7 +707,7 @@ async def test_fast_failing_discovery(custom_routing_opener, error):
 
 @pytest.mark.parametrize(
     ("error", "marks_unauthenticated", "fetches_new"),
-    (
+    tuple(
         (Neo4jError._hydrate_neo4j(code=args[0], message="message"), *args[1:])
         for args in (
             ("Neo.ClientError.Database.DatabaseNotFound", False, False),

--- a/tests/unit/async_/test_auth_management.py
+++ b/tests/unit/async_/test_auth_management.py
@@ -116,7 +116,7 @@ async def test_static_manager(
 
 @mark_async_test
 @pytest.mark.parametrize(
-    ("auth1", "auth2"), list(itertools.product(SAMPLE_AUTHS, repeat=2))
+    ("auth1", "auth2"), tuple(itertools.product(SAMPLE_AUTHS, repeat=2))
 )
 @pytest.mark.parametrize("error", SAMPLE_ERRORS)
 async def test_basic_manager_manual_expiry(
@@ -141,7 +141,7 @@ async def test_basic_manager_manual_expiry(
 
 @mark_async_test
 @pytest.mark.parametrize(
-    ("auth1", "auth2"), itertools.product(SAMPLE_AUTHS, repeat=2)
+    ("auth1", "auth2"), tuple(itertools.product(SAMPLE_AUTHS, repeat=2))
 )
 @pytest.mark.parametrize("error", SAMPLE_ERRORS)
 @pytest.mark.parametrize("expires_at", (None, 0.001, 1, 1000.0))
@@ -170,7 +170,7 @@ async def test_bearer_manager_manual_expiry(
 
 @mark_async_test
 @pytest.mark.parametrize(
-    ("auth1", "auth2"), itertools.product(SAMPLE_AUTHS, repeat=2)
+    ("auth1", "auth2"), tuple(itertools.product(SAMPLE_AUTHS, repeat=2))
 )
 @pytest.mark.parametrize("expires_at", (None, -1, 1.0, 1, 1000.0))
 async def test_bearer_manager_time_expiry(

--- a/tests/unit/async_/work/test_session.py
+++ b/tests/unit/async_/work/test_session.py
@@ -710,7 +710,7 @@ async def test_session_custom_api_telemetry(async_fake_pool, mode):
 
 @pytest.mark.parametrize(
     ("db", "pool_ssr", "pool_routing", "expect_cache_usage"),
-    (
+    tuple(
         (db, ssr, routing, ssr and routing and not db)
         for ssr in (True, False)
         for routing in (True, False)
@@ -790,7 +790,7 @@ async def test_uses_home_db_cache_when_expected(
 
 @pytest.mark.parametrize(
     ("db", "pool_ssr", "pool_routing", "expect_cache_usage"),
-    (
+    tuple(
         (db, ssr, routing, ssr and routing and not db)
         for ssr in (True, False)
         for routing in (True, False)

--- a/tests/unit/async_/work/test_transaction.py
+++ b/tests/unit/async_/work/test_transaction.py
@@ -16,12 +16,12 @@
 
 from __future__ import annotations
 
+import typing as t
 from unittest.mock import MagicMock
 
 import pytest
 
 from neo4j import (
-    _typing as t,
     AsyncTransaction,
     NotificationMinimumSeverity,
     Query,

--- a/tests/unit/common/codec/hydration/v1/test_temporal_dehydration.py
+++ b/tests/unit/common/codec/hydration/v1/test_temporal_dehydration.py
@@ -34,6 +34,7 @@ from neo4j.time import (
     Time,
 )
 
+from ......_pandas_util import pd_timedelta
 from ._base import HydrationHandlerTestBase
 
 
@@ -98,7 +99,7 @@ class TestTimeDehydration(HydrationHandlerTestBase):
         assert_transforms(dt, Structure(b"d", 1539344261, 474716862))
 
     def test_numpy_nat_local_date_time(self, assert_transforms):
-        dt = np.datetime64("NaT")
+        dt = np.datetime64("NaT", "ns")
         assert_transforms(dt, None)
 
     @pytest.mark.parametrize(
@@ -259,7 +260,7 @@ class TestTimeDehydration(HydrationHandlerTestBase):
         assert_transforms(value, Structure(b"E", *expected_fields))
 
     def test_numpy_nat_duration(self, assert_transforms):
-        duration = np.timedelta64("NaT")
+        duration = np.timedelta64("NaT", "ns")
         assert_transforms(duration, None)
 
     @pytest.mark.parametrize(
@@ -277,11 +278,11 @@ class TestTimeDehydration(HydrationHandlerTestBase):
         ("value", "expected_fields"),
         (
             (
-                pd.Timedelta(days=1, seconds=2, microseconds=3, nanoseconds=4),
+                pd_timedelta(days=1, seconds=2, microseconds=3, nanoseconds=4),
                 (0, 0, AVERAGE_SECONDS_IN_DAY + 2, 3004),
             ),
             (
-                pd.Timedelta(
+                pd_timedelta(
                     days=-1, seconds=2, microseconds=3, nanoseconds=4
                 ),
                 (0, 0, -AVERAGE_SECONDS_IN_DAY + 2 + 1, -NANO_SECONDS + 3004),

--- a/tests/unit/common/test_api.py
+++ b/tests/unit/common/test_api.py
@@ -255,7 +255,7 @@ def test_bookmarks_repr(values, expected_repr) -> None:
 
 @pytest.mark.parametrize(
     ("values1", "values2"),
-    (
+    tuple(
         values
         for values in itertools.combinations_with_replacement(
             (

--- a/tests/unit/common/test_types.py
+++ b/tests/unit/common/test_types.py
@@ -97,7 +97,7 @@ def test_node_with_null_properties():
 
 @pytest.mark.parametrize(
     ("g1", "id1", "eid1", "props1", "g2", "id2", "eid2", "props2"),
-    (
+    tuple(
         (*n1, *n2)
         for n1, n2 in product(
             (  # type: ignore

--- a/tests/unit/common/time/test_datetime.py
+++ b/tests/unit/common/time/test_datetime.py
@@ -1011,32 +1011,38 @@ def test_inequality(dt1, dt2) -> None:
 
 @pytest.mark.parametrize(
     ("dt1", "dt2"),
-    itertools.product(
-        (
-            datetime(2022, 11, 25, 12, 34, 56, 789123),
-            DateTime(2022, 11, 25, 12, 34, 56, 789123000),
-            datetime(2022, 11, 25, 12, 34, 56, 789123, FixedOffset(0)),
-            DateTime(2022, 11, 25, 12, 34, 56, 789123456, FixedOffset(0)),
-            datetime(2022, 11, 25, 12, 35, 56, 789123, FixedOffset(1)),
-            DateTime(2022, 11, 25, 12, 35, 56, 789123456, FixedOffset(1)),
-            datetime(2022, 11, 25, 12, 34, 56, 789123, FixedOffset(-1)),
-            DateTime(2022, 11, 25, 12, 34, 56, 789123456, FixedOffset(-1)),
-            datetime(2022, 11, 25, 12, 34, 56, 789123, FixedOffset(60 * -16)),
-            DateTime(
-                2022, 11, 25, 12, 34, 56, 789123000, FixedOffset(60 * -16)
+    tuple(
+        itertools.product(
+            (
+                datetime(2022, 11, 25, 12, 34, 56, 789123),
+                DateTime(2022, 11, 25, 12, 34, 56, 789123000),
+                datetime(2022, 11, 25, 12, 34, 56, 789123, FixedOffset(0)),
+                DateTime(2022, 11, 25, 12, 34, 56, 789123456, FixedOffset(0)),
+                datetime(2022, 11, 25, 12, 35, 56, 789123, FixedOffset(1)),
+                DateTime(2022, 11, 25, 12, 35, 56, 789123456, FixedOffset(1)),
+                datetime(2022, 11, 25, 12, 34, 56, 789123, FixedOffset(-1)),
+                DateTime(2022, 11, 25, 12, 34, 56, 789123456, FixedOffset(-1)),
+                datetime(
+                    2022, 11, 25, 12, 34, 56, 789123, FixedOffset(60 * -16)
+                ),
+                DateTime(
+                    2022, 11, 25, 12, 34, 56, 789123000, FixedOffset(60 * -16)
+                ),
+                datetime(
+                    2022, 11, 25, 11, 34, 56, 789123, FixedOffset(60 * -17)
+                ),
+                DateTime(
+                    2022, 11, 25, 11, 34, 56, 789123000, FixedOffset(60 * -17)
+                ),
+                DateTime(
+                    2022, 11, 25, 12, 34, 56, 789123456, FixedOffset(60 * -16)
+                ),
+                DateTime(
+                    2022, 11, 25, 11, 34, 56, 789123456, FixedOffset(60 * -17)
+                ),
             ),
-            datetime(2022, 11, 25, 11, 34, 56, 789123, FixedOffset(60 * -17)),
-            DateTime(
-                2022, 11, 25, 11, 34, 56, 789123000, FixedOffset(60 * -17)
-            ),
-            DateTime(
-                2022, 11, 25, 12, 34, 56, 789123456, FixedOffset(60 * -16)
-            ),
-            DateTime(
-                2022, 11, 25, 11, 34, 56, 789123456, FixedOffset(60 * -17)
-            ),
-        ),
-        repeat=2,
+            repeat=2,
+        )
     ),
 )
 def test_hashed_equality(dt1, dt2) -> None:
@@ -1058,7 +1064,7 @@ def test_hashed_equality(dt1, dt2) -> None:
 
 @pytest.mark.parametrize(
     ("dt1", "dt2"),
-    (
+    tuple(
         itertools.product(
             (
                 datetime(2022, 11, 25, 12, 34, 56, 789123),
@@ -1085,13 +1091,15 @@ def test_comparison_with_only_one_naive_fails(dt1, dt2, tz, op) -> None:
 
 @pytest.mark.parametrize(
     ("dt1", "dt2"),
-    itertools.product(
-        (
-            datetime(2022, 11, 25, 12, 34, 56, 789123),
-            DateTime(2022, 11, 25, 12, 34, 56, 789123000),
-            DateTime(2022, 11, 25, 12, 34, 56, 789123001),
-        ),
-        repeat=2,
+    tuple(
+        itertools.product(
+            (
+                datetime(2022, 11, 25, 12, 34, 56, 789123),
+                DateTime(2022, 11, 25, 12, 34, 56, 789123000),
+                DateTime(2022, 11, 25, 12, 34, 56, 789123001),
+            ),
+            repeat=2,
+        )
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/unit/common/time/test_time.py
+++ b/tests/unit/common/time/test_time.py
@@ -389,24 +389,26 @@ class TestTime:
 
     @pytest.mark.parametrize(
         ("t1", "t2"),
-        itertools.product(
-            (
-                time(12, 34, 56, 789123),
-                Time(12, 34, 56, 789123000),
-                time(12, 34, 56, 789123, FixedOffset(0)),
-                Time(12, 34, 56, 789123456, FixedOffset(0)),
-                time(12, 35, 56, 789123, FixedOffset(1)),
-                Time(12, 35, 56, 789123456, FixedOffset(1)),
-                time(12, 34, 56, 789123, FixedOffset(-1)),
-                Time(12, 34, 56, 789123456, FixedOffset(-1)),
-                time(12, 34, 56, 789123, FixedOffset(60 * -16)),
-                Time(12, 34, 56, 789123000, FixedOffset(60 * -16)),
-                time(11, 34, 56, 789123, FixedOffset(60 * -17)),
-                Time(11, 34, 56, 789123000, FixedOffset(60 * -17)),
-                Time(12, 34, 56, 789123456, FixedOffset(60 * -16)),
-                Time(11, 34, 56, 789123456, FixedOffset(60 * -17)),
-            ),
-            repeat=2,
+        tuple(
+            itertools.product(
+                (
+                    time(12, 34, 56, 789123),
+                    Time(12, 34, 56, 789123000),
+                    time(12, 34, 56, 789123, FixedOffset(0)),
+                    Time(12, 34, 56, 789123456, FixedOffset(0)),
+                    time(12, 35, 56, 789123, FixedOffset(1)),
+                    Time(12, 35, 56, 789123456, FixedOffset(1)),
+                    time(12, 34, 56, 789123, FixedOffset(-1)),
+                    Time(12, 34, 56, 789123456, FixedOffset(-1)),
+                    time(12, 34, 56, 789123, FixedOffset(60 * -16)),
+                    Time(12, 34, 56, 789123000, FixedOffset(60 * -16)),
+                    time(11, 34, 56, 789123, FixedOffset(60 * -17)),
+                    Time(11, 34, 56, 789123000, FixedOffset(60 * -17)),
+                    Time(12, 34, 56, 789123456, FixedOffset(60 * -16)),
+                    Time(11, 34, 56, 789123456, FixedOffset(60 * -17)),
+                ),
+                repeat=2,
+            )
         ),
     )
     def test_hashed_equality(self, t1, t2) -> None:
@@ -427,7 +429,7 @@ class TestTime:
 
     @pytest.mark.parametrize(
         ("t1", "t2"),
-        (
+        tuple(
             itertools.product(
                 (
                     time(12, 34, 56, 789123),
@@ -465,13 +467,15 @@ class TestTime:
 
     @pytest.mark.parametrize(
         ("t1", "t2"),
-        itertools.product(
-            (
-                time(12, 34, 56, 789123),
-                Time(12, 34, 56, 789123000),
-                Time(12, 34, 56, 789123001),
-            ),
-            repeat=2,
+        tuple(
+            itertools.product(
+                (
+                    time(12, 34, 56, 789123),
+                    Time(12, 34, 56, 789123000),
+                    Time(12, 34, 56, 789123001),
+                ),
+                repeat=2,
+            )
         ),
     )
     @pytest.mark.parametrize(

--- a/tests/unit/sync/io/test_class_bolt3.py
+++ b/tests/unit/sync/io/test_class_bolt3.py
@@ -245,13 +245,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -443,13 +445,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -521,18 +525,24 @@ def raises_if_db(db):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x0.py
+++ b/tests/unit/sync/io/test_class_bolt4x0.py
@@ -350,13 +350,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -548,13 +550,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -612,18 +616,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x1.py
+++ b/tests/unit/sync/io/test_class_bolt4x1.py
@@ -372,13 +372,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -570,13 +572,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -634,18 +638,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x2.py
+++ b/tests/unit/sync/io/test_class_bolt4x2.py
@@ -372,13 +372,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -570,13 +572,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -634,18 +638,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x3.py
+++ b/tests/unit/sync/io/test_class_bolt4x3.py
@@ -401,13 +401,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -599,13 +601,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -663,18 +667,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt4x4.py
+++ b/tests/unit/sync/io/test_class_bolt4x4.py
@@ -425,13 +425,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -623,18 +625,24 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x0.py
+++ b/tests/unit/sync/io/test_class_bolt5x0.py
@@ -425,13 +425,15 @@ def test_re_auth_noop(auth, fake_socket, mocker):
 
 @pytest.mark.parametrize(
     ("auth1", "auth2"),
-    itertools.permutations(
-        (
-            None,
-            neo4j.Auth("scheme", "principal", "credentials", "realm"),
-            ("user", "password"),
-        ),
-        2,
+    tuple(
+        itertools.permutations(
+            (
+                None,
+                neo4j.Auth("scheme", "principal", "credentials", "realm"),
+                ("user", "password"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -623,13 +625,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -687,18 +691,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x1.py
+++ b/tests/unit/sync/io/test_class_bolt5x1.py
@@ -676,13 +676,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -741,18 +743,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x2.py
+++ b/tests/unit/sync/io/test_class_bolt5x2.py
@@ -515,11 +515,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -713,13 +717,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -778,18 +784,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x3.py
+++ b/tests/unit/sync/io/test_class_bolt5x3.py
@@ -402,11 +402,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -600,13 +604,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -665,18 +671,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x4.py
+++ b/tests/unit/sync/io/test_class_bolt5x4.py
@@ -407,11 +407,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -605,13 +609,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -670,18 +676,24 @@ def test_tracks_last_database(fake_socket_pair, actions):
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x5.py
+++ b/tests/unit/sync/io/test_class_bolt5x5.py
@@ -407,11 +407,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -605,13 +609,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -677,20 +683,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x6.py
+++ b/tests/unit/sync/io/test_class_bolt5x6.py
@@ -407,11 +407,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -605,13 +609,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -677,20 +683,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))

--- a/tests/unit/sync/io/test_class_bolt5x7.py
+++ b/tests/unit/sync/io/test_class_bolt5x7.py
@@ -408,11 +408,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -606,13 +610,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -678,20 +684,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))
@@ -765,21 +781,31 @@ def test_enriches_statuses(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        lower_limit=1,
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            lower_limit=1,
+            upper_limit=3,
+        )
     ),
 )
 @mark_sync_test

--- a/tests/unit/sync/io/test_class_bolt5x8.py
+++ b/tests/unit/sync/io/test_class_bolt5x8.py
@@ -408,11 +408,15 @@ def _assert_notifications_in_extra(extra, expected):
 )
 @pytest.mark.parametrize(
     ("cls_min_sev", "method_min_sev"),
-    itertools.product((None, "WARNING", "OFF"), repeat=2),
+    tuple(itertools.product((None, "WARNING", "OFF"), repeat=2)),
 )
 @pytest.mark.parametrize(
     ("cls_dis_clss", "method_dis_clss"),
-    itertools.product((None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2),
+    tuple(
+        itertools.product(
+            (None, [], ["HINT"], ["HINT", "DEPRECATION"]), repeat=2
+        )
+    ),
 )
 @mark_sync_test
 def test_supports_notification_filters(
@@ -606,13 +610,15 @@ def test_tx_timeout(
 
 @pytest.mark.parametrize(
     "actions",
-    itertools.combinations_with_replacement(
-        itertools.product(
-            ("run", "begin", "begin_run"),
-            ("reset", "commit", "rollback"),
-            (None, "some_db", "another_db"),
-        ),
-        2,
+    tuple(
+        itertools.combinations_with_replacement(
+            itertools.product(
+                ("run", "begin", "begin_run"),
+                ("reset", "commit", "rollback"),
+                (None, "some_db", "another_db"),
+            ),
+            2,
+        )
     ),
 )
 @mark_sync_test
@@ -678,20 +684,30 @@ DEFAULT_DIAG_REC_PAIRS = (
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            upper_limit=3,
+        )
     ),
 )
 @pytest.mark.parametrize("method", ("pull", "discard"))
@@ -765,21 +781,31 @@ def test_enriches_statuses(
 
 @pytest.mark.parametrize(
     "sent_diag_records",
-    powerset(
-        (
-            ...,
-            None,
-            {},
-            [],
-            "1",
-            1,
-            {"OPERATION_CODE": "0"},
-            {"OPERATION": "", "OPERATION_CODE": "0", "CURRENT_SCHEMA": "/"},
-            {"OPERATION": "Foo", "OPERATION_CODE": 1, "CURRENT_SCHEMA": False},
-            {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
-        ),
-        lower_limit=1,
-        upper_limit=3,
+    tuple(
+        powerset(
+            (
+                ...,
+                None,
+                {},
+                [],
+                "1",
+                1,
+                {"OPERATION_CODE": "0"},
+                {
+                    "OPERATION": "",
+                    "OPERATION_CODE": "0",
+                    "CURRENT_SCHEMA": "/",
+                },
+                {
+                    "OPERATION": "Foo",
+                    "OPERATION_CODE": 1,
+                    "CURRENT_SCHEMA": False,
+                },
+                {"OPERATION": "", "OPERATION_CODE": "0", "bar": "baz"},
+            ),
+            lower_limit=1,
+            upper_limit=3,
+        )
     ),
 )
 @mark_sync_test

--- a/tests/unit/sync/io/test_neo4j_pool.py
+++ b/tests/unit/sync/io/test_neo4j_pool.py
@@ -658,9 +658,9 @@ def test_discovery_is_retried(custom_routing_opener, error):
 
 @pytest.mark.parametrize(
     "error",
-    map(
-        lambda args: Neo4jError._hydrate_neo4j(code=args[0], message=args[1]),
-        (
+    tuple(
+        Neo4jError._hydrate_neo4j(code=code, message=message)
+        for code, message in (
             ("Neo.ClientError.Database.DatabaseNotFound", "message"),
             ("Neo.ClientError.Transaction.InvalidBookmark", "message"),
             ("Neo.ClientError.Transaction.InvalidBookmarkMixture", "message"),
@@ -673,7 +673,7 @@ def test_discovery_is_retried(custom_routing_opener, error):
             ("Neo.ClientError.Security.TokenExpired", "message"),
             ("Neo.ClientError.Security.Unauthorized", "message"),
             ("Neo.ClientError.Security.MadeUpError", "message"),
-        ),
+        )
     ),
 )
 @mark_sync_test
@@ -707,7 +707,7 @@ def test_fast_failing_discovery(custom_routing_opener, error):
 
 @pytest.mark.parametrize(
     ("error", "marks_unauthenticated", "fetches_new"),
-    (
+    tuple(
         (Neo4jError._hydrate_neo4j(code=args[0], message="message"), *args[1:])
         for args in (
             ("Neo.ClientError.Database.DatabaseNotFound", False, False),

--- a/tests/unit/sync/test_auth_management.py
+++ b/tests/unit/sync/test_auth_management.py
@@ -116,7 +116,7 @@ def test_static_manager(
 
 @mark_sync_test
 @pytest.mark.parametrize(
-    ("auth1", "auth2"), list(itertools.product(SAMPLE_AUTHS, repeat=2))
+    ("auth1", "auth2"), tuple(itertools.product(SAMPLE_AUTHS, repeat=2))
 )
 @pytest.mark.parametrize("error", SAMPLE_ERRORS)
 def test_basic_manager_manual_expiry(
@@ -141,7 +141,7 @@ def test_basic_manager_manual_expiry(
 
 @mark_sync_test
 @pytest.mark.parametrize(
-    ("auth1", "auth2"), itertools.product(SAMPLE_AUTHS, repeat=2)
+    ("auth1", "auth2"), tuple(itertools.product(SAMPLE_AUTHS, repeat=2))
 )
 @pytest.mark.parametrize("error", SAMPLE_ERRORS)
 @pytest.mark.parametrize("expires_at", (None, 0.001, 1, 1000.0))
@@ -170,7 +170,7 @@ def test_bearer_manager_manual_expiry(
 
 @mark_sync_test
 @pytest.mark.parametrize(
-    ("auth1", "auth2"), itertools.product(SAMPLE_AUTHS, repeat=2)
+    ("auth1", "auth2"), tuple(itertools.product(SAMPLE_AUTHS, repeat=2))
 )
 @pytest.mark.parametrize("expires_at", (None, -1, 1.0, 1, 1000.0))
 def test_bearer_manager_time_expiry(

--- a/tests/unit/sync/work/test_session.py
+++ b/tests/unit/sync/work/test_session.py
@@ -710,7 +710,7 @@ def test_session_custom_api_telemetry(fake_pool, mode):
 
 @pytest.mark.parametrize(
     ("db", "pool_ssr", "pool_routing", "expect_cache_usage"),
-    (
+    tuple(
         (db, ssr, routing, ssr and routing and not db)
         for ssr in (True, False)
         for routing in (True, False)
@@ -790,7 +790,7 @@ def test_uses_home_db_cache_when_expected(
 
 @pytest.mark.parametrize(
     ("db", "pool_ssr", "pool_routing", "expect_cache_usage"),
-    (
+    tuple(
         (db, ssr, routing, ssr and routing and not db)
         for ssr in (True, False)
         for routing in (True, False)

--- a/tests/unit/sync/work/test_transaction.py
+++ b/tests/unit/sync/work/test_transaction.py
@@ -16,12 +16,12 @@
 
 from __future__ import annotations
 
+import typing as t
 from unittest.mock import MagicMock
 
 import pytest
 
 from neo4j import (
-    _typing as t,
     NotificationMinimumSeverity,
     Query,
     Transaction,

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,9 @@ envlist = py{37,38,39,310,311,312,313}-{unit,integration,performance}
 requires = virtualenv<20.22.0
 
 [testenv]
-passenv = TEST_*
+passenv = TEST_*, GITHUB_ACTIONS
 deps = -r requirements-dev.txt
+
 setenv =
     COVERAGE_FILE={envdir}/.coverage
     TEST_SUITE_NAME={envname}


### PR DESCRIPTION
* Tests: use eager iterators

`pytest` deprecated using generators (lazy) for test parametrization. Instead a collection (eager) such as tuple, or list is expected.

* Fix numpy deprecation: timedelta64 without explicit unit

* win: fix socket resource exhaustion

This is a combined back port of:
 * https://github.com/neo4j/neo4j-python-driver/pull/1317
 * https://github.com/neo4j/neo4j-python-driver/pull/1320

Amends:
 * https://github.com/neo4j/neo4j-python-driver/pull/1330 (introduced broken typing import in tests)
 
 Part of: DRIVERS-526