### PR TITLE
[5.28] Fix application error desyncing auto-commit result

### DIFF
--- a/src/neo4j/_async/work/session.py
+++ b/src/neo4j/_async/work/session.py
@@ -100,9 +100,6 @@ class AsyncSession(AsyncWorkspace):
     # The current auto-commit transaction result, if any.
     _auto_result = None
 
-    # The state this session is in.
-    _state_failed = False
-
     _config: SessionConfig
     _bookmark_manager: Bookmarks | None
     _pipelined_begin: ContextBool
@@ -121,12 +118,12 @@ class AsyncSession(AsyncWorkspace):
         return self
 
     async def __aexit__(self, exception_type, exception_value, traceback):
-        if exception_type:
-            if issubclass(exception_type, asyncio.CancelledError):
-                self._handle_cancellation(message="__aexit__")
-                self._closed = True
-                return
-            self._state_failed = True
+        if exception_type and issubclass(
+            exception_type, asyncio.CancelledError
+        ):
+            self._handle_cancellation(message="__aexit__")
+            self._closed = True
+            return
         await self.close()
 
     async def _connect(self, access_mode, **acquire_kwargs):
@@ -203,14 +200,21 @@ class AsyncSession(AsyncWorkspace):
         if self._closed:
             return
         if self._connection:
-            if self._auto_result and self._state_failed is False:
+            if self._auto_result:
                 try:
+                    # The user didn't consume the auto-commit result.
+                    # Therefore, we try to consume it on a best-effort basis
+                    # before closing the parent session.
                     await self._auto_result.consume()
-                    await self._update_bookmark(self._auto_result._bookmark)
-                except Exception:
-                    # TODO: Investigate potential non graceful close states
-                    self._auto_result = None
-                    self._state_failed = True
+                except (Neo4jError, DriverError) as e:
+                    # Consume failed, we'll swallow the error.
+                    # Best practice is to consume the result before closing the
+                    # session.
+                    log.warning(
+                        "Failed to consume outstanding auto-commit "
+                        "transaction result before closing session: %s",
+                        e,
+                    )
 
             if self._transaction:
                 if self._transaction._closed() is False:
@@ -223,18 +227,16 @@ class AsyncSession(AsyncWorkspace):
                     await self._connection.send_all()
                     await self._connection.fetch_all()
                     # TODO: Investigate potential non graceful close states
-            except Neo4jError:
-                pass
-            except TransactionError:
-                pass
-            except ServiceUnavailable:
-                pass
-            except SessionExpired:
+            except (
+                Neo4jError,
+                TransactionError,
+                ServiceUnavailable,
+                SessionExpired,
+            ):
                 pass
             finally:
                 await self._disconnect()
 
-            self._state_failed = False
         self._closed = True
 
     if AsyncUtil.is_async_code:

--- a/src/neo4j/_sync/work/session.py
+++ b/src/neo4j/_sync/work/session.py
@@ -100,9 +100,6 @@ class Session(Workspace):
     # The current auto-commit transaction result, if any.
     _auto_result = None
 
-    # The state this session is in.
-    _state_failed = False
-
     _config: SessionConfig
     _bookmark_manager: Bookmarks | None
     _pipelined_begin: ContextBool
@@ -121,12 +118,12 @@ class Session(Workspace):
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        if exception_type:
-            if issubclass(exception_type, asyncio.CancelledError):
-                self._handle_cancellation(message="__exit__")
-                self._closed = True
-                return
-            self._state_failed = True
+        if exception_type and issubclass(
+            exception_type, asyncio.CancelledError
+        ):
+            self._handle_cancellation(message="__exit__")
+            self._closed = True
+            return
         self.close()
 
     def _connect(self, access_mode, **acquire_kwargs):
@@ -203,14 +200,21 @@ class Session(Workspace):
         if self._closed:
             return
         if self._connection:
-            if self._auto_result and self._state_failed is False:
+            if self._auto_result:
                 try:
+                    # The user didn't consume the auto-commit result.
+                    # Therefore, we try to consume it on a best-effort basis
+                    # before closing the parent session.
                     self._auto_result.consume()
-                    self._update_bookmark(self._auto_result._bookmark)
-                except Exception:
-                    # TODO: Investigate potential non graceful close states
-                    self._auto_result = None
-                    self._state_failed = True
+                except (Neo4jError, DriverError) as e:
+                    # Consume failed, we'll swallow the error.
+                    # Best practice is to consume the result before closing the
+                    # session.
+                    log.warning(
+                        "Failed to consume outstanding auto-commit "
+                        "transaction result before closing session: %s",
+                        e,
+                    )
 
             if self._transaction:
                 if self._transaction._closed() is False:
@@ -223,18 +227,16 @@ class Session(Workspace):
                     self._connection.send_all()
                     self._connection.fetch_all()
                     # TODO: Investigate potential non graceful close states
-            except Neo4jError:
-                pass
-            except TransactionError:
-                pass
-            except ServiceUnavailable:
-                pass
-            except SessionExpired:
+            except (
+                Neo4jError,
+                TransactionError,
+                ServiceUnavailable,
+                SessionExpired,
+            ):
                 pass
             finally:
                 self._disconnect()
 
-            self._state_failed = False
         self._closed = True
 
     if Util.is_async_code:

--- a/tests/unit/async_/work/test_session.py
+++ b/tests/unit/async_/work/test_session.py
@@ -58,6 +58,10 @@ def assert_warns_tx_func_deprecation(tx_func_name):
         yield
 
 
+class ApplicationError(RuntimeError):
+    pass
+
+
 @mark_async_test
 async def test_session_context_calls_close(mocker):
     s = AsyncSession(None, SessionConfig())
