### PR TITLE
Clean up dead and broken code

### DIFF
--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -432,11 +432,6 @@ class AsyncBolt:
 
     @property
     @abc.abstractmethod
-    def encrypted(self):
-        pass
-
-    @property
-    @abc.abstractmethod
     def der_encoded_server_certificate(self):
         pass
 

--- a/src/neo4j/_async/io/_bolt3.py
+++ b/src/neo4j/_async/io/_bolt3.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from enum import Enum
 from logging import getLogger
-from ssl import SSLSocket
 
 from ... import _typing as t
 from ..._exceptions import BoltProtocolError
@@ -194,10 +193,6 @@ class AsyncBolt3(AsyncBolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == BoltStates.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):

--- a/src/neo4j/_async/io/_bolt4.py
+++ b/src/neo4j/_async/io/_bolt4.py
@@ -15,7 +15,6 @@
 
 
 from logging import getLogger
-from ssl import SSLSocket
 
 from ..._api import TelemetryAPI
 from ..._exceptions import BoltProtocolError
@@ -114,10 +113,6 @@ class AsyncBolt4x0(AsyncBolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == BoltStates.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -16,7 +16,6 @@
 
 from enum import Enum
 from logging import getLogger
-from ssl import SSLSocket
 
 from ... import _typing as t
 from ..._api import TelemetryAPI
@@ -116,10 +115,6 @@ class AsyncBolt5x0(AsyncBolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == self.bolt_states.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):

--- a/src/neo4j/_async/io/_bolt6.py
+++ b/src/neo4j/_async/io/_bolt6.py
@@ -15,7 +15,6 @@
 
 
 from logging import getLogger
-from ssl import SSLSocket
 
 from ... import _typing as t
 from ..._api import TelemetryAPI
@@ -122,10 +121,6 @@ class AsyncBolt6x0(AsyncBolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == self.bolt_states.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -432,11 +432,6 @@ class Bolt:
 
     @property
     @abc.abstractmethod
-    def encrypted(self):
-        pass
-
-    @property
-    @abc.abstractmethod
     def der_encoded_server_certificate(self):
         pass
 

--- a/src/neo4j/_sync/io/_bolt3.py
+++ b/src/neo4j/_sync/io/_bolt3.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from enum import Enum
 from logging import getLogger
-from ssl import SSLSocket
 
 from ... import _typing as t
 from ..._exceptions import BoltProtocolError
@@ -194,10 +193,6 @@ class Bolt3(Bolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == BoltStates.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):

--- a/src/neo4j/_sync/io/_bolt4.py
+++ b/src/neo4j/_sync/io/_bolt4.py
@@ -15,7 +15,6 @@
 
 
 from logging import getLogger
-from ssl import SSLSocket
 
 from ..._api import TelemetryAPI
 from ..._exceptions import BoltProtocolError
@@ -114,10 +113,6 @@ class Bolt4x0(Bolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == BoltStates.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):

--- a/src/neo4j/_sync/io/_bolt5.py
+++ b/src/neo4j/_sync/io/_bolt5.py
@@ -16,7 +16,6 @@
 
 from enum import Enum
 from logging import getLogger
-from ssl import SSLSocket
 
 from ... import _typing as t
 from ..._api import TelemetryAPI
@@ -116,10 +115,6 @@ class Bolt5x0(Bolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == self.bolt_states.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):

--- a/src/neo4j/_sync/io/_bolt6.py
+++ b/src/neo4j/_sync/io/_bolt6.py
@@ -15,7 +15,6 @@
 
 
 from logging import getLogger
-from ssl import SSLSocket
 
 from ... import _typing as t
 from ..._api import TelemetryAPI
@@ -122,10 +121,6 @@ class Bolt6x0(Bolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == self.bolt_states.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):


### PR DESCRIPTION
The code is broken because
 * in async, `AsyncBolt.socket` is of type `AsyncBoltSocket` wrapping `asyncio` constructs
 * in sync, `Bolt.socket` is of type `BoltSocket` wrapping `socket.socket` or `ssl.SSLSocket`

Note that `(Async)Bolt.socket` is *never* of type `ssl.SSLSocket` directly. Therefore this check is useless. The code could be fixed, but it's never called. Therefore removing it is the best option.