### PR TITLE
Fix BoltSocketBase.getpeercert pass-through

### DIFF
--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -400,7 +400,7 @@ class AsyncBoltSocketBase(abc.ABC):
 class BoltSocketBase(abc.ABC):
     Bolt: t.Final[type[Bolt]] = None  # type: ignore[assignment]
 
-    def __init__(self, socket_: socket):
+    def __init__(self, socket_: socket | SSLSocket):
         self._socket = socket_
         self._read_deadline = None
         self._write_deadline = None
@@ -416,14 +416,18 @@ class BoltSocketBase(abc.ABC):
         self.__socket = socket_
         self.getsockname = socket_.getsockname
         self.getpeername = socket_.getpeername
-        if hasattr(socket, "getpeercert"):
-            self.getpeercert = t.cast(SSLSocket, socket_).getpeercert
+        if hasattr(socket_, "getpeercert"):
+            self.getpeercert = socket_.getpeercert
         elif "getpeercert" in self.__dict__:
             del self.__dict__["getpeercert"]
 
-    getsockname: t.Callable = None  # type: ignore
-    getpeername: t.Callable = None  # type: ignore
-    getpeercert: t.Callable = None  # type: ignore
+    def __unimplemented(*args, **kwargs):
+        raise NotImplementedError
+
+    getsockname: t.Callable = __unimplemented
+    getpeername: t.Callable = __unimplemented
+    # only exists if the wrapped socket is an SSLSocket
+    getpeercert: t.Callable
 
     def _wait_for_read(self, func, *args, **kwargs):
         return self._wait_for_io(

--- a/src/neo4j/_async_compat/network/_bolt_socket.py
+++ b/src/neo4j/_async_compat/network/_bolt_socket.py
@@ -414,18 +414,25 @@ class BoltSocketBase(abc.ABC):
     @_socket.setter
     def _socket(self, socket_: socket | SSLSocket):
         self.__socket = socket_
-        self.getsockname = socket_.getsockname
-        self.getpeername = socket_.getpeername
+        self.getsockname = socket_.getsockname  # type: ignore[method-assign]
+        self.getpeername = socket_.getpeername  # type: ignore[method-assign]
         if hasattr(socket_, "getpeercert"):
-            self.getpeercert = socket_.getpeercert
+            self.getpeercert = socket_.getpeercert  # type: ignore[method-assign]
         elif "getpeercert" in self.__dict__:
             del self.__dict__["getpeercert"]
 
-    def __unimplemented(*args, **kwargs):
-        raise NotImplementedError
+    def getsockname(self, *args, **kwargs) -> t.Any:
+        raise NotImplementedError(
+            "Programming error in BoltSocketBase: should forward getsockname "
+            "to wrapped socket"
+        )
 
-    getsockname: t.Callable = __unimplemented
-    getpeername: t.Callable = __unimplemented
+    def getpeername(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Programming error in BoltSocketBase: should forward getpeername "
+            "to wrapped socket"
+        )
+
     # only exists if the wrapped socket is an SSLSocket
     getpeercert: t.Callable
 

--- a/tests/unit/mixed/async_compat/test_network.py
+++ b/tests/unit/mixed/async_compat/test_network.py
@@ -516,3 +516,55 @@ async def test_bolt_ssl_timeout(
         ssl_context_mock.wrap_socket.assert_called_once()
 
         assert last_ssl_timeout == expected_timeout
+
+
+@pytest.mark.parametrize(
+    "property", ("getsockname", "getpeername", "getpeercert")
+)
+@pytest.mark.parametrize("is_ssl", [False, True])
+def test_bolt_socket_forwards_to_tcp_socket(property: str, is_ssl: bool):
+    class FakeSocket:
+        def __init__(self, with_ssl: bool) -> None:
+            self.getsockname = object()
+            self.getpeername = object()
+            if with_ssl:
+                self.getpeercert = object()
+
+    sock: socket.socket | SSLSocket = t.cast(t.Any, FakeSocket(is_ssl))
+    bolt_sock = BoltSocket(sock)
+
+    if not is_ssl and property == "getpeercert":
+        assert not hasattr(bolt_sock, property)
+        with pytest.raises(AttributeError):
+            getattr(bolt_sock, property)
+    else:
+        assert getattr(bolt_sock, property) is getattr(sock, property)
+
+
+@pytest.mark.parametrize(
+    "property", ("getsockname", "getpeername", "getpeercert")
+)
+@pytest.mark.parametrize("ssl1", [False, True])
+@pytest.mark.parametrize("ssl2", [False, True])
+def test_bolt_socket_setter_forwards_to_tcp_socket(
+    property: str, ssl1: bool, ssl2: bool
+):
+    class FakeSocket:
+        def __init__(self, with_ssl: bool) -> None:
+            self.getsockname = object()
+            self.getpeername = object()
+            if with_ssl:
+                self.getpeercert = object()
+
+    sock1: socket.socket | SSLSocket = t.cast(t.Any, FakeSocket(ssl1))
+    bolt_sock = BoltSocket(sock1)
+
+    sock2: socket.socket | SSLSocket = t.cast(t.Any, FakeSocket(ssl2))
+    bolt_sock._socket = sock2
+
+    if not ssl2 and property == "getpeercert":
+        assert not hasattr(bolt_sock, property)
+        with pytest.raises(AttributeError):
+            getattr(bolt_sock, property)
+    else:
+        assert getattr(bolt_sock, property) is getattr(sock2, property)


### PR DESCRIPTION
`(Async)BoltSocketBase.getpeercert` is not used throughout the code-base. Therefore does this bug and its fix have no direct impact. It's future-proofing the code-base.

The `hasattr` was introspecting the `socket.socket` class instead of the `socket_` object. A silly typo, really.