### PR TITLE
[5.28] Clean up dead and broken code

### DIFF
--- a/src/neo4j/_async/io/_bolt.py
+++ b/src/neo4j/_async/io/_bolt.py
@@ -442,11 +442,6 @@ class AsyncBolt:
 
     @property
     @abc.abstractmethod
-    def encrypted(self):
-        pass
-
-    @property
-    @abc.abstractmethod
     def der_encoded_server_certificate(self):
         pass
 

--- a/src/neo4j/_async/io/_bolt3.py
+++ b/src/neo4j/_async/io/_bolt3.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import typing as t
 from enum import Enum
 from logging import getLogger
-from ssl import SSLSocket
 
 from ..._exceptions import BoltProtocolError
 from ...api import (
@@ -197,10 +196,6 @@ class AsyncBolt3(AsyncBolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == BoltStates.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):

--- a/src/neo4j/_async/io/_bolt4.py
+++ b/src/neo4j/_async/io/_bolt4.py
@@ -15,7 +15,6 @@
 
 
 from logging import getLogger
-from ssl import SSLSocket
 
 from ..._api import TelemetryAPI
 from ..._exceptions import BoltProtocolError
@@ -115,10 +114,6 @@ class AsyncBolt4x0(AsyncBolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == BoltStates.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):

--- a/src/neo4j/_async/io/_bolt5.py
+++ b/src/neo4j/_async/io/_bolt5.py
@@ -17,7 +17,6 @@
 import typing as t
 from enum import Enum
 from logging import getLogger
-from ssl import SSLSocket
 
 from ..._api import TelemetryAPI
 from ..._async_compat.util import AsyncUtil
@@ -119,10 +118,6 @@ class AsyncBolt5x0(AsyncBolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == self.bolt_states.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):

--- a/src/neo4j/_sync/io/_bolt.py
+++ b/src/neo4j/_sync/io/_bolt.py
@@ -442,11 +442,6 @@ class Bolt:
 
     @property
     @abc.abstractmethod
-    def encrypted(self):
-        pass
-
-    @property
-    @abc.abstractmethod
     def der_encoded_server_certificate(self):
         pass
 

--- a/src/neo4j/_sync/io/_bolt3.py
+++ b/src/neo4j/_sync/io/_bolt3.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import typing as t
 from enum import Enum
 from logging import getLogger
-from ssl import SSLSocket
 
 from ..._exceptions import BoltProtocolError
 from ...api import (
@@ -197,10 +196,6 @@ class Bolt3(Bolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == BoltStates.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):

--- a/src/neo4j/_sync/io/_bolt4.py
+++ b/src/neo4j/_sync/io/_bolt4.py
@@ -15,7 +15,6 @@
 
 
 from logging import getLogger
-from ssl import SSLSocket
 
 from ..._api import TelemetryAPI
 from ..._exceptions import BoltProtocolError
@@ -115,10 +114,6 @@ class Bolt4x0(Bolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == BoltStates.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):

--- a/src/neo4j/_sync/io/_bolt5.py
+++ b/src/neo4j/_sync/io/_bolt5.py
@@ -17,7 +17,6 @@
 import typing as t
 from enum import Enum
 from logging import getLogger
-from ssl import SSLSocket
 
 from ..._api import TelemetryAPI
 from ..._async_compat.util import Util
@@ -119,10 +118,6 @@ class Bolt5x0(Bolt):
         if self.responses:
             return self.responses[-1] and self.responses[-1].message == "reset"
         return self._server_state_manager.state == self.bolt_states.READY
-
-    @property
-    def encrypted(self):
-        return isinstance(self.socket, SSLSocket)
 
     @property
     def der_encoded_server_certificate(self):


### PR DESCRIPTION
The code is broken because
 * in async, `AsyncBolt.socket` is of type `AsyncBoltSocket` wrapping `asyncio` constructs
 * in sync, `Bolt.socket` is of type `BoltSocket` wrapping `socket.socket` or `ssl.SSLSocket`

Note that `(Async)Bolt.socket` is *never* of type `ssl.SSLSocket` directly. Therefore this check is useless. The code could be fixed, but it's never called. Therefore removing it is the best option.

Back port of: https://github.com/neo4j/neo4j-python-driver/pull/1335