@@ -939,3 +943,47 @@ async def test_work_connections_are_prepared_connection(
         async_fake_pool.acquire.assert_awaited_once()
         unprepared = async_fake_pool.acquire.call_args.kwargs.get("unprepared")
         assert unprepared is False or unprepared is None
+
+
+@mark_async_test
+async def test_auto_commit_is_consumed_on_application_error(
+    async_fake_pool,
+    async_scripted_connection_generator,
+) -> None:
+    bookmark = "res:bm1"
+    conn = async_scripted_connection_generator()
+    conn.set_script(
+        (
+            ("run", {"on_success": ({"fields": ["n"]},), "on_summary": None}),
+            (
+                "pull",
+                {
+                    "on_records": ([[1]],),
+                    "on_success": ({"has_more": True},),
+                    "on_summary": None,
+                },
+            ),
+            (
+                "discard",
+                {
+                    "on_success": ({"bookmark": bookmark},),
+                    "on_summary": None,
+                },
+            ),
+        )
+    )
+    async_fake_pool.buffered_connection_mocks.append(conn)
+    async_fake_pool.pool_config.telemetry_disabled = True
+
+    with pytest.raises(ApplicationError):
+        async with AsyncSession(async_fake_pool, SessionConfig()) as session:
+            res = await session.run("RETURN 1")
+            raise ApplicationError("boom")
+
+    assert not res._attached
+    assert session._auto_result is None
+    assert res._bookmark == bookmark
+    assert set(session._bookmarks) == {bookmark}
+
+    received_bookmarks = await session.last_bookmarks()
+    assert received_bookmarks.raw_values == {bookmark}

--- a/tests/unit/sync/work/test_session.py
+++ b/tests/unit/sync/work/test_session.py
@@ -58,6 +58,10 @@ def assert_warns_tx_func_deprecation(tx_func_name):
         yield
 
 
+class ApplicationError(RuntimeError):
+    pass
+
+
 @mark_sync_test
 def test_session_context_calls_close(mocker):
     s = Session(None, SessionConfig())
@@ -939,3 +943,47 @@ def test_work_connections_are_prepared_connection(
         fake_pool.acquire.assert_called_once()
         unprepared = fake_pool.acquire.call_args.kwargs.get("unprepared")
         assert unprepared is False or unprepared is None
+
+
+@mark_sync_test
+def test_auto_commit_is_consumed_on_application_error(
+    fake_pool,
+    scripted_connection_generator,
+) -> None:
+    bookmark = "res:bm1"
+    conn = scripted_connection_generator()
+    conn.set_script(
+        (
+            ("run", {"on_success": ({"fields": ["n"]},), "on_summary": None}),
+            (
+                "pull",
+                {
+                    "on_records": ([[1]],),
+                    "on_success": ({"has_more": True},),
+                    "on_summary": None,
+                },
+            ),
+            (
+                "discard",
+                {
+                    "on_success": ({"bookmark": bookmark},),
+                    "on_summary": None,
+                },
+            ),
+        )
+    )
+    fake_pool.buffered_connection_mocks.append(conn)
+    fake_pool.pool_config.telemetry_disabled = True
+
+    with pytest.raises(ApplicationError):
+        with Session(fake_pool, SessionConfig()) as session:
+            res = session.run("RETURN 1")
+            raise ApplicationError("boom")
+
+    assert not res._attached
+    assert session._auto_result is None
+    assert res._bookmark == bookmark
+    assert set(session._bookmarks) == {bookmark}
+
+    received_bookmarks = session.last_bookmarks()
+    assert received_bookmarks.raw_values == {bookmark}


### PR DESCRIPTION
Raising an application error inside a `with driver.session() as s:` block that has an on-going auto-commit transaction, i.e., `res = s.run(...)` has been called but `res` has not yet been consumed will lead to the session returning its backing connection to the pool (where it can be picked up by other sessions) without properly finalizing the auto-commit transaction. `res` then holds a reference to (and potentially uses) a connection that is no longer bound to `res`'s parent session. This can lead to all sorts of misbehavior (from data races casing protocol errors all the way to reading records of another query).

Reproducer:

```python
from __future__ import annotations

from neo4j import GraphDatabase, Result
from neo4j.debug import watch

watch("neo4j")

URL = "bolt://localhost:7687"
AUTH = ("neo4j", "pass")
DB = "neo4j"

class MyError(RuntimeError):
    pass

def inspect_records(result: neo4j.Result, n: int, stream_name: str):
    print(f"\ninspecting stream {stream_name}: fetching {n} records")
    records = [record["res"] for record in result.fetch(n)]
    print(f"got {len(records)} records")
    for record in records:
        print(repr(record))
        assert isinstance(record, str) and record.startswith(f"{stream_name}-")

def main():
    range_top = 10
    query = (
        'UNWIND range(1, $upper) AS i '
        'RETURN "res" + $n + "-" + apoc.text.lpad(toString(i), $pad, "0") '
        'AS res'
    )
    params = {"upper": range_top, "pad": len(str(range_top))}

    with GraphDatabase.driver(URL, auth=AUTH) as driver:
        fetch_size = 2
        try:
            with (
                driver.session(database=DB, fetch_size=fetch_size) as session
            ):
                res1 = session.run(query, parameters={**params, "n": 1})
                inspect_records(res1, 3, "res1")
                raise MyError("test error")
        except MyError as e:
            print(f"Caught MyError: {e}")

        with (
            driver.session(database=DB, fetch_size=fetch_size) as session
        ):
            res2 = session.run(query, parameters={**params, "n": 2})
            inspect_records(res2, 3, "res2")
            # !!! res1 now reading records from res2
            inspect_records(res1, 3, "res1")

if __name__ == "__main__":
    main()
```

Back port of: https://github.com/neo4j/neo4j-python-driver/pull/1333

Fixes: DRIVERS-529