### PR TITLE
[5.28] CI: reduce log output

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Install tox
         run: python -m pip install -U tox>=4.8.0
       - name: Run unit tests
-        run: python -m tox -vv -f unit ${{ matrix.python-version.tox-factor }}
+        run: python -m tox -vv -f unit ${{ matrix.python-version.tox-factor }} -- -vv --showlocals --tb=long --log-level DEBUG
 
   gha-conclusion:
     name: gha-conclusion

--- a/testkit/integration.py
+++ b/testkit/integration.py
@@ -18,4 +18,17 @@ from _common import run_python
 
 
 if __name__ == "__main__":
-    run_python(["-m", "tox", "-vv", "-f", "integration"])
+    run_python(
+        [
+            "-m",
+            "tox",
+            "-vv",
+            "-f",
+            "integration",
+            "--",
+            "-vv",
+            "--showlocals",
+            "--tb=long",
+            "--log-level=DEBUG",
+        ]
+    )

--- a/testkit/unittests.py
+++ b/testkit/unittests.py
@@ -27,5 +27,10 @@ if __name__ == "__main__":
             "--parallel-no-spinner",
             "-f",
             "unit",
+            "--",
+            "-vv",
+            "--showlocals",
+            "--tb=long",
+            "--log-level=DEBUG",
         ]
     )

--- a/tests/_teamcity.py
+++ b/tests/_teamcity.py
@@ -161,6 +161,18 @@ def _report_skip(test_id: str, reason: str | None) -> None:
         _message("testIgnored", name=test_id, message=reason)
 
 
+def _silence_report(report: pytest.TestReport) -> None:
+    """
+    Make sure the report omits details in the test suite summary.
+
+    All relevant output was already included in the TeamCity service messages.
+    """
+    report.longrepr = None
+    report.sections = [
+        section for section in report.sections if "log" not in section[0]
+    ]
+
+
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     if not _ENABLED:
         return
@@ -169,6 +181,7 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
 
     test_stdouts = []
     test_stderrs = []
+    test_logs = []
     for section_name, section_data in report.sections:
         if not section_data:
             continue
@@ -180,6 +193,8 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
             test_stderrs.append(
                 f"===== [{section_name}] =====\n{section_data}"
             )
+        if "log" in section_name:
+            test_logs.append(f"===== [{section_name}] =====\n{section_data}")
     test_stdout = "\n".join(test_stdouts)
     test_stderr = "\n".join(test_stderrs)
 
@@ -195,13 +210,15 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     if report.when in {"setup", "teardown"} and report.outcome == "failed":
         test_stage_id = f"{test_id}__{report.when}"
         _message("testStarted", name=test_stage_id)
-        _report_output(test_stage_id, test_stdout, test_stderr)
+        report_stdout = "\n".join((test_stdout, *test_logs))
+        _report_output(test_stage_id, report_stdout, test_stderr)
         _message(
             "testFailed",
             name=test_stage_id,
             message=f"{report.when.capitalize()} failed",
             details=report.longreprtext,
         )
+        _silence_report(report)
         _message("testFinished", name=test_stage_id)
 
     if report.when == "setup":
@@ -211,6 +228,9 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
 
     if report.when == "call":
         if report.outcome == "failed":
+            report_stdout = "\n".join((test_stdout, *test_logs))
+            _report_output(test_id, report_stdout, test_stderr)
             _message("testFailed", name=test_id, message=report.longreprtext)
+            _silence_report(report)
         elif report.outcome == "skipped":
             _report_skip(test_id, _skip_reason(report))

--- a/tests/unit/async_/test_conf.py
+++ b/tests/unit/async_/test_conf.py
@@ -36,7 +36,6 @@ from neo4j.auth_management import (
     AsyncClientCertificateProviders,
     ClientCertificate,
 )
-from neo4j.debug import watch
 from neo4j.exceptions import ConfigurationError
 
 from ..._async_compat import mark_async_test
@@ -44,8 +43,6 @@ from ..common.test_conf import test_session_config
 
 
 # python -m pytest tests/unit/test_conf.py -s -v
-
-watch("neo4j")
 
 test_pool_config = {
     "connection_timeout": 30.0,

--- a/tests/unit/common/test_conf.py
+++ b/tests/unit/common/test_conf.py
@@ -24,11 +24,8 @@ from neo4j.api import (
     READ_ACCESS,
     WRITE_ACCESS,
 )
-from neo4j.debug import watch
 from neo4j.exceptions import ConfigurationError
 
-
-watch("neo4j")
 
 test_session_config = {
     "connection_acquisition_timeout": 60.0,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,10 +15,10 @@
 
 
 import logging
+import typing as t
 
 import pytest
 
-from neo4j import _typing as t  # noqa: TCH001
 from neo4j.debug import (
     ColourFormatter,
     TaskIdFilter,
@@ -47,9 +47,13 @@ from .sync.fixtures import (
 )
 
 
+if t.TYPE_CHECKING:
+    from collections.abc import Callable
+
+
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config):
-    formatter_cls: t.Callable[[str], logging.Formatter] = ColourFormatter
+    formatter_cls: Callable[[str], logging.Formatter] = ColourFormatter
     if _ENABLED:
         formatter_cls = logging.Formatter
     logging_plugin = config.pluginmanager.get_plugin("logging-plugin")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,6 +14,17 @@
 # limitations under the License.
 
 
+import logging
+
+import pytest
+
+from neo4j import _typing as t  # noqa: TCH001
+from neo4j.debug import (
+    ColourFormatter,
+    TaskIdFilter,
+)
+
+from .._teamcity import _ENABLED
 from .async_.fixtures import (
     async_fake_connection,
     async_fake_connection_generator,
@@ -34,6 +45,23 @@ from .sync.fixtures import (
     scripted_connection,
     scripted_connection_generator,
 )
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_configure(config):
+    formatter_cls: t.Callable[[str], logging.Formatter] = ColourFormatter
+    if _ENABLED:
+        formatter_cls = logging.Formatter
+    logging_plugin = config.pluginmanager.get_plugin("logging-plugin")
+    logging_plugin.formatter = formatter_cls(
+        "[%(levelname)-8s] [Thread %(thread)d] [Task %(task)-15s] "
+        "%(asctime)s  %(message)s"
+    )
+    for attr_name in vars(logging_plugin):
+        attr = getattr(logging_plugin, attr_name)
+        if isinstance(attr, logging.Handler):
+            attr.addFilter(TaskIdFilter())
+            attr.setFormatter(logging_plugin.formatter)
 
 
 __all__ = [

--- a/tests/unit/sync/test_conf.py
+++ b/tests/unit/sync/test_conf.py
@@ -36,7 +36,6 @@ from neo4j.auth_management import (
     ClientCertificate,
     ClientCertificateProviders,
 )
-from neo4j.debug import watch
 from neo4j.exceptions import ConfigurationError
 
 from ..._async_compat import mark_sync_test
@@ -44,8 +43,6 @@ from ..common.test_conf import test_session_config
 
 
 # python -m pytest tests/unit/test_conf.py -s -v
-
-watch("neo4j")
 
 test_pool_config = {
     "connection_timeout": 30.0,

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ warnargs =
 parallel_show_output = true
 commands =
     coverage erase
-    unit: coverage run -m pytest {[testenv]warnargs} -v {posargs} tests/unit
-    integration: coverage run -m pytest {[testenv]warnargs} -v {posargs} tests/integration
-    performance: python -m pytest --benchmark-autosave -v {posargs} tests/performance
+    unit: coverage run -m pytest {[testenv]warnargs} {posargs} tests/unit
+    integration: coverage run -m pytest {[testenv]warnargs} {posargs} tests/integration
+    performance: python -m pytest --benchmark-autosave {posargs} tests/performance
     unit,integration: coverage report


### PR DESCRIPTION
Back port of: https://github.com/neo4j/neo4j-python-driver/pull/1321

Closes: DRIVERS-